### PR TITLE
Add agents guide for Maven build/test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# Codex Agent Guidelines
+
+This is a large multi-module Maven project. Building and testing the entire repository can take considerable time. It's not unusual for test execution to take 5–10 minutes per module.
+
+## Build
+- Always invoke Maven in offline mode using the `-o` flag.
+- To build the entire project without running tests:
+  ```bash
+  mvn -o verify -DskipTests
+  ```
+- To build the project and run all tests:
+  ```bash
+  mvn -o verify
+  ```
+  Running all modules sequentially will take a long time.
+
+## Running Tests
+- To test a specific module, use the `-pl` option. Example for running the SHACL tests:
+  ```bash
+  mvn -o -pl core/sail/shacl test
+  ```
+- Running from a module subdirectory is also possible; remember to include `-o`.


### PR DESCRIPTION
## Summary
- add AGENTS.md with notes on building and running tests
- explain using `mvn -o verify -DskipTests` to build without tests

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_683ef9f297d0832ebf24206a0b40e2c6