### PR TITLE
Use Testcontainers for ES tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,3 +46,11 @@ mvn -o -q process-resources
   ```
 - Replace `${year}` with the current year for new files only.
 - Do not modify or omit any other part of the header.
+
+## Elasticsearch Integration Tests
+The Elasticsearch Store module uses Testcontainers to spin up a Docker-based Elasticsearch instance during tests. Ensure Docker is running locally. Execute the module tests with:
+```bash
+mvn -o -pl core/sail/elasticsearch-store test
+```
+Tests are skipped automatically when Docker is unavailable (via `@Testcontainers(disabledWithoutDocker = true)`).
+

--- a/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/ElasticsearchTestContainer.java
+++ b/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/ElasticsearchTestContainer.java
@@ -1,0 +1,60 @@
+/*****************************************************************************
+ * Copyright (c) 2025 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *****************************************************************************/
+package org.eclipse.rdf4j.sail.elasticsearchstore;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.UUID;
+
+import org.apache.http.HttpHost;
+import org.eclipse.rdf4j.testsuite.repository.RepositoryTest;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@Testcontainers(disabledWithoutDocker = true)
+public abstract class ElasticsearchTestContainer extends RepositoryTest {
+
+	protected static final String CLUSTER_NAME = "es-it-" + UUID.randomUUID();
+
+	private static final DockerImageName ES_IMAGE = DockerImageName
+			.parse("docker.elastic.co/elasticsearch/elasticsearch:8.14.0");
+
+	@Container
+	protected static final ElasticsearchContainer ES = new ElasticsearchContainer(ES_IMAGE)
+			.withEnv("cluster.name", CLUSTER_NAME)
+			.withReuse(true)
+			.withStartupTimeout(Duration.ofMinutes(2));
+
+	protected static RestHighLevelClient client;
+	protected static int transportPort;
+
+	@BeforeAll
+	static void startContainer() {
+		client = new RestHighLevelClient(RestClient.builder(HttpHost.create(ES.getHttpHostAddress())));
+		transportPort = ES.getMappedPort(9300);
+		System.setProperty("es.host", ES.getHttpHostAddress());
+	}
+
+	@AfterAll
+	static void stopContainer() throws IOException {
+		client.close();
+	}
+
+	protected String getHttpHostAddress() {
+		return ES.getHttpHostAddress();
+	}
+}

--- a/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/compliance/ElasticsearchStoreRepositoryIT.java
+++ b/core/sail/elasticsearch-store/src/test/java/org/eclipse/rdf4j/sail/elasticsearchstore/compliance/ElasticsearchStoreRepositoryIT.java
@@ -13,34 +13,26 @@ package org.eclipse.rdf4j.sail.elasticsearchstore.compliance;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.sail.elasticsearchstore.ElasticsearchStore;
+import org.eclipse.rdf4j.sail.elasticsearchstore.ElasticsearchTestContainer;
 import org.eclipse.rdf4j.sail.elasticsearchstore.SingletonClientProvider;
-import org.eclipse.rdf4j.sail.elasticsearchstore.TestHelpers;
-import org.eclipse.rdf4j.testsuite.repository.RepositoryTest;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 
-public class ElasticsearchStoreRepositoryIT extends RepositoryTest {
+public class ElasticsearchStoreRepositoryIT extends ElasticsearchTestContainer {
 
-	private static SingletonClientProvider clientPool;
-
-	@BeforeAll
-	public static void beforeClass() {
-		TestHelpers.openClient();
-		clientPool = new SingletonClientProvider("localhost", TestHelpers.PORT, TestHelpers.CLUSTER);
-	}
+	private SingletonClientProvider clientPool;
 
 	@AfterAll
-	public static void afterClass() throws Exception {
-		clientPool.close();
-		TestHelpers.closeClient();
+	public void afterClass() throws Exception {
+		if (clientPool != null) {
+			clientPool.close();
+		}
 	}
 
 	@Override
 	protected Repository createRepository() {
-		SailRepository sailRepository = new SailRepository(
-				new ElasticsearchStore(clientPool, "index1"));
-		return sailRepository;
+		clientPool = new SingletonClientProvider("localhost", transportPort, CLUSTER_NAME);
+		return new SailRepository(new ElasticsearchStore(clientPool, "index1"));
 	}
 
 	@Disabled

--- a/core/sail/pom.xml
+++ b/core/sail/pom.xml
@@ -26,4 +26,16 @@
 		<module>elasticsearch-store</module>
 		<module>extensible-store</module>
 	</modules>
+	<dependencies>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>elasticsearch</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -378,6 +378,7 @@
 		<junit.version>5.9.3</junit.version>
 		<jetty.version>9.4.54.v20240208</jetty.version>
 		<netty.version>4.1.111.Final</netty.version>
+		<testcontainers.version>1.19.7</testcontainers.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -652,6 +653,18 @@
 				<groupId>org.apache.kerby</groupId>
 				<artifactId>kerby-pkix</artifactId>
 				<version>1.1.1</version>
+			</dependency>
+			<dependency>
+				<groupId>org.testcontainers</groupId>
+				<artifactId>junit-jupiter</artifactId>
+				<version>${testcontainers.version}</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.testcontainers</groupId>
+				<artifactId>elasticsearch</artifactId>
+				<version>${testcontainers.version}</version>
+				<scope>test</scope>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>


### PR DESCRIPTION
## Summary
- add Testcontainers dependencies to Sail POM
- start a dockerised Elasticsearch for tests
- migrate `ElasticsearchStoreRepositoryIT` to the container
- document running integration tests in `AGENTS.md`
- manage dependency versions from the root POM

## Testing
- `mvn -o -q process-resources`
- `mvn -o -pl core/sail/elasticsearch-store test` *(fails: Could not resolve dependencies)*


------
https://chatgpt.com/codex/tasks/task_e_683f3f078130832e94be23111eda811f