### PR TITLE
Fix optional union pattern grouping

### DIFF
--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/graphpattern/AlternativeGraphPattern.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/graphpattern/AlternativeGraphPattern.java
@@ -11,7 +11,10 @@
 
 package org.eclipse.rdf4j.sparqlbuilder.graphpattern;
 
+import java.util.stream.Collectors;
+
 import org.eclipse.rdf4j.sparqlbuilder.core.QueryElementCollection;
+import org.eclipse.rdf4j.sparqlbuilder.util.SparqlBuilderUtils;
 
 /**
  * A SPARQL Alternative Graph Pattern.
@@ -46,5 +49,22 @@ class AlternativeGraphPattern extends QueryElementCollection<GroupGraphPattern> 
 		addElements(GraphPatterns::extractOrConvertToGGP, patterns);
 
 		return this;
+	}
+
+	@Override
+	public String getQueryString() {
+		return elements.stream()
+				.map(this::formatGroupForUnion)
+				.collect(Collectors.joining(DELIMETER));
+	}
+
+	private String formatGroupForUnion(GroupGraphPattern pattern) {
+		String queryString = pattern.getQueryString();
+
+		if (pattern.isOptional) {
+			return SparqlBuilderUtils.getBracedString(queryString);
+		}
+
+		return queryString;
 	}
 }

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/core/SparqlBuilderTest.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/core/SparqlBuilderTest.java
@@ -18,6 +18,7 @@ import org.eclipse.rdf4j.model.vocabulary.DC;
 import org.eclipse.rdf4j.sparqlbuilder.constraint.Expressions;
 import org.eclipse.rdf4j.sparqlbuilder.core.query.Queries;
 import org.eclipse.rdf4j.sparqlbuilder.core.query.SelectQuery;
+import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPattern;
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatternNotTriples;
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf;
@@ -150,6 +151,21 @@ public class SparqlBuilderTest {
 				.contains("FILTER ( ?price < 50 )");
 		assertThat(query.getQueryString())
 				.contains("FILTER ( ?price > 30 )");
+	}
+
+	@Test
+	public void testUnionWrapsOptionalPatternInGroup() {
+		Variable subject = SparqlBuilder.var("subject");
+
+		GraphPattern unionPattern = GraphPatterns
+				.union(GraphPatterns.optional(subject.isA(Rdf.iri("http://example.org/Class"))))
+				.union(subject.has(Rdf.iri("http://example.org/secondpred"), Rdf.literalOf("test")));
+
+		SelectQuery select = Queries.SELECT(subject).where(unionPattern);
+
+		assertThat(select.getQueryString())
+				.contains(
+						"{ OPTIONAL { ?subject a <http://example.org/Class> . } } UNION { ?subject <http://example.org/secondpred> \"test\" . }");
 	}
 
 }


### PR DESCRIPTION
## Summary
- add a regression test covering a UNION that starts with an OPTIONAL pattern
- ensure AlternativeGraphPattern wraps optional operands in braces before joining with UNION

## Testing
- mvn -pl core/sparqlbuilder -Dtest=org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilderTest#testUnionWrapsOptionalPatternInGroup test

------
https://chatgpt.com/codex/tasks/task_e_68d99870ea34832e8670b3562832d8eb