### PR TITLE
Fix base URI encoding for remote transactions

### DIFF
--- a/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/RDF4JProtocolSession.java
+++ b/core/http/client/src/main/java/org/eclipse/rdf4j/http/client/RDF4JProtocolSession.java
@@ -1070,8 +1070,8 @@ public class RDF4JProtocolSession extends SPARQLProtocolSession {
 				url.addParameter(Protocol.CONTEXT_PARAM_NAME, encodedContext);
 			}
 			if (baseURI != null && !baseURI.trim().isEmpty()) {
-				String encodedBaseURI = Protocol.encodeValue(SimpleValueFactory.getInstance().createIRI(baseURI));
-				url.setParameter(Protocol.BASEURI_PARAM_NAME, encodedBaseURI);
+				String normalizedBaseURI = SimpleValueFactory.getInstance().createIRI(baseURI).stringValue();
+				url.setParameter(Protocol.BASEURI_PARAM_NAME, normalizedBaseURI);
 			}
 			if (preserveNodeIds) {
 				url.setParameter(Protocol.PRESERVE_BNODE_ID_PARAM_NAME, "true");

--- a/core/http/client/src/test/java/org/eclipse/rdf4j/http/client/RDF4JProtocolSessionTest.java
+++ b/core/http/client/src/test/java/org/eclipse/rdf4j/http/client/RDF4JProtocolSessionTest.java
@@ -15,6 +15,7 @@ import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
 
 import java.io.ByteArrayInputStream;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 
@@ -182,6 +183,45 @@ public class RDF4JProtocolSessionTest extends SPARQLProtocolSessionTest {
 						.withQueryStringParameter("action", "DELETE")
 						.withHeader(testHeader, testValue)
 		);
+	}
+
+	@Test
+	public void testAddDataTransactionUsesPlainBaseURI(MockServerClient client) throws Exception {
+		RDF4JProtocolSession session = getRDF4JSession();
+
+		String transactionsLocation = Protocol.getTransactionsLocation(session.getRepositoryURL());
+		URI transactionsURI = URI.create(transactionsLocation);
+		String transactionLocation = transactionsLocation + "/1";
+		URI transactionURI = URI.create(transactionLocation);
+
+		client.when(
+				request()
+						.withMethod("POST")
+						.withPath(transactionsURI.getPath()),
+				Times.once())
+				.respond(response().withStatusCode(201).withHeader("Location", transactionLocation));
+
+		client.when(
+				request()
+						.withMethod("PUT")
+						.withPath(transactionURI.getPath())
+						.withQueryStringParameter("action", "ADD"),
+				Times.once())
+				.respond(response().withStatusCode(204));
+
+		session.beginTransaction(IsolationLevels.SERIALIZABLE);
+
+		String baseIRI = "http://example.com/";
+		ByteArrayInputStream data = new ByteArrayInputStream("<foo> <bar> <baz> ."
+				.getBytes(StandardCharsets.UTF_8));
+		session.addData(data, baseIRI, RDFFormat.TURTLE);
+
+		client.verify(
+				request()
+						.withMethod("PUT")
+						.withPath(transactionURI.getPath())
+						.withQueryStringParameter("baseURI", baseIRI),
+				VerificationTimes.once());
 	}
 
 	@Test


### PR DESCRIPTION
## Summary
- add a regression test covering how HTTP transactions serialize the base URI
- ensure RDF4JProtocolSession sends the base URI string without angle bracket encoding

## Testing
- mvn -pl core/http/client -Dtest=RDF4JProtocolSessionTest test

------
https://chatgpt.com/codex/tasks/task_e_68d99cfc1cb8832eb2b79fa92d3c6e2e