### PR TITLE
Add SketchRegistry base implementation

### DIFF
--- a/core/sail/memory/pom.xml
+++ b/core/sail/memory/pom.xml
@@ -36,6 +36,11 @@
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.datasketches</groupId>
+			<artifactId>datasketches-java</artifactId>
+			<version>${datasketches.version}</version>
+		</dependency>
+		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>rdf4j-rio-turtle</artifactId>
 			<version>${project.version}</version>

--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/ext/PredStats.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/ext/PredStats.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ ******************************************************************************/
+package org.eclipse.rdf4j.sail.memory.ext;
+
+import org.apache.datasketches.hll.HllSketch;
+import org.eclipse.rdf4j.model.Value;
+
+/**
+ * Statistics for a single predicate. Keeps two HyperLogLog sketches for distinct subjects and objects and counts total
+ * triples.
+ */
+public final class PredStats {
+
+	private final HllSketch subjHll;
+	private final HllSketch objHll;
+	private volatile long triples;
+	private volatile boolean dirty;
+
+	/**
+	 * Create a new {@link PredStats} using sketches of size {@code 2^p} registers.
+	 *
+	 * @param p log₂ of the number of registers
+	 */
+	public PredStats(int p) {
+		this.subjHll = new HllSketch(p);
+		this.objHll = new HllSketch(p);
+	}
+
+	/**
+	 * Update the statistics for a newly inserted triple.
+	 *
+	 * @param subj subject value of the triple
+	 * @param obj  object value of the triple
+	 */
+	public void update(Value subj, Value obj) {
+		subjHll.update(subj.stringValue());
+		objHll.update(obj.stringValue());
+		triples++;
+	}
+
+	/** Mark this stats instance as dirty due to a delete. */
+	public void markDirty() {
+		dirty = true;
+	}
+
+	/** @return HyperLogLog sketch counting distinct subjects. */
+	public HllSketch getSubjHll() {
+		return subjHll;
+	}
+
+	/** @return HyperLogLog sketch counting distinct objects. */
+	public HllSketch getObjHll() {
+		return objHll;
+	}
+
+	/** @return total number of triples seen. */
+	public long getTriples() {
+		return triples;
+	}
+
+	/** @return {@code true} when deletes have been observed. */
+	public boolean isDirty() {
+		return dirty;
+	}
+}

--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/ext/SketchRegistry.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/ext/SketchRegistry.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ ******************************************************************************/
+package org.eclipse.rdf4j.sail.memory.ext;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import org.apache.datasketches.hll.HllSketch;
+import org.apache.datasketches.hll.Union;
+
+/**
+ * Central registry that stores {@link PredStats} for all predicates.
+ */
+public class SketchRegistry {
+
+	private final ConcurrentMap<String, PredStats> data = new ConcurrentHashMap<>();
+	private final int defaultP;
+
+	/** Create a registry with default sketch precision of {@code p=14}. */
+	public SketchRegistry() {
+		this(14);
+	}
+
+	/**
+	 * @param defaultP log₂ of the register count for new sketches
+	 */
+	public SketchRegistry(int defaultP) {
+		this.defaultP = defaultP;
+	}
+
+	/**
+	 * Return the {@link PredStats} instance for the given predicate IRI, creating it if necessary.
+	 *
+	 * @param predIri the predicate IRI string
+	 * @return stats container
+	 */
+	public PredStats forPred(String predIri) {
+		return data.computeIfAbsent(predIri, k -> new PredStats(defaultP));
+	}
+
+	/**
+	 * Estimate the size of the intersection between two sketches using the inclusion–exclusion principle.
+	 */
+	public long estimateIntersection(HllSketch a, HllSketch b) {
+		Union u = new Union(a.getLgConfigK());
+		u.update(a);
+		u.update(b);
+		double est = a.getEstimate() + b.getEstimate() - u.getResult().getEstimate();
+		return Math.round(est);
+	}
+
+	/**
+	 * Placeholder for future rebuild logic of dirty sketches.
+	 */
+	public void refreshDirtyIfNeeded() {
+// TODO implement
+	}
+}

--- a/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/ext/PredStatsTest.java
+++ b/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/ext/PredStatsTest.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ ******************************************************************************/
+package org.eclipse.rdf4j.sail.memory.ext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.withinPercentage;
+
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link PredStats}. */
+public class PredStatsTest {
+
+	@Test
+	public void distinctSubjectEstimate() {
+		ValueFactory vf = SimpleValueFactory.getInstance();
+		PredStats ps = new PredStats(14);
+		for (int i = 0; i < 1000; i++) {
+			ps.update(vf.createIRI("urn:s" + i), vf.createIRI("urn:o" + i));
+		}
+		double est = ps.getSubjHll().getEstimate();
+		assertThat(est).isCloseTo(1000.0, withinPercentage(3.0));
+	}
+}

--- a/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/ext/RegistryIntersectionTest.java
+++ b/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/ext/RegistryIntersectionTest.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ ******************************************************************************/
+package org.eclipse.rdf4j.sail.memory.ext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.withinPercentage;
+
+import org.apache.datasketches.hll.HllSketch;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.junit.jupiter.api.Test;
+
+/** Tests for {@link SketchRegistry#estimateIntersection(HllSketch, HllSketch)}. */
+public class RegistryIntersectionTest {
+
+	@Test
+	public void estimateOverlap() {
+		HllSketch a = new HllSketch(14);
+		HllSketch b = new HllSketch(14);
+		for (int i = 0; i < 1000; i++) {
+			a.update("v" + i);
+		}
+		for (int i = 500; i < 1500; i++) {
+			b.update("v" + i);
+		}
+		SketchRegistry reg = new SketchRegistry(14);
+		long est = reg.estimateIntersection(a, b);
+		assertThat((double) est).isCloseTo(500.0, withinPercentage(3.0));
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -373,6 +373,7 @@
 		<elasticsearch.version>7.15.2</elasticsearch.version>
 		<spring.version>5.3.37</spring.version>
 		<guava.version>32.1.3-jre</guava.version>
+		<datasketches.version>6.0.0</datasketches.version>
 		<jmhVersion>1.37</jmhVersion>
 		<servlet.version>4.0.0</servlet.version>
 		<junit.version>5.9.3</junit.version>


### PR DESCRIPTION
## Summary
- implement PredStats container and SketchRegistry
- add datasketches dependency
- create unit tests for sketches

## Testing
- `mvn -o -pl :rdf4j-sail-memory verify -DskipTests`
- `mvn -o -pl :rdf4j-sail-memory test`

------
https://chatgpt.com/codex/tasks/task_e_6845fef5b318832ea1dc5ab68b856bdd