### PR TITLE
Add baseline select query clause coverage

### DIFF
--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/core/query/SelectQueryClausesTest.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/core/query/SelectQueryClausesTest.java
@@ -37,4 +37,27 @@ class SelectQueryClausesTest {
 				"SELECT ?s ?p ?o WHERE { <http://example.com/ns#subject> ?p ?o . }",
 				query.getQueryString());
 	}
+
+	@Test
+	void qPfx01_singlePrefixDeclaration() {
+		SelectQuery query = Queries.SELECT()
+				.prefix(SparqlBuilder.prefix("ex", Rdf.iri("http://example.com/ns#")))
+				.where(GraphPatterns.tp(SparqlBuilder.var("s"), SparqlBuilder.var("p"), SparqlBuilder.var("o")));
+
+		assertSparqlEquals(
+				"PREFIX ex: <http://example.com/ns#> SELECT * WHERE { ?s ?p ?o . }",
+				query.getQueryString());
+	}
+
+	@Test
+	void qPfx02_multiplePrefixesNormalizedOrder() {
+		SelectQuery query = Queries.SELECT()
+				.prefix(SparqlBuilder.prefix("foaf", Rdf.iri("http://xmlns.com/foaf/0.1/")))
+				.prefix(SparqlBuilder.prefix("ex", Rdf.iri("http://example.com/ns#")))
+				.where(GraphPatterns.tp(SparqlBuilder.var("s"), SparqlBuilder.var("p"), SparqlBuilder.var("o")));
+
+		assertSparqlEquals(
+				"PREFIX ex: <http://example.com/ns#> PREFIX foaf: <http://xmlns.com/foaf/0.1/> SELECT * WHERE { ?s ?p ?o . }",
+				query.getQueryString());
+	}
 }

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/core/query/SelectQueryClausesTest.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/core/query/SelectQueryClausesTest.java
@@ -1,0 +1,40 @@
+package org.eclipse.rdf4j.sparqlbuilder.core.query;
+
+import static org.eclipse.rdf4j.sparqlbuilder.util.QueryAssert.assertSparqlEquals;
+
+import org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder;
+import org.eclipse.rdf4j.sparqlbuilder.core.Variable;
+import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns;
+import org.eclipse.rdf4j.sparqlbuilder.graphpattern.TriplePattern;
+import org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf;
+import org.junit.jupiter.api.Test;
+
+class SelectQueryClausesTest {
+
+	@Test
+	void qSel01_selectAllWithSingleTriplePattern() {
+		Variable s = SparqlBuilder.var("s");
+		Variable p = SparqlBuilder.var("p");
+		Variable o = SparqlBuilder.var("o");
+
+		TriplePattern pattern = GraphPatterns.tp(s, p, o);
+
+		SelectQuery query = Queries.SELECT().where(pattern);
+
+		assertSparqlEquals("SELECT * WHERE { ?s ?p ?o . }", query.getQueryString());
+	}
+
+	@Test
+	void qSel02_selectExplicitProjectionOrder() {
+		Variable s = SparqlBuilder.var("s");
+		Variable p = SparqlBuilder.var("p");
+		Variable o = SparqlBuilder.var("o");
+
+		SelectQuery query = Queries.SELECT(s, p, o)
+				.where(GraphPatterns.tp(Rdf.iri("http://example.com/ns#subject"), p, o));
+
+		assertSparqlEquals(
+				"SELECT ?s ?p ?o WHERE { <http://example.com/ns#subject> ?p ?o . }",
+				query.getQueryString());
+	}
+}

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/util/QueryAssert.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/util/QueryAssert.java
@@ -1,0 +1,24 @@
+package org.eclipse.rdf4j.sparqlbuilder.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.regex.Pattern;
+
+public final class QueryAssert {
+
+	private static final Pattern WHITESPACE = Pattern.compile("\\s+");
+
+	private QueryAssert() {
+	}
+
+	public static void assertSparqlEquals(String expected, String actual) {
+		assertThat(normalize(actual)).isEqualTo(normalize(expected));
+	}
+
+	private static String normalize(String sparql) {
+		if (sparql == null) {
+			return null;
+		}
+		return WHITESPACE.matcher(sparql.trim()).replaceAll(" ");
+	}
+}

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/util/QueryAssert.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/util/QueryAssert.java
@@ -2,11 +2,18 @@ package org.eclipse.rdf4j.sparqlbuilder.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public final class QueryAssert {
 
 	private static final Pattern WHITESPACE = Pattern.compile("\\s+");
+	private static final Pattern PREFIX_DECLARATION = Pattern
+			.compile("PREFIX\\s+[^\\s]+:\\s*<[^>]+>", Pattern.CASE_INSENSITIVE);
+	private static final Pattern BASE_DECLARATION = Pattern.compile("BASE\\s+<[^>]+>", Pattern.CASE_INSENSITIVE);
 
 	private QueryAssert() {
 	}
@@ -19,6 +26,52 @@ public final class QueryAssert {
 		if (sparql == null) {
 			return null;
 		}
-		return WHITESPACE.matcher(sparql.trim()).replaceAll(" ");
+		String trimmed = sparql.trim();
+		List<String> bases = extractDeclarations(BASE_DECLARATION, trimmed);
+		String withoutBases = stripDeclarations(BASE_DECLARATION, trimmed);
+
+		List<String> prefixes = extractDeclarations(PREFIX_DECLARATION, withoutBases);
+		Collections.sort(prefixes);
+		String remainder = stripDeclarations(PREFIX_DECLARATION, withoutBases);
+
+		StringBuilder canonical = new StringBuilder();
+		appendDeclarations(canonical, bases);
+		appendDeclarations(canonical, prefixes);
+		if (!remainder.isBlank()) {
+			if (canonical.length() > 0) {
+				canonical.append(' ');
+			}
+			canonical.append(remainder.trim());
+		}
+
+		return WHITESPACE.matcher(canonical.toString().trim()).replaceAll(" ");
+	}
+
+	private static List<String> extractDeclarations(Pattern pattern, String sparql) {
+		Matcher matcher = pattern.matcher(sparql);
+		List<String> declarations = new ArrayList<>();
+		while (matcher.find()) {
+			declarations.add(matcher.group().trim());
+		}
+		return declarations;
+	}
+
+	private static String stripDeclarations(Pattern pattern, String sparql) {
+		return pattern.matcher(sparql).replaceAll(" ").trim();
+	}
+
+	private static void appendDeclarations(StringBuilder builder, List<String> declarations) {
+		if (declarations.isEmpty()) {
+			return;
+		}
+		if (builder.length() > 0) {
+			builder.append(' ');
+		}
+		for (int i = 0; i < declarations.size(); i++) {
+			if (i > 0) {
+				builder.append(' ');
+			}
+			builder.append(declarations.get(i));
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- add QueryAssert helper to normalize SPARQL strings for assertions
- cover basic SELECT projection scenarios with normalized expectations

## Testing
- mvn -pl core/sparqlbuilder -Dtest=SelectQueryClausesTest test

------
https://chatgpt.com/codex/tasks/task_e_68d9ffc125e0832e9fa53186f7ca4f70