### PR TITLE
Add WHERE and CONSTRUCT coverage to sparqlbuilder tests

### DIFF
--- a/core/sparqlbuilder/pom.xml
+++ b/core/sparqlbuilder/pom.xml
@@ -26,5 +26,11 @@
 			<artifactId>assertj-core</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.eclipse.rdf4j</groupId>
+			<artifactId>rdf4j-queryparser-sparql</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/core/Projection.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/core/Projection.java
@@ -94,13 +94,13 @@ public class Projection extends QueryElementCollection<Projectable> {
 		StringBuilder selectStatement = new StringBuilder();
 		selectStatement.append(SELECT).append(" ");
 
+		if (isDistinct) {
+			selectStatement.append(DISTINCT).append(" ");
+		}
+
 		if (selectAll || isEmpty()) {
 			selectStatement.append("*").append(" ");
 		} else {
-			if (isDistinct) {
-				selectStatement.append(DISTINCT).append(" ");
-			}
-
 			selectStatement.append(super.getQueryString());
 		}
 

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/TestCoverageBacklog.md
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/TestCoverageBacklog.md
@@ -1,0 +1,70 @@
+<!--
+Copyright (c) 2024 Eclipse RDF4J contributors.
+
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Distribution License v1.0
+which accompanies this distribution, and is available at
+http://www.eclipse.org/org/documents/edl-v10.php.
+
+SPDX-License-Identifier: BSD-3-Clause
+-->
+# SparqlBuilder Test Coverage Backlog
+
+The following test cases from the agreed plan are **not yet implemented**.
+
+## Query skeleton & clauses
+- (complete) Q-WH series and Q-CON series now covered.
+
+## VALUES
+- VAL-05: Empty row set handling (allowed/disallowed behaviour).
+
+## Generator helpers
+- GEN-01: `var()` uniqueness across multiple calls.
+- GEN-02: `bNode()` uniqueness across multiple calls.
+
+## Graph patterns
+- GP-SS-01: Subselect via `GraphPatterns.select(...).where(...).groupBy(...).having(...)`.
+
+## RDF terms & predicate-object lists
+- RDF-TP-01 through RDF-TP-04.
+- RDF-VAL-01 through RDF-VAL-09.
+
+## Property paths
+- PATH-01 through PATH-09.
+
+## Expressions, functions, aggregates, BIND
+- EXPR-AR-01, EXPR-BO-01, EXPR-CMP-01, EXPR-IN-01, EXPR-NIN-01.
+- EXPR-FN-STR-01 through EXPR-FN-STR-04.
+- EXPR-FN-DT-01, EXPR-FN-BNODE-01, EXPR-FN-BOUND-01, EXPR-FN-COALESCE-01, EXPR-FN-NUM-01.
+- EXPR-AGG-01 through EXPR-AGG-04.
+- EXPR-BIND-01, EXPR-BIND-02.
+- EXPR-CUST-01.
+
+## SPARQL Update
+- UPD-DATA-01 through UPD-DATA-03.
+- UPD-MOD-01 through UPD-MOD-05.
+- UPD-LOAD-01, UPD-LOAD-02.
+- UPD-CLR-01 through UPD-CLR-05.
+- UPD-CRD-01, UPD-DRP-01.
+- UPD-COPY-01, UPD-MOVE-01, UPD-ADD-01.
+
+## Availability & negatives
+- NEG-ASK-01, NEG-DESC-01.
+- NEG-VAL-01 (arity mismatch already covered) – confirm semantics once broader suite stabilises.
+- NEG-PATH-01.
+- NEG-EXP-01.
+
+## Combinatorial suite
+- CT-01 through CT-10.
+
+## Subselects
+- SS-01, SS-02.
+
+## End-to-end interaction
+- IT-01 through IT-04.
+
+## Stability & regression sentinels
+- STA-01 through STA-05.
+
+## Known limitations & placeholders
+- LIM-ASK, LIM-SERVICE.

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/core/query/ConstructQueryTest.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/core/query/ConstructQueryTest.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ ******************************************************************************/
+package org.eclipse.rdf4j.sparqlbuilder.core.query;
+
+import static org.eclipse.rdf4j.sparqlbuilder.util.QueryAssert.assertSparqlEquals;
+
+import org.eclipse.rdf4j.sparqlbuilder.core.GraphTemplate;
+import org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder;
+import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns;
+import org.eclipse.rdf4j.sparqlbuilder.graphpattern.TriplePattern;
+import org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf;
+import org.junit.jupiter.api.Test;
+
+class ConstructQueryTest {
+
+	@Test
+	void qCon01_basicConstructQuery() {
+		TriplePattern triple = GraphPatterns.tp(
+				SparqlBuilder.var("s"),
+				SparqlBuilder.var("p"),
+				SparqlBuilder.var("o"));
+
+		ConstructQuery query = Queries.CONSTRUCT()
+				.construct(triple)
+				.where(triple);
+
+		assertSparqlEquals("CONSTRUCT { ?s ?p ?o . } WHERE { ?s ?p ?o . }", query.getQueryString());
+	}
+
+	@Test
+	void qCon02_constructWithExplicitTemplate() {
+		GraphTemplate template = SparqlBuilder.construct(
+				GraphPatterns.tp(SparqlBuilder.var("s"), Rdf.iri("http://example.com/ns#name"), SparqlBuilder.var("n")),
+				GraphPatterns.tp(SparqlBuilder.var("s"), Rdf.iri("http://example.com/ns#age"), SparqlBuilder.var("a")));
+
+		TriplePattern wherePattern = GraphPatterns.tp(
+				SparqlBuilder.var("s"),
+				Rdf.iri("http://example.com/ns#name"),
+				SparqlBuilder.var("n"));
+
+		ConstructQuery query = Queries.CONSTRUCT()
+				.construct(template)
+				.where(wherePattern);
+
+		assertSparqlEquals(
+				"CONSTRUCT { ?s <http://example.com/ns#name> ?n . ?s <http://example.com/ns#age> ?a . } WHERE { ?s <http://example.com/ns#name> ?n . }",
+				query.getQueryString());
+	}
+
+	@Test
+	void qCon03_constructWithDatasetClauses() {
+		TriplePattern triple = GraphPatterns.tp(
+				SparqlBuilder.var("s"),
+				SparqlBuilder.var("p"),
+				SparqlBuilder.var("o"));
+
+		ConstructQuery query = Queries.CONSTRUCT()
+				.from(SparqlBuilder.from(Rdf.iri("http://example.com/default")))
+				.from(SparqlBuilder.fromNamed(Rdf.iri("http://example.com/named")))
+				.construct(triple)
+				.where(triple);
+
+		assertSparqlEquals(
+				"CONSTRUCT { ?s ?p ?o . } FROM <http://example.com/default> FROM NAMED <http://example.com/named> WHERE { ?s ?p ?o . }",
+				query.getQueryString());
+	}
+}

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/core/query/SelectQueryClausesTest.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/core/query/SelectQueryClausesTest.java
@@ -1,0 +1,320 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ ******************************************************************************/
+package org.eclipse.rdf4j.sparqlbuilder.core.query;
+
+import static org.eclipse.rdf4j.sparqlbuilder.util.QueryAssert.assertSparqlEquals;
+
+import org.eclipse.rdf4j.sparqlbuilder.constraint.Expressions;
+import org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder;
+import org.eclipse.rdf4j.sparqlbuilder.core.Variable;
+import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPattern;
+import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns;
+import org.eclipse.rdf4j.sparqlbuilder.graphpattern.TriplePattern;
+import org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf;
+import org.junit.jupiter.api.Test;
+
+class SelectQueryClausesTest {
+
+	@Test
+	void qSel01_selectAllWithSingleTriplePattern() {
+		Variable s = SparqlBuilder.var("s");
+		Variable p = SparqlBuilder.var("p");
+		Variable o = SparqlBuilder.var("o");
+
+		TriplePattern pattern = GraphPatterns.tp(s, p, o);
+
+		SelectQuery query = Queries.SELECT().where(pattern);
+
+		assertSparqlEquals("SELECT * WHERE { ?s ?p ?o . }", query.getQueryString());
+	}
+
+	@Test
+	void qSel02_selectExplicitProjectionOrder() {
+		Variable s = SparqlBuilder.var("s");
+		Variable p = SparqlBuilder.var("p");
+		Variable o = SparqlBuilder.var("o");
+
+		SelectQuery query = Queries.SELECT(s, p, o)
+				.where(GraphPatterns.tp(Rdf.iri("http://example.com/ns#subject"), p, o));
+
+		assertSparqlEquals(
+				"SELECT ?s ?p ?o WHERE { <http://example.com/ns#subject> ?p ?o . }",
+				query.getQueryString());
+	}
+
+	@Test
+	void qSel03_projectionWithAliasExpression() {
+		Variable s = SparqlBuilder.var("s");
+		Variable o = SparqlBuilder.var("o");
+		Variable label = SparqlBuilder.var("label");
+
+		SelectQuery query = Queries.SELECT(SparqlBuilder.as(Expressions.str(o), label), o)
+				.where(GraphPatterns.tp(s, Rdf.iri("http://example.com/ns#name"), o));
+
+		assertSparqlEquals(
+				"SELECT ( STR( ?o ) AS ?label ) ?o WHERE { ?s <http://example.com/ns#name> ?o . }",
+				query.getQueryString());
+	}
+
+	@Test
+	void qSel04_selectDistinctAllProjection() {
+		SelectQuery query = Queries.SELECT()
+				.distinct()
+				.where(GraphPatterns.tp(SparqlBuilder.var("s"), SparqlBuilder.var("p"), SparqlBuilder.var("o")));
+
+		assertSparqlEquals(
+				"SELECT DISTINCT * WHERE { ?s ?p ?o . }",
+				query.getQueryString());
+	}
+
+	@Test
+	void qPfx01_singlePrefixDeclaration() {
+		SelectQuery query = Queries.SELECT()
+				.prefix(SparqlBuilder.prefix("ex", Rdf.iri("http://example.com/ns#")))
+				.where(GraphPatterns.tp(SparqlBuilder.var("s"), SparqlBuilder.var("p"), SparqlBuilder.var("o")));
+
+		assertSparqlEquals(
+				"PREFIX ex: <http://example.com/ns#> SELECT * WHERE { ?s ?p ?o . }",
+				query.getQueryString());
+	}
+
+	@Test
+	void qPfx02_multiplePrefixesNormalizedOrder() {
+		SelectQuery query = Queries.SELECT()
+				.prefix(SparqlBuilder.prefix("foaf", Rdf.iri("http://xmlns.com/foaf/0.1/")))
+				.prefix(SparqlBuilder.prefix("ex", Rdf.iri("http://example.com/ns#")))
+				.where(GraphPatterns.tp(SparqlBuilder.var("s"), SparqlBuilder.var("p"), SparqlBuilder.var("o")));
+
+		assertSparqlEquals(
+				"PREFIX ex: <http://example.com/ns#> PREFIX foaf: <http://xmlns.com/foaf/0.1/> SELECT * WHERE { ?s ?p ?o . }",
+				query.getQueryString());
+	}
+
+	@Test
+	void qPfx03_baseDeclaration() {
+		SelectQuery query = Queries.SELECT()
+				.base(Rdf.iri("http://example.com/base/"))
+				.prefix(SparqlBuilder.prefix("ex", Rdf.iri("http://example.com/ns#")))
+				.where(GraphPatterns.tp(SparqlBuilder.var("s"), SparqlBuilder.var("p"), SparqlBuilder.var("o")));
+
+		assertSparqlEquals(
+				"BASE <http://example.com/base/> PREFIX ex: <http://example.com/ns#> SELECT * WHERE { ?s ?p ?o . }",
+				query.getQueryString());
+	}
+
+	@Test
+	void qDs01_singleFromDefaultGraph() {
+		SelectQuery query = Queries.SELECT()
+				.from(SparqlBuilder.from(Rdf.iri("http://example.com/graph")))
+				.where(GraphPatterns.tp(SparqlBuilder.var("s"), SparqlBuilder.var("p"), SparqlBuilder.var("o")));
+
+		assertSparqlEquals(
+				"SELECT * FROM <http://example.com/graph> WHERE { ?s ?p ?o . }",
+				query.getQueryString());
+	}
+
+	@Test
+	void qDs02_singleFromNamedGraph() {
+		SelectQuery query = Queries.SELECT()
+				.from(SparqlBuilder.fromNamed(Rdf.iri("http://example.com/namedGraph")))
+				.where(GraphPatterns.tp(SparqlBuilder.var("s"), SparqlBuilder.var("p"), SparqlBuilder.var("o")));
+
+		assertSparqlEquals(
+				"SELECT * FROM NAMED <http://example.com/namedGraph> WHERE { ?s ?p ?o . }",
+				query.getQueryString());
+	}
+
+	@Test
+	void qDs03_multipleFromClauses() {
+		SelectQuery query = Queries.SELECT()
+				.from(
+						SparqlBuilder.from(Rdf.iri("http://example.com/defaultOne")),
+						SparqlBuilder.fromNamed(Rdf.iri("http://example.com/namedOne")))
+				.from(SparqlBuilder.from(Rdf.iri("http://example.com/defaultTwo")))
+				.where(GraphPatterns.tp(SparqlBuilder.var("s"), SparqlBuilder.var("p"), SparqlBuilder.var("o")));
+
+		assertSparqlEquals(
+				"SELECT * FROM <http://example.com/defaultOne> FROM NAMED <http://example.com/namedOne> FROM <http://example.com/defaultTwo> WHERE { ?s ?p ?o . }",
+				query.getQueryString());
+	}
+
+	@Test
+	void qDs04_datasetViaBuilder() {
+		SelectQuery query = Queries.SELECT()
+				.from(SparqlBuilder.dataset(
+						SparqlBuilder.from(Rdf.iri("http://example.com/default")),
+						SparqlBuilder.fromNamed(Rdf.iri("http://example.com/named"))))
+				.where(GraphPatterns.tp(SparqlBuilder.var("s"), SparqlBuilder.var("p"), SparqlBuilder.var("o")));
+
+		assertSparqlEquals(
+				"SELECT * FROM <http://example.com/default> FROM NAMED <http://example.com/named> WHERE { ?s ?p ?o . }",
+				query.getQueryString());
+	}
+
+	@Test
+	void qWh01_singleTriplePatternWhereClause() {
+		Variable s = SparqlBuilder.var("s");
+		Variable p = SparqlBuilder.var("p");
+		Variable o = SparqlBuilder.var("o");
+
+		SelectQuery query = Queries.SELECT()
+				.where(GraphPatterns.tp(s, p, o));
+
+		assertSparqlEquals("SELECT * WHERE { ?s ?p ?o . }", query.getQueryString());
+	}
+
+	@Test
+	void qWh02_multiplePatternsCombined() {
+		Variable s = SparqlBuilder.var("s");
+		Variable name = SparqlBuilder.var("name");
+		Variable age = SparqlBuilder.var("age");
+
+		SelectQuery query = Queries.SELECT(s)
+				.where(GraphPatterns.tp(s, Rdf.iri("http://example.com/ns#name"), name))
+				.where(GraphPatterns.tp(s, Rdf.iri("http://example.com/ns#age"), age));
+
+		assertSparqlEquals(
+				"SELECT ?s WHERE { ?s <http://example.com/ns#name> ?name . ?s <http://example.com/ns#age> ?age . }",
+				query.getQueryString());
+	}
+
+	@Test
+	void qWh03_prebuiltQueryPatternSuppliedToWhere() {
+		Variable s = SparqlBuilder.var("s");
+		Variable name = SparqlBuilder.var("name");
+		Variable age = SparqlBuilder.var("age");
+
+		GraphPattern combined = GraphPatterns.and(
+				GraphPatterns.tp(s, Rdf.iri("http://example.com/ns#name"), name),
+				GraphPatterns.tp(s, Rdf.iri("http://example.com/ns#age"), age));
+
+		SelectQuery query = Queries.SELECT(s).where(combined);
+
+		assertSparqlEquals(
+				"SELECT ?s WHERE { ?s <http://example.com/ns#name> ?name . ?s <http://example.com/ns#age> ?age . }",
+				query.getQueryString());
+	}
+
+	@Test
+	void qGrp01_groupBySingleVariable() {
+		Variable s = SparqlBuilder.var("s");
+		Variable name = SparqlBuilder.var("name");
+
+		SelectQuery query = Queries.SELECT(s)
+				.where(GraphPatterns.tp(s, Rdf.iri("http://example.com/ns#name"), name))
+				.groupBy(s);
+
+		assertSparqlEquals(
+				"SELECT ?s WHERE { ?s <http://example.com/ns#name> ?name . } GROUP BY ?s",
+				query.getQueryString());
+	}
+
+	@Test
+	void qGrp02_groupByExpression() {
+		Variable name = SparqlBuilder.var("name");
+		Variable count = SparqlBuilder.var("count");
+
+		SelectQuery query = Queries.SELECT(SparqlBuilder.as(Expressions.count(name), count))
+				.where(GraphPatterns.tp(SparqlBuilder.var("s"), Rdf.iri("http://example.com/ns#name"), name))
+				.groupBy(Expressions.str(name));
+
+		assertSparqlEquals(
+				"SELECT ( COUNT( ?name ) AS ?count ) WHERE { ?s <http://example.com/ns#name> ?name . } GROUP BY STR( ?name )",
+				query.getQueryString());
+	}
+
+	@Test
+	void qHav01_havingWithCountGreaterThanOne() {
+		Variable s = SparqlBuilder.var("s");
+		Variable name = SparqlBuilder.var("name");
+
+		SelectQuery query = Queries.SELECT(s)
+				.where(GraphPatterns.tp(s, Rdf.iri("http://example.com/ns#name"), name))
+				.groupBy(s)
+				.having(Expressions.gt(Expressions.count(name), Rdf.literalOf(1)));
+
+		assertSparqlEquals(
+				"SELECT ?s WHERE { ?s <http://example.com/ns#name> ?name . } GROUP BY ?s HAVING ( COUNT( ?name ) > 1 )",
+				query.getQueryString());
+	}
+
+	@Test
+	void qOrd01_orderByAscendingVariable() {
+		Variable s = SparqlBuilder.var("s");
+		Variable name = SparqlBuilder.var("name");
+
+		SelectQuery query = Queries.SELECT(s, name)
+				.where(GraphPatterns.tp(s, Rdf.iri("http://example.com/ns#name"), name))
+				.orderBy(name);
+
+		assertSparqlEquals(
+				"SELECT ?s ?name WHERE { ?s <http://example.com/ns#name> ?name . } ORDER BY ?name",
+				query.getQueryString());
+	}
+
+	@Test
+	void qOrd02_orderByDescendingExpression() {
+		Variable s = SparqlBuilder.var("s");
+		Variable name = SparqlBuilder.var("name");
+
+		SelectQuery query = Queries.SELECT(s, name)
+				.where(GraphPatterns.tp(s, Rdf.iri("http://example.com/ns#name"), name))
+				.orderBy(Expressions.str(name).desc());
+
+		assertSparqlEquals(
+				"SELECT ?s ?name WHERE { ?s <http://example.com/ns#name> ?name . } ORDER BY DESC( STR( ?name ) )",
+				query.getQueryString());
+	}
+
+	@Test
+	void qOrd03_multipleOrderKeys() {
+		Variable s = SparqlBuilder.var("s");
+		Variable name = SparqlBuilder.var("name");
+		Variable age = SparqlBuilder.var("age");
+
+		SelectQuery query = Queries.SELECT(s, name, age)
+				.where(GraphPatterns.tp(s, Rdf.iri("http://example.com/ns#name"), name))
+				.where(GraphPatterns.tp(s, Rdf.iri("http://example.com/ns#age"), age))
+				.orderBy(name, age.desc());
+
+		assertSparqlEquals(
+				"SELECT ?s ?name ?age WHERE { ?s <http://example.com/ns#name> ?name . ?s <http://example.com/ns#age> ?age . } ORDER BY ?name DESC( ?age )",
+				query.getQueryString());
+	}
+
+	@Test
+	void qLim01_limitClause() {
+		Variable s = SparqlBuilder.var("s");
+		Variable name = SparqlBuilder.var("name");
+
+		SelectQuery query = Queries.SELECT(s, name)
+				.where(GraphPatterns.tp(s, Rdf.iri("http://example.com/ns#name"), name))
+				.limit(5);
+
+		assertSparqlEquals(
+				"SELECT ?s ?name WHERE { ?s <http://example.com/ns#name> ?name . } LIMIT 5",
+				query.getQueryString());
+	}
+
+	@Test
+	void qOff01_offsetClause() {
+		Variable s = SparqlBuilder.var("s");
+		Variable name = SparqlBuilder.var("name");
+
+		SelectQuery query = Queries.SELECT(s, name)
+				.where(GraphPatterns.tp(s, Rdf.iri("http://example.com/ns#name"), name))
+				.offset(10);
+
+		assertSparqlEquals(
+				"SELECT ?s ?name WHERE { ?s <http://example.com/ns#name> ?name . } OFFSET 10",
+				query.getQueryString());
+	}
+}

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/core/query/ValuesClauseTest.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/core/query/ValuesClauseTest.java
@@ -1,0 +1,112 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ ******************************************************************************/
+package org.eclipse.rdf4j.sparqlbuilder.core.query;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.eclipse.rdf4j.sparqlbuilder.util.QueryAssert.assertSparqlEquals;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.util.Values;
+import org.eclipse.rdf4j.sparqlbuilder.constraint.Values.Builder;
+import org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder;
+import org.eclipse.rdf4j.sparqlbuilder.core.Variable;
+import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns;
+import org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf;
+import org.junit.jupiter.api.Test;
+
+class ValuesClauseTest {
+
+	private static final IRI NAME = Values.iri("http://example.com/ns#name");
+	private static final IRI AGE = Values.iri("http://example.com/ns#age");
+
+	@Test
+	void val01_queryLevelSingleVariableValues() {
+		Variable name = SparqlBuilder.var("name");
+
+		SelectQuery query = Queries.SELECT(name)
+				.where(GraphPatterns.tp(SparqlBuilder.var("s"), Rdf.iri(NAME), name))
+				.values(builder -> builder.variables(name).values(Rdf.literalOf("Alice"), Rdf.literalOf("Bob")));
+
+		assertSparqlEquals(
+				"SELECT ?name WHERE { ?s <http://example.com/ns#name> ?name . } VALUES ?name { \"Alice\" \"Bob\" }",
+				query.getQueryString());
+	}
+
+	@Test
+	void val02_multiVariableRowWiseValues() {
+		Variable name = SparqlBuilder.var("name");
+		Variable age = SparqlBuilder.var("age");
+
+		SelectQuery query = Queries.SELECT(name, age)
+				.where(GraphPatterns.tp(SparqlBuilder.var("s"), Rdf.iri(NAME), name))
+				.where(GraphPatterns.tp(SparqlBuilder.var("s"), Rdf.iri(AGE), age))
+				.values(builder -> builder.variables(name, age)
+						.values(Rdf.literalOf("Alice"), Rdf.literalOf(30))
+						.values(Rdf.literalOf("Bob"), Rdf.literalOf(40)));
+
+		assertSparqlEquals(
+				"SELECT ?name ?age WHERE { ?s <http://example.com/ns#name> ?name . ?s <http://example.com/ns#age> ?age . } VALUES ( ?name ?age ) { ( \"Alice\" 30 ) ( \"Bob\" 40 ) }",
+				query.getQueryString());
+	}
+
+	@Test
+	void val03_mixedValueTypes() {
+		Variable person = SparqlBuilder.var("person");
+		Variable literal = SparqlBuilder.var("literal");
+
+		SelectQuery query = Queries.SELECT(person, literal)
+				.where(GraphPatterns.tp(person, Rdf.iri(NAME), literal))
+				.values(builder -> builder.variables(person, literal)
+						.values(Rdf.iri("http://example.com/ns#p1"), Rdf.literalOfLanguage("Alice", "en"))
+						.values(Rdf.iri("http://example.com/ns#p2"), Rdf.literalOf(25))
+						.values(null, null));
+
+		assertSparqlEquals(
+				"SELECT ?person ?literal WHERE { ?person <http://example.com/ns#name> ?literal . } VALUES ( ?person ?literal ) { ( <http://example.com/ns#p1> \"Alice\"@en ) ( <http://example.com/ns#p2> 25 ) ( UNDEF UNDEF ) }",
+				query.getQueryString());
+	}
+
+	@Test
+	void val04_valuesInsideGraphPattern() {
+		Variable s = SparqlBuilder.var("s");
+		Variable name = SparqlBuilder.var("name");
+
+		SelectQuery query = Queries.SELECT(s)
+				.where(GraphPatterns.tp(s, Rdf.iri(NAME), name)
+						.values(builder -> builder.variables(name).values(Rdf.literalOf("Alice"))));
+
+		assertSparqlEquals(
+				"SELECT ?s WHERE { ?s <http://example.com/ns#name> ?name . VALUES ?name { \"Alice\" } }",
+				query.getQueryString());
+	}
+
+	@Test
+	void val05_valuesArityMismatchThrows() {
+		Variable name = SparqlBuilder.var("name");
+		Variable age = SparqlBuilder.var("age");
+
+		SelectQuery query = Queries.SELECT(name, age)
+				.where(GraphPatterns.tp(SparqlBuilder.var("s"), Rdf.iri(NAME), name))
+				.where(GraphPatterns.tp(SparqlBuilder.var("s"), Rdf.iri(AGE), age));
+
+		assertThatThrownBy(() -> query.values(builder -> builder.variables(name, age).values(Rdf.literalOf("Alice"))))
+				.isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	void val06_valuesBuilderRequiresRowsBeforeBuild() {
+		Builder builder = (Builder) org.eclipse.rdf4j.sparqlbuilder.constraint.Values.builder();
+
+		builder.variables(SparqlBuilder.var("x"));
+
+		assertThatThrownBy(builder::build).isInstanceOf(IllegalArgumentException.class);
+	}
+}

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/graphpattern/GraphPatternCombinatorsTest.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/graphpattern/GraphPatternCombinatorsTest.java
@@ -1,0 +1,147 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ ******************************************************************************/
+package org.eclipse.rdf4j.sparqlbuilder.graphpattern;
+
+import static org.eclipse.rdf4j.sparqlbuilder.util.QueryAssert.assertSparqlEquals;
+
+import org.eclipse.rdf4j.model.util.Values;
+import org.eclipse.rdf4j.sparqlbuilder.constraint.Expressions;
+import org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder;
+import org.eclipse.rdf4j.sparqlbuilder.core.Variable;
+import org.eclipse.rdf4j.sparqlbuilder.core.query.Queries;
+import org.eclipse.rdf4j.sparqlbuilder.core.query.SelectQuery;
+import org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf;
+import org.junit.jupiter.api.Test;
+
+class GraphPatternCombinatorsTest {
+
+	private static final String NS = "http://example.com/ns#";
+
+	private static Variable var(String name) {
+		return SparqlBuilder.var(name);
+	}
+
+	@Test
+	void gpOpt01_optionalWrapsPattern() {
+		Variable s = var("s");
+		Variable name = var("name");
+
+		SelectQuery query = Queries.SELECT(s)
+				.where(GraphPatterns.tp(s, Rdf.iri(NS + "name"), name).optional());
+
+		assertSparqlEquals("SELECT ?s WHERE { OPTIONAL { ?s <http://example.com/ns#name> ?name . } }",
+				query.getQueryString());
+	}
+
+	@Test
+	void gpOpt02_optionalToggleOffRemovesWrapper() {
+		Variable s = var("s");
+		Variable p = var("p");
+		Variable o = var("o");
+
+		GraphPattern pattern = GraphPatterns.tp(s, p, o).optional();
+		pattern.optional(false);
+
+		SelectQuery query = Queries.SELECT(s).where(pattern);
+
+		assertSparqlEquals("SELECT ?s WHERE { ?s ?p ?o . }", query.getQueryString());
+	}
+
+	@Test
+	void gpUni01_unionOfTwoBranches() {
+		Variable s = var("s");
+
+		GraphPattern union = GraphPatterns.union(
+				GraphPatterns.tp(s, Rdf.iri(NS + "name"), Rdf.literalOf("Alice")),
+				GraphPatterns.tp(s, Rdf.iri(NS + "name"), Rdf.literalOf("Bob")));
+
+		SelectQuery query = Queries.SELECT(s).where(union);
+
+		assertSparqlEquals(
+				"SELECT ?s WHERE { { ?s <http://example.com/ns#name> \"Alice\" . } UNION { ?s <http://example.com/ns#name> \"Bob\" . } }",
+				query.getQueryString());
+	}
+
+	@Test
+	void gpMin01_minusPattern() {
+		Variable s = var("s");
+		Variable o = var("o");
+
+		GraphPattern pattern = GraphPatterns.tp(s, Rdf.iri(NS + "name"), o)
+				.minus(GraphPatterns.tp(s, Rdf.iri(NS + "deprecated"), o));
+
+		SelectQuery query = Queries.SELECT(s).where(pattern);
+
+		assertSparqlEquals(
+				"SELECT ?s WHERE { ?s <http://example.com/ns#name> ?o . MINUS { ?s <http://example.com/ns#deprecated> ?o . } }",
+				query.getQueryString());
+	}
+
+	@Test
+	void gpFlt01_filterOnExpression() {
+		Variable s = var("s");
+		Variable age = var("age");
+
+		GraphPattern pattern = GraphPatterns.tp(s, Rdf.iri(NS + "age"), age)
+				.filter(Expressions.gt(age, Rdf.literalOf(18)));
+
+		SelectQuery query = Queries.SELECT(s).where(pattern);
+
+		assertSparqlEquals(
+				"SELECT ?s WHERE { ?s <http://example.com/ns#age> ?age . FILTER ( ?age > 18 ) }",
+				query.getQueryString());
+	}
+
+	@Test
+	void gpExi01_filterExists() {
+		Variable s = var("s");
+		Variable name = var("name");
+
+		GraphPattern pattern = GraphPatterns.tp(s, Rdf.iri(NS + "name"), name)
+				.filterExists(GraphPatterns.tp(name, Rdf.iri(NS + "given"), Rdf.literalOf("A")));
+
+		SelectQuery query = Queries.SELECT(s).where(pattern);
+
+		assertSparqlEquals(
+				"SELECT ?s WHERE { ?s <http://example.com/ns#name> ?name . FILTER EXISTS { ?name <http://example.com/ns#given> \"A\" . } }",
+				query.getQueryString());
+	}
+
+	@Test
+	void gpNex01_filterNotExists() {
+		Variable s = var("s");
+		Variable name = var("name");
+
+		GraphPattern pattern = GraphPatterns.tp(s, Rdf.iri(NS + "name"), name)
+				.filterExists(false, GraphPatterns.tp(name, Rdf.iri(NS + "deprecated"), Rdf.literalOf(true)));
+
+		SelectQuery query = Queries.SELECT(s).where(pattern);
+
+		assertSparqlEquals(
+				"SELECT ?s WHERE { ?s <http://example.com/ns#name> ?name . FILTER NOT EXISTS { ?name <http://example.com/ns#deprecated> true . } }",
+				query.getQueryString());
+	}
+
+	@Test
+	void gpGra01_namedGraphWrapper() {
+		Variable s = var("s");
+		Variable p = var("p");
+		Variable o = var("o");
+
+		GraphPattern pattern = GraphPatterns.tp(s, p, o).from(Rdf.iri(Values.iri(NS + "graph")));
+
+		SelectQuery query = Queries.SELECT(s).where(pattern);
+
+		assertSparqlEquals(
+				"SELECT ?s WHERE { GRAPH <http://example.com/ns#graph> { ?s ?p ?o . } }",
+				query.getQueryString());
+	}
+}

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/util/QueryAssert.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/util/QueryAssert.java
@@ -1,0 +1,95 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ ******************************************************************************/
+package org.eclipse.rdf4j.sparqlbuilder.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.eclipse.rdf4j.query.parser.sparql.SPARQLParser;
+
+public final class QueryAssert {
+
+	private static final Pattern WHITESPACE = Pattern.compile("\\s+");
+	private static final Pattern PREFIX_DECLARATION = Pattern
+			.compile("PREFIX\\s+[^\\s]+:\\s*<[^>]+>", Pattern.CASE_INSENSITIVE);
+	private static final Pattern BASE_DECLARATION = Pattern.compile("BASE\\s+<[^>]+>", Pattern.CASE_INSENSITIVE);
+
+	private QueryAssert() {
+	}
+
+	public static void assertSparqlEquals(String expected, String actual) {
+		if (actual != null) {
+			assertThatCode(() -> new SPARQLParser().parseQuery(actual, null))
+					.as("SPARQL parser should accept actual query")
+					.doesNotThrowAnyException();
+		}
+		assertThat(normalize(actual)).isEqualTo(normalize(expected));
+	}
+
+	private static String normalize(String sparql) {
+		if (sparql == null) {
+			return null;
+		}
+		String trimmed = sparql.trim();
+		List<String> bases = extractDeclarations(BASE_DECLARATION, trimmed);
+		String withoutBases = stripDeclarations(BASE_DECLARATION, trimmed);
+
+		List<String> prefixes = extractDeclarations(PREFIX_DECLARATION, withoutBases);
+		Collections.sort(prefixes);
+		String remainder = stripDeclarations(PREFIX_DECLARATION, withoutBases);
+
+		StringBuilder canonical = new StringBuilder();
+		appendDeclarations(canonical, bases);
+		appendDeclarations(canonical, prefixes);
+		if (!remainder.isBlank()) {
+			if (canonical.length() > 0) {
+				canonical.append(' ');
+			}
+			canonical.append(remainder.trim());
+		}
+
+		return WHITESPACE.matcher(canonical.toString().trim()).replaceAll(" ");
+	}
+
+	private static List<String> extractDeclarations(Pattern pattern, String sparql) {
+		Matcher matcher = pattern.matcher(sparql);
+		List<String> declarations = new ArrayList<>();
+		while (matcher.find()) {
+			declarations.add(matcher.group().trim());
+		}
+		return declarations;
+	}
+
+	private static String stripDeclarations(Pattern pattern, String sparql) {
+		return pattern.matcher(sparql).replaceAll(" ").trim();
+	}
+
+	private static void appendDeclarations(StringBuilder builder, List<String> declarations) {
+		if (declarations.isEmpty()) {
+			return;
+		}
+		if (builder.length() > 0) {
+			builder.append(' ');
+		}
+		for (int i = 0; i < declarations.size(); i++) {
+			if (i > 0) {
+				builder.append(' ');
+			}
+			builder.append(declarations.get(i));
+		}
+	}
+}

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/util/QueryAssertTest.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/util/QueryAssertTest.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ ******************************************************************************/
+package org.eclipse.rdf4j.sparqlbuilder.util;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class QueryAssertTest {
+
+	@Test
+	void assertSparqlEquals_requiresQueryToParse() {
+		String invalidQuery = "SELECT * WHERE { ?s ?p ?o .";
+
+		assertThatThrownBy(() -> QueryAssert.assertSparqlEquals(invalidQuery, invalidQuery))
+				.isInstanceOf(AssertionError.class);
+	}
+}


### PR DESCRIPTION
## Summary
- document the remaining sparqlbuilder backlog in a dedicated TestCoverageBacklog checklist
- add SELECT WHERE clause coverage for single, chained, and prebuilt patterns with parser-normalized assertions
- introduce ConstructQueryTest to exercise baseline, explicit template, and dataset rendering

## Testing
- mvn -pl core/sparqlbuilder -Dtest=SelectQueryClausesTest,ConstructQueryTest test

------
https://chatgpt.com/codex/tasks/task_e_68d9ffc125e0832e9fa53186f7ca4f70