### PR TITLE
Add basic HLL sketch support

### DIFF
--- a/core/sail/memory/pom.xml
+++ b/core/sail/memory/pom.xml
@@ -46,6 +46,11 @@
 			<artifactId>slf4j-api</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>net.agkn</groupId>
+			<artifactId>hll</artifactId>
+			<version>1.6.0</version>
+		</dependency>
+		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>rdf4j-sail-testsuite</artifactId>
 			<version>${project.version}</version>

--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/MemorySailStore.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/MemorySailStore.java
@@ -50,6 +50,7 @@ import org.eclipse.rdf4j.sail.base.SailDataset;
 import org.eclipse.rdf4j.sail.base.SailSink;
 import org.eclipse.rdf4j.sail.base.SailSource;
 import org.eclipse.rdf4j.sail.base.SailStore;
+import org.eclipse.rdf4j.sail.memory.SketchRegistry;
 import org.eclipse.rdf4j.sail.memory.model.MemBNode;
 import org.eclipse.rdf4j.sail.memory.model.MemIRI;
 import org.eclipse.rdf4j.sail.memory.model.MemResource;
@@ -124,6 +125,8 @@ class MemorySailStore implements SailStore {
 
 	final SnapshotMonitor snapshotMonitor;
 
+	private final SketchRegistry registry;
+
 	/**
 	 * Store for namespace prefix info.
 	 */
@@ -149,8 +152,9 @@ class MemorySailStore implements SailStore {
 	 */
 	private final Object snapshotCleanupThreadLockObject = new Object();
 
-	public MemorySailStore(boolean debug) {
+	public MemorySailStore(boolean debug, SketchRegistry registry) {
 		snapshotMonitor = new SnapshotMonitor(debug);
+		this.registry = registry;
 	}
 
 	@Override
@@ -852,6 +856,7 @@ class MemorySailStore implements SailStore {
 			MemStatement st = new MemStatement(memSubj, memPred, memObj, memContext, explicit, nextSnapshot);
 			statements.add(st);
 			st.addToComponentLists();
+			registry.forPred(pred.stringValue()).update(subj, obj);
 			invalidateCache();
 			return st;
 		}

--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/MemoryStore.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/MemoryStore.java
@@ -32,6 +32,7 @@ import org.eclipse.rdf4j.sail.base.SailSink;
 import org.eclipse.rdf4j.sail.base.SailStore;
 import org.eclipse.rdf4j.sail.helpers.AbstractNotifyingSail;
 import org.eclipse.rdf4j.sail.helpers.DirectoryLockManager;
+import org.eclipse.rdf4j.sail.memory.SketchRegistry;
 import org.eclipse.rdf4j.sail.memory.model.MemValueFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -70,6 +71,7 @@ public class MemoryStore extends AbstractNotifyingSail implements FederatedServi
 	 * Factory/cache for MemValue objects.
 	 */
 	private SailStore store;
+	private final SketchRegistry registry = new SketchRegistry();
 
 	private volatile boolean persist = false;
 
@@ -258,7 +260,7 @@ public class MemoryStore extends AbstractNotifyingSail implements FederatedServi
 	protected void initializeInternal() throws SailException {
 		logger.debug("Initializing MemoryStore...");
 
-		this.store = new MemorySailStore(debugEnabled());
+		this.store = new MemorySailStore(debugEnabled(), registry);
 
 		if (persist) {
 			File dataDir = getDataDir();

--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/PredStats.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/PredStats.java
@@ -1,0 +1,52 @@
+/*****************************************************************************
+ * Copyright (c) 2025 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *****************************************************************************/
+package org.eclipse.rdf4j.sail.memory;
+
+import java.nio.charset.StandardCharsets;
+
+import org.eclipse.rdf4j.model.Value;
+
+import net.agkn.hll.HLL;
+
+final class PredStats {
+	private static final int LOG2M = 14;
+	private static final int REGWIDTH = 5;
+
+	final HLL subj = new HLL(LOG2M, REGWIDTH);
+	final HLL obj = new HLL(LOG2M, REGWIDTH);
+
+	long triples = 0L;
+
+	void update(Value s, Value o) {
+		subj.addRaw(hash64(s.stringValue()));
+		obj.addRaw(hash64(o.stringValue()));
+		++triples;
+	}
+
+	private static long hash64(String str) {
+		final long FNV_64_PRIME = 0x100000001b3L;
+		long hash = 0xcbf29ce484222325L;
+		byte[] data = str.getBytes(StandardCharsets.UTF_8);
+		for (byte b : data) {
+			hash ^= (b & 0xff);
+			hash *= FNV_64_PRIME;
+		}
+		return hash;
+	}
+
+	double dupSubj() {
+		return triples / Math.max(1.0, subj.cardinality());
+	}
+
+	double dupObj() {
+		return triples / Math.max(1.0, obj.cardinality());
+	}
+}

--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/SketchRegistry.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/SketchRegistry.java
@@ -1,0 +1,34 @@
+/*****************************************************************************
+ * Copyright (c) 2025 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *****************************************************************************/
+package org.eclipse.rdf4j.sail.memory;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import net.agkn.hll.HLL;
+
+final class SketchRegistry {
+	private final ConcurrentMap<String, PredStats> map = new ConcurrentHashMap<>();
+
+	PredStats forPred(String iri) {
+		return map.computeIfAbsent(iri, k -> new PredStats());
+	}
+
+	long intersection(HLL a, HLL b) {
+		try {
+			HLL union = a.clone();
+			union.union(b);
+			return a.cardinality() + b.cardinality() - union.cardinality();
+		} catch (CloneNotSupportedException e) {
+			throw new RuntimeException(e);
+		}
+	}
+}

--- a/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/Hash64DeterminismTest.java
+++ b/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/Hash64DeterminismTest.java
@@ -1,0 +1,54 @@
+/*****************************************************************************
+ * Copyright (c) 2025 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *****************************************************************************/
+package org.eclipse.rdf4j.sail.memory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+public class Hash64DeterminismTest {
+
+	private long hash64(String s) {
+		final long FNV_64_PRIME = 0x100000001b3L;
+		long hash = 0xcbf29ce484222325L;
+		for (byte b : s.getBytes(StandardCharsets.UTF_8)) {
+			hash ^= (b & 0xff);
+			hash *= FNV_64_PRIME;
+		}
+		return hash;
+	}
+
+	@Test
+	public void repeatability() {
+		long h1 = hash64("test");
+		long h2 = hash64("test");
+		assertEquals(h1, h2);
+	}
+
+	@Test
+	public void collisionRate() {
+		Set<Long> hashes = new HashSet<>();
+		int collisions = 0;
+		for (int i = 0; i < 100000; i++) {
+			long h = hash64(UUID.randomUUID().toString());
+			if (!hashes.add(h)) {
+				collisions++;
+			}
+		}
+		assertTrue(collisions <= 1000);
+	}
+}

--- a/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/IntersectionAccuracyTest.java
+++ b/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/IntersectionAccuracyTest.java
@@ -1,0 +1,71 @@
+/*****************************************************************************
+ * Copyright (c) 2025 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *****************************************************************************/
+package org.eclipse.rdf4j.sail.memory;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.eclipse.rdf4j.sail.memory.SketchRegistry;
+import org.junit.jupiter.api.Test;
+
+import net.agkn.hll.HLL;
+
+public class IntersectionAccuracyTest {
+	private static final int LOG2M = 14;
+	private static final int REGWIDTH = 5;
+
+	private long hash64(String s) {
+		final long FNV_64_PRIME = 0x100000001b3L;
+		long hash = 0xcbf29ce484222325L;
+		for (byte b : s.getBytes(StandardCharsets.UTF_8)) {
+			hash ^= (b & 0xff);
+			hash *= FNV_64_PRIME;
+		}
+		return hash;
+	}
+
+	@Test
+	public void intersectionWithinError() {
+		for (int overlap = 0; overlap <= 10000; overlap += 2000) {
+			Set<String> leftSet = new HashSet<>();
+			Set<String> rightSet = new HashSet<>();
+			HLL left = new HLL(LOG2M, REGWIDTH);
+			HLL right = new HLL(LOG2M, REGWIDTH);
+			for (int i = 0; i < 10000; i++) {
+				String val = "x" + i;
+				if (i < overlap) {
+					leftSet.add(val);
+					rightSet.add(val);
+					long h = hash64(val);
+					left.addRaw(h);
+					right.addRaw(h);
+				} else {
+					leftSet.add(val);
+					left.addRaw(hash64(val));
+					String val2 = "y" + i;
+					rightSet.add(val2);
+					right.addRaw(hash64(val2));
+				}
+			}
+			SketchRegistry reg = new SketchRegistry();
+			long inter = reg.intersection(left, right);
+			if (overlap == 0) {
+				assertTrue(inter <= 800);
+			} else {
+				double err = Math.abs(inter - overlap) / (double) overlap;
+				assertTrue(err <= 0.08);
+			}
+		}
+	}
+}

--- a/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/SnapshotMonitorTest.java
+++ b/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/SnapshotMonitorTest.java
@@ -17,6 +17,7 @@ import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.sail.base.SailDataset;
 import org.eclipse.rdf4j.sail.base.SailSink;
 import org.eclipse.rdf4j.sail.base.SailSource;
+import org.eclipse.rdf4j.sail.memory.SketchRegistry;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
@@ -26,7 +27,7 @@ public class SnapshotMonitorTest {
 	@Test
 	@Timeout(60)
 	public void testAutomaticCleanupDataset() throws InterruptedException {
-		try (MemorySailStore memorySailStore = new MemorySailStore(false)) {
+		try (MemorySailStore memorySailStore = new MemorySailStore(false, new SketchRegistry())) {
 
 			try (SailSource explicitSailSource = memorySailStore.getExplicitSailSource()) {
 				getAndAbandonDataset(explicitSailSource, memorySailStore.snapshotMonitor);
@@ -46,7 +47,7 @@ public class SnapshotMonitorTest {
 	@Test
 	@Timeout(60)
 	public void testAutomaticCleanupSink() throws InterruptedException {
-		try (MemorySailStore memorySailStore = new MemorySailStore(false)) {
+		try (MemorySailStore memorySailStore = new MemorySailStore(false, new SketchRegistry())) {
 
 			try (SailSource explicitSailSource = memorySailStore.getExplicitSailSource()) {
 				getAndAbandonSink(explicitSailSource, memorySailStore.snapshotMonitor);
@@ -65,7 +66,7 @@ public class SnapshotMonitorTest {
 
 	@Test
 	public void testReservationAndReleaseDataset() {
-		try (MemorySailStore memorySailStore = new MemorySailStore(false)) {
+		try (MemorySailStore memorySailStore = new MemorySailStore(false, new SketchRegistry())) {
 
 			try (SailSource explicitSailSource = memorySailStore.getExplicitSailSource()) {
 				try (SailDataset dataset = explicitSailSource.dataset(IsolationLevels.SNAPSHOT)) {
@@ -85,7 +86,7 @@ public class SnapshotMonitorTest {
 
 	@Test
 	public void testReservationAndReleaseDatasetNone() {
-		try (MemorySailStore memorySailStore = new MemorySailStore(false)) {
+		try (MemorySailStore memorySailStore = new MemorySailStore(false, new SketchRegistry())) {
 
 			try (SailSource explicitSailSource = memorySailStore.getExplicitSailSource()) {
 				try (SailDataset dataset = explicitSailSource.dataset(IsolationLevels.NONE)) {
@@ -100,7 +101,7 @@ public class SnapshotMonitorTest {
 
 	@Test
 	public void testReservationAndReleaseSinkSerializable() {
-		try (MemorySailStore memorySailStore = new MemorySailStore(false)) {
+		try (MemorySailStore memorySailStore = new MemorySailStore(false, new SketchRegistry())) {
 
 			try (SailSource explicitSailSource = memorySailStore.getExplicitSailSource()) {
 				try (SailSink sink = explicitSailSource.sink(IsolationLevels.SERIALIZABLE)) {
@@ -119,7 +120,7 @@ public class SnapshotMonitorTest {
 
 	@Test
 	public void testReservationAndReleaseSink() {
-		try (MemorySailStore memorySailStore = new MemorySailStore(false)) {
+		try (MemorySailStore memorySailStore = new MemorySailStore(false, new SketchRegistry())) {
 
 			try (SailSource explicitSailSource = memorySailStore.getExplicitSailSource()) {
 				try (SailSink sink = explicitSailSource.sink(IsolationLevels.SNAPSHOT)) {
@@ -134,7 +135,7 @@ public class SnapshotMonitorTest {
 
 	@Test
 	public void testMultipleReservations() {
-		try (MemorySailStore memorySailStore = new MemorySailStore(true)) {
+		try (MemorySailStore memorySailStore = new MemorySailStore(true, new SketchRegistry())) {
 
 			try (SailSource explicitSailSource = memorySailStore.getExplicitSailSource()) {
 				try (SailDataset dataset = explicitSailSource.dataset(IsolationLevels.SNAPSHOT)) {
@@ -177,7 +178,7 @@ public class SnapshotMonitorTest {
 
 	@Test
 	public void testOverlappingReservations() {
-		try (MemorySailStore memorySailStore = new MemorySailStore(true)) {
+		try (MemorySailStore memorySailStore = new MemorySailStore(true, new SketchRegistry())) {
 
 			try (SailSource explicitSailSource = memorySailStore.getExplicitSailSource()) {
 				SailDataset dataset = explicitSailSource.dataset(IsolationLevels.SNAPSHOT);

--- a/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/UnionPropertyTest.java
+++ b/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/UnionPropertyTest.java
@@ -1,0 +1,63 @@
+/*****************************************************************************
+ * Copyright (c) 2025 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *****************************************************************************/
+package org.eclipse.rdf4j.sail.memory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.CloneNotSupportedException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import net.agkn.hll.HLL;
+
+public class UnionPropertyTest {
+	private static final int LOG2M = 14;
+	private static final int REGWIDTH = 5;
+
+	private long hash64(String s) {
+		final long FNV_64_PRIME = 0x100000001b3L;
+		long hash = 0xcbf29ce484222325L;
+		for (byte b : s.getBytes(StandardCharsets.UTF_8)) {
+			hash ^= (b & 0xff);
+			hash *= FNV_64_PRIME;
+		}
+		return hash;
+	}
+
+	@Test
+	public void unionMatchesSetSize() {
+		HLL a = new HLL(LOG2M, REGWIDTH);
+		HLL b = new HLL(LOG2M, REGWIDTH);
+		Set<String> set = new HashSet<>();
+		for (int i = 0; i < 5000; i++) {
+			String v = "a" + i;
+			set.add(v);
+			long h = hash64(v);
+			a.addRaw(h);
+		}
+		for (int i = 2500; i < 7500; i++) {
+			String v = "b" + i;
+			set.add(v);
+			long h = hash64(v);
+			b.addRaw(h);
+		}
+		try {
+			HLL u = a.clone();
+			u.union(b);
+			assertEquals(set.size(), u.cardinality(), set.size() * 0.05);
+		} catch (CloneNotSupportedException e) {
+			throw new RuntimeException(e);
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add AGKN hll dependency to memory module
- implement `PredStats` and `SketchRegistry`
- update `MemorySailStore` and `MemoryStore` to use sketches
- basic FNV64 hashing helper
- add unit tests for hashing and HLL behaviours

## Testing
- `mvn -o -pl core/sail/memory -am verify -DskipTests` *(fails: maven build incomplete)*
- `mvn -o -pl core/sail/memory test` *(fails: see logs)*

------
https://chatgpt.com/codex/tasks/task_e_68460191c2f8832eb548a391752cf8da