### PR TITLE
Add grouping and ordering clause tests for SELECT builder

### DIFF
--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/core/Projection.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/core/Projection.java
@@ -94,13 +94,13 @@ public class Projection extends QueryElementCollection<Projectable> {
 		StringBuilder selectStatement = new StringBuilder();
 		selectStatement.append(SELECT).append(" ");
 
+		if (isDistinct) {
+			selectStatement.append(DISTINCT).append(" ");
+		}
+
 		if (selectAll || isEmpty()) {
 			selectStatement.append("*").append(" ");
 		} else {
-			if (isDistinct) {
-				selectStatement.append(DISTINCT).append(" ");
-			}
-
 			selectStatement.append(super.getQueryString());
 		}
 

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/core/query/SelectQueryClausesTest.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/core/query/SelectQueryClausesTest.java
@@ -1,0 +1,275 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ ******************************************************************************/
+package org.eclipse.rdf4j.sparqlbuilder.core.query;
+
+import static org.eclipse.rdf4j.sparqlbuilder.util.QueryAssert.assertSparqlEquals;
+
+import org.eclipse.rdf4j.sparqlbuilder.constraint.Expressions;
+import org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder;
+import org.eclipse.rdf4j.sparqlbuilder.core.Variable;
+import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns;
+import org.eclipse.rdf4j.sparqlbuilder.graphpattern.TriplePattern;
+import org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf;
+import org.junit.jupiter.api.Test;
+
+class SelectQueryClausesTest {
+
+	@Test
+	void qSel01_selectAllWithSingleTriplePattern() {
+		Variable s = SparqlBuilder.var("s");
+		Variable p = SparqlBuilder.var("p");
+		Variable o = SparqlBuilder.var("o");
+
+		TriplePattern pattern = GraphPatterns.tp(s, p, o);
+
+		SelectQuery query = Queries.SELECT().where(pattern);
+
+		assertSparqlEquals("SELECT * WHERE { ?s ?p ?o . }", query.getQueryString());
+	}
+
+	@Test
+	void qSel02_selectExplicitProjectionOrder() {
+		Variable s = SparqlBuilder.var("s");
+		Variable p = SparqlBuilder.var("p");
+		Variable o = SparqlBuilder.var("o");
+
+		SelectQuery query = Queries.SELECT(s, p, o)
+				.where(GraphPatterns.tp(Rdf.iri("http://example.com/ns#subject"), p, o));
+
+		assertSparqlEquals(
+				"SELECT ?s ?p ?o WHERE { <http://example.com/ns#subject> ?p ?o . }",
+				query.getQueryString());
+	}
+
+	@Test
+	void qSel03_projectionWithAliasExpression() {
+		Variable s = SparqlBuilder.var("s");
+		Variable o = SparqlBuilder.var("o");
+		Variable label = SparqlBuilder.var("label");
+
+		SelectQuery query = Queries.SELECT(SparqlBuilder.as(Expressions.str(o), label), o)
+				.where(GraphPatterns.tp(s, Rdf.iri("http://example.com/ns#name"), o));
+
+		assertSparqlEquals(
+				"SELECT ( STR( ?o ) AS ?label ) ?o WHERE { ?s <http://example.com/ns#name> ?o . }",
+				query.getQueryString());
+	}
+
+	@Test
+	void qSel04_selectDistinctAllProjection() {
+		SelectQuery query = Queries.SELECT()
+				.distinct()
+				.where(GraphPatterns.tp(SparqlBuilder.var("s"), SparqlBuilder.var("p"), SparqlBuilder.var("o")));
+
+		assertSparqlEquals(
+				"SELECT DISTINCT * WHERE { ?s ?p ?o . }",
+				query.getQueryString());
+	}
+
+	@Test
+	void qPfx01_singlePrefixDeclaration() {
+		SelectQuery query = Queries.SELECT()
+				.prefix(SparqlBuilder.prefix("ex", Rdf.iri("http://example.com/ns#")))
+				.where(GraphPatterns.tp(SparqlBuilder.var("s"), SparqlBuilder.var("p"), SparqlBuilder.var("o")));
+
+		assertSparqlEquals(
+				"PREFIX ex: <http://example.com/ns#> SELECT * WHERE { ?s ?p ?o . }",
+				query.getQueryString());
+	}
+
+	@Test
+	void qPfx02_multiplePrefixesNormalizedOrder() {
+		SelectQuery query = Queries.SELECT()
+				.prefix(SparqlBuilder.prefix("foaf", Rdf.iri("http://xmlns.com/foaf/0.1/")))
+				.prefix(SparqlBuilder.prefix("ex", Rdf.iri("http://example.com/ns#")))
+				.where(GraphPatterns.tp(SparqlBuilder.var("s"), SparqlBuilder.var("p"), SparqlBuilder.var("o")));
+
+		assertSparqlEquals(
+				"PREFIX ex: <http://example.com/ns#> PREFIX foaf: <http://xmlns.com/foaf/0.1/> SELECT * WHERE { ?s ?p ?o . }",
+				query.getQueryString());
+	}
+
+	@Test
+	void qPfx03_baseDeclaration() {
+		SelectQuery query = Queries.SELECT()
+				.base(Rdf.iri("http://example.com/base/"))
+				.prefix(SparqlBuilder.prefix("ex", Rdf.iri("http://example.com/ns#")))
+				.where(GraphPatterns.tp(SparqlBuilder.var("s"), SparqlBuilder.var("p"), SparqlBuilder.var("o")));
+
+		assertSparqlEquals(
+				"BASE <http://example.com/base/> PREFIX ex: <http://example.com/ns#> SELECT * WHERE { ?s ?p ?o . }",
+				query.getQueryString());
+	}
+
+	@Test
+	void qDs01_singleFromDefaultGraph() {
+		SelectQuery query = Queries.SELECT()
+				.from(SparqlBuilder.from(Rdf.iri("http://example.com/graph")))
+				.where(GraphPatterns.tp(SparqlBuilder.var("s"), SparqlBuilder.var("p"), SparqlBuilder.var("o")));
+
+		assertSparqlEquals(
+				"SELECT * FROM <http://example.com/graph> WHERE { ?s ?p ?o . }",
+				query.getQueryString());
+	}
+
+	@Test
+	void qDs02_singleFromNamedGraph() {
+		SelectQuery query = Queries.SELECT()
+				.from(SparqlBuilder.fromNamed(Rdf.iri("http://example.com/namedGraph")))
+				.where(GraphPatterns.tp(SparqlBuilder.var("s"), SparqlBuilder.var("p"), SparqlBuilder.var("o")));
+
+		assertSparqlEquals(
+				"SELECT * FROM NAMED <http://example.com/namedGraph> WHERE { ?s ?p ?o . }",
+				query.getQueryString());
+	}
+
+	@Test
+	void qDs03_multipleFromClauses() {
+		SelectQuery query = Queries.SELECT()
+				.from(
+						SparqlBuilder.from(Rdf.iri("http://example.com/defaultOne")),
+						SparqlBuilder.fromNamed(Rdf.iri("http://example.com/namedOne")))
+				.from(SparqlBuilder.from(Rdf.iri("http://example.com/defaultTwo")))
+				.where(GraphPatterns.tp(SparqlBuilder.var("s"), SparqlBuilder.var("p"), SparqlBuilder.var("o")));
+
+		assertSparqlEquals(
+				"SELECT * FROM <http://example.com/defaultOne> FROM NAMED <http://example.com/namedOne> FROM <http://example.com/defaultTwo> WHERE { ?s ?p ?o . }",
+				query.getQueryString());
+	}
+
+	@Test
+	void qDs04_datasetViaBuilder() {
+		SelectQuery query = Queries.SELECT()
+				.from(SparqlBuilder.dataset(
+						SparqlBuilder.from(Rdf.iri("http://example.com/default")),
+						SparqlBuilder.fromNamed(Rdf.iri("http://example.com/named"))))
+				.where(GraphPatterns.tp(SparqlBuilder.var("s"), SparqlBuilder.var("p"), SparqlBuilder.var("o")));
+
+		assertSparqlEquals(
+				"SELECT * FROM <http://example.com/default> FROM NAMED <http://example.com/named> WHERE { ?s ?p ?o . }",
+				query.getQueryString());
+	}
+
+	@Test
+	void qGrp01_groupBySingleVariable() {
+		Variable s = SparqlBuilder.var("s");
+		Variable name = SparqlBuilder.var("name");
+
+		SelectQuery query = Queries.SELECT(s)
+				.where(GraphPatterns.tp(s, Rdf.iri("http://example.com/ns#name"), name))
+				.groupBy(s);
+
+		assertSparqlEquals(
+				"SELECT ?s WHERE { ?s <http://example.com/ns#name> ?name . } GROUP BY ?s",
+				query.getQueryString());
+	}
+
+	@Test
+	void qGrp02_groupByExpression() {
+		Variable s = SparqlBuilder.var("s");
+		Variable name = SparqlBuilder.var("name");
+
+		SelectQuery query = Queries.SELECT(s)
+				.where(GraphPatterns.tp(s, Rdf.iri("http://example.com/ns#name"), name))
+				.groupBy(Expressions.str(name));
+
+		assertSparqlEquals(
+				"SELECT ?s WHERE { ?s <http://example.com/ns#name> ?name . } GROUP BY STR( ?name )",
+				query.getQueryString());
+	}
+
+	@Test
+	void qHav01_havingWithCountGreaterThanOne() {
+		Variable s = SparqlBuilder.var("s");
+		Variable name = SparqlBuilder.var("name");
+
+		SelectQuery query = Queries.SELECT(s)
+				.where(GraphPatterns.tp(s, Rdf.iri("http://example.com/ns#name"), name))
+				.groupBy(s)
+				.having(Expressions.gt(Expressions.count(name), Rdf.literalOf(1)));
+
+		assertSparqlEquals(
+				"SELECT ?s WHERE { ?s <http://example.com/ns#name> ?name . } GROUP BY ?s HAVING ( COUNT( ?name ) > 1 )",
+				query.getQueryString());
+	}
+
+	@Test
+	void qOrd01_orderByAscendingVariable() {
+		Variable s = SparqlBuilder.var("s");
+		Variable name = SparqlBuilder.var("name");
+
+		SelectQuery query = Queries.SELECT(s, name)
+				.where(GraphPatterns.tp(s, Rdf.iri("http://example.com/ns#name"), name))
+				.orderBy(name);
+
+		assertSparqlEquals(
+				"SELECT ?s ?name WHERE { ?s <http://example.com/ns#name> ?name . } ORDER BY ?name",
+				query.getQueryString());
+	}
+
+	@Test
+	void qOrd02_orderByDescendingExpression() {
+		Variable s = SparqlBuilder.var("s");
+		Variable name = SparqlBuilder.var("name");
+
+		SelectQuery query = Queries.SELECT(s, name)
+				.where(GraphPatterns.tp(s, Rdf.iri("http://example.com/ns#name"), name))
+				.orderBy(Expressions.str(name).desc());
+
+		assertSparqlEquals(
+				"SELECT ?s ?name WHERE { ?s <http://example.com/ns#name> ?name . } ORDER BY DESC( STR( ?name ) )",
+				query.getQueryString());
+	}
+
+	@Test
+	void qOrd03_multipleOrderKeys() {
+		Variable s = SparqlBuilder.var("s");
+		Variable name = SparqlBuilder.var("name");
+		Variable age = SparqlBuilder.var("age");
+
+		SelectQuery query = Queries.SELECT(s, name, age)
+				.where(GraphPatterns.tp(s, Rdf.iri("http://example.com/ns#name"), name))
+				.where(GraphPatterns.tp(s, Rdf.iri("http://example.com/ns#age"), age))
+				.orderBy(name, age.desc());
+
+		assertSparqlEquals(
+				"SELECT ?s ?name ?age WHERE { ?s <http://example.com/ns#name> ?name . ?s <http://example.com/ns#age> ?age . } ORDER BY ?name DESC( ?age )",
+				query.getQueryString());
+	}
+
+	@Test
+	void qLim01_limitClause() {
+		Variable s = SparqlBuilder.var("s");
+		Variable name = SparqlBuilder.var("name");
+
+		SelectQuery query = Queries.SELECT(s, name)
+				.where(GraphPatterns.tp(s, Rdf.iri("http://example.com/ns#name"), name))
+				.limit(5);
+
+		assertSparqlEquals(
+				"SELECT ?s ?name WHERE { ?s <http://example.com/ns#name> ?name . } LIMIT 5",
+				query.getQueryString());
+	}
+
+	@Test
+	void qOff01_offsetClause() {
+		Variable s = SparqlBuilder.var("s");
+		Variable name = SparqlBuilder.var("name");
+
+		SelectQuery query = Queries.SELECT(s, name)
+				.where(GraphPatterns.tp(s, Rdf.iri("http://example.com/ns#name"), name))
+				.offset(10);
+
+		assertSparqlEquals(
+				"SELECT ?s ?name WHERE { ?s <http://example.com/ns#name> ?name . } OFFSET 10",
+				query.getQueryString());
+	}
+}

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/util/QueryAssert.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/util/QueryAssert.java
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ ******************************************************************************/
+package org.eclipse.rdf4j.sparqlbuilder.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public final class QueryAssert {
+
+	private static final Pattern WHITESPACE = Pattern.compile("\\s+");
+	private static final Pattern PREFIX_DECLARATION = Pattern
+			.compile("PREFIX\\s+[^\\s]+:\\s*<[^>]+>", Pattern.CASE_INSENSITIVE);
+	private static final Pattern BASE_DECLARATION = Pattern.compile("BASE\\s+<[^>]+>", Pattern.CASE_INSENSITIVE);
+
+	private QueryAssert() {
+	}
+
+	public static void assertSparqlEquals(String expected, String actual) {
+		assertThat(normalize(actual)).isEqualTo(normalize(expected));
+	}
+
+	private static String normalize(String sparql) {
+		if (sparql == null) {
+			return null;
+		}
+		String trimmed = sparql.trim();
+		List<String> bases = extractDeclarations(BASE_DECLARATION, trimmed);
+		String withoutBases = stripDeclarations(BASE_DECLARATION, trimmed);
+
+		List<String> prefixes = extractDeclarations(PREFIX_DECLARATION, withoutBases);
+		Collections.sort(prefixes);
+		String remainder = stripDeclarations(PREFIX_DECLARATION, withoutBases);
+
+		StringBuilder canonical = new StringBuilder();
+		appendDeclarations(canonical, bases);
+		appendDeclarations(canonical, prefixes);
+		if (!remainder.isBlank()) {
+			if (canonical.length() > 0) {
+				canonical.append(' ');
+			}
+			canonical.append(remainder.trim());
+		}
+
+		return WHITESPACE.matcher(canonical.toString().trim()).replaceAll(" ");
+	}
+
+	private static List<String> extractDeclarations(Pattern pattern, String sparql) {
+		Matcher matcher = pattern.matcher(sparql);
+		List<String> declarations = new ArrayList<>();
+		while (matcher.find()) {
+			declarations.add(matcher.group().trim());
+		}
+		return declarations;
+	}
+
+	private static String stripDeclarations(Pattern pattern, String sparql) {
+		return pattern.matcher(sparql).replaceAll(" ").trim();
+	}
+
+	private static void appendDeclarations(StringBuilder builder, List<String> declarations) {
+		if (declarations.isEmpty()) {
+			return;
+		}
+		if (builder.length() > 0) {
+			builder.append(' ');
+		}
+		for (int i = 0; i < declarations.size(); i++) {
+			if (i > 0) {
+				builder.append(' ');
+			}
+			builder.append(declarations.get(i));
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add alias projection coverage to `SelectQueryClausesTest`
- assert `SELECT DISTINCT *` rendering and fix `Projection` to emit DISTINCT ahead of the projection body
- extend `SelectQueryClausesTest` with group-by, having, ordering, limit, and offset clauses using canonical comparisons
- add standard license headers to new sparqlbuilder test utilities

## Testing
- mvn -pl core/sparqlbuilder -Dtest=SelectQueryClausesTest test

------
https://chatgpt.com/codex/tasks/task_e_68d9ffc125e0832e9fa53186f7ca4f70