### PR TITLE
Disable Dash license workflow in CI

### DIFF
--- a/.github/workflows/dash-license.yml
+++ b/.github/workflows/dash-license.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   license-check:
+    if: ${{ false }}
+    # Disabled until ClearlyDefined throttling is resolved (see eclipse-rdf4j/rdf4j#5457)
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## Summary
- disable the Dash license GitHub Actions job so the ClearlyDefined throttling no longer breaks CI
- remove the regression test guarding the workflow configuration per request

## Testing
- mvn -pl tools/config test

------
https://chatgpt.com/codex/tasks/task_e_68d97973abd4832e9134bce79de0ceeb