### PR TITLE
Run e2e suite in Copilot setup workflow

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -32,7 +32,7 @@ jobs:
         run: mvn -B -T 2C dependency:go-offline
 
       - name: Maven install (skip tests)
-        run: mvn -B clean install -DskipTests -Pquick
+        run: mvn -B install -DskipTests -Pquick
 
       - name: Install system dependencies for E2E tests
         run: sudo apt-get update && sudo apt-get install -y libxml2-utils

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,54 @@
+name: Copilot Setup Steps
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  setup:
+    name: Prepare Maven workspace and prime E2E dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: 11
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Validate formatting configuration
+        run: mvn -B -T 2C formatter:validate impsort:check xml-format:xml-check
+
+      - name: Quick compile (skip tests)
+        run: mvn -B -T 2C compile -DskipTests -Pquick
+
+      - name: Download Maven dependencies for offline use
+        run: mvn -B -T 2C dependency:go-offline
+
+      - name: Maven install (skip tests)
+        run: mvn -B clean install -DskipTests -Pquick
+
+      - name: Install system dependencies for E2E tests
+        run: sudo apt-get update && sudo apt-get install -y libxml2-utils
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'npm'
+
+      - name: Install Playwright dependencies for E2E tests
+        working-directory: ./e2e
+        run: |
+          npm install
+          npx playwright install --with-deps
+
+      - name: Run end-to-end tests of RDF4J Server and Workbench
+        working-directory: ./e2e
+        run: ./run.sh

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -42,6 +42,7 @@ jobs:
         with:
           node-version: 18
           cache: 'npm'
+          cache-dependency-path: ./e2e/package-lock.json
 
       - name: Install Playwright dependencies for E2E tests
         working-directory: ./e2e


### PR DESCRIPTION
## Summary
- run the RDF4J end-to-end test script from the Copilot setup workflow so caches stay warm
- enable npm caching in the Copilot setup workflow
- remove the Copilot workflow regression test that enforced skipping the end-to-end run script

## Testing
- mvn -pl core/model -Dtest=org.eclipse.rdf4j.model.CopilotWorkflowSetupTest#copilotSetupInvokesEndToEndScript verify
- mvn -pl core/model -DskipTests verify

------
https://chatgpt.com/codex/tasks/task_e_68d9990b6da0832e8c6b2223b5f7d1db