### PR TITLE
Add LMDB benchmarks for optional filters and sub-selects

### DIFF
--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/QueryBenchmarkTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/QueryBenchmarkTest.java
@@ -11,6 +11,8 @@
 
 package org.eclipse.rdf4j.sail.lmdb;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -48,6 +50,11 @@ public class QueryBenchmarkTest {
 	private static final String query3;
 	private static final String query4;
 	private static final String query5;
+	private static final String optionalLhsFilterQuery;
+	private static final String optionalRhsFilterQuery;
+	private static final String orderedUnionLimitQuery;
+	private static final String subSelectQuery;
+	private static final String multipleSubSelectQuery;
 
 	static List<Statement> statementList;
 
@@ -58,6 +65,16 @@ public class QueryBenchmarkTest {
 			query3 = IOUtils.toString(getResourceAsStream("benchmarkFiles/query3.qr"), StandardCharsets.UTF_8);
 			query4 = IOUtils.toString(getResourceAsStream("benchmarkFiles/query4.qr"), StandardCharsets.UTF_8);
 			query5 = IOUtils.toString(getResourceAsStream("benchmarkFiles/query5.qr"), StandardCharsets.UTF_8);
+			optionalLhsFilterQuery = IOUtils.toString(
+					getResourceAsStream("benchmarkFiles/optional-lhs-filter.qr"), StandardCharsets.UTF_8);
+			optionalRhsFilterQuery = IOUtils.toString(
+					getResourceAsStream("benchmarkFiles/optional-rhs-filter.qr"), StandardCharsets.UTF_8);
+			orderedUnionLimitQuery = IOUtils.toString(
+					getResourceAsStream("benchmarkFiles/ordered-union-limit.qr"), StandardCharsets.UTF_8);
+			subSelectQuery = IOUtils.toString(getResourceAsStream("benchmarkFiles/sub-select.qr"),
+					StandardCharsets.UTF_8);
+			multipleSubSelectQuery = IOUtils.toString(
+					getResourceAsStream("benchmarkFiles/multiple-sub-select.qr"), StandardCharsets.UTF_8);
 		} catch (IOException e) {
 			throw new RuntimeException(e);
 		}
@@ -125,6 +142,61 @@ public class QueryBenchmarkTest {
 				count = stream.count();
 			}
 			System.out.println(count);
+		}
+	}
+
+	@Test
+	public void optionalLhsFilterQueryProducesExpectedCount() {
+		try (SailRepositoryConnection connection = repository.getConnection()) {
+			long count;
+			try (var stream = connection.prepareTupleQuery(optionalLhsFilterQuery).evaluate().stream()) {
+				count = stream.count();
+			}
+			assertEquals(34904L, count);
+		}
+	}
+
+	@Test
+	public void optionalRhsFilterQueryProducesExpectedCount() {
+		try (SailRepositoryConnection connection = repository.getConnection()) {
+			long count;
+			try (var stream = connection.prepareTupleQuery(optionalRhsFilterQuery).evaluate().stream()) {
+				count = stream.count();
+			}
+			assertEquals(37917L, count);
+		}
+	}
+
+	@Test
+	public void orderedUnionLimitQueryProducesExpectedCount() {
+		try (SailRepositoryConnection connection = repository.getConnection()) {
+			long count;
+			try (var stream = connection.prepareTupleQuery(orderedUnionLimitQuery).evaluate().stream()) {
+				count = stream.count();
+			}
+			assertEquals(250L, count);
+		}
+	}
+
+	@Test
+	public void subSelectQueryProducesExpectedCount() {
+		try (SailRepositoryConnection connection = repository.getConnection()) {
+			long count;
+			try (var stream = connection.prepareTupleQuery(subSelectQuery).evaluate().stream()) {
+				count = stream.count();
+			}
+			assertEquals(16035L, count);
+		}
+	}
+
+	@Test
+	public void multipleSubSelectQueryProducesExpectedCount() {
+		try (SailRepositoryConnection connection = repository.getConnection()) {
+			long count;
+			try (var stream = connection.prepareTupleQuery(multipleSubSelectQuery).evaluate().stream()) {
+				count = stream.count();
+			}
+			assertEquals(27881L, count);
 		}
 	}
 

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/benchmark/QueryBenchmark.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/benchmark/QueryBenchmark.java
@@ -67,6 +67,9 @@ public class QueryBenchmark {
 	private static final String common_themes;
 	private static final String different_datasets_with_similar_distributions;
 	private static final String long_chain;
+	private static final String optional_lhs_filter;
+	private static final String optional_rhs_filter;
+	private static final String ordered_union_limit;
 	private static final String lots_of_optional;
 	private static final String minus;
 	private static final String nested_optionals;
@@ -74,6 +77,8 @@ public class QueryBenchmark {
 	private static final String query_distinct_predicates;
 	private static final String simple_filter_not;
 	private static final String wild_card_chain_with_common_ends;
+	private static final String sub_select;
+	private static final String multiple_sub_select;
 
 	static {
 		try {
@@ -83,6 +88,12 @@ public class QueryBenchmark {
 					getResourceAsStream("benchmarkFiles/different-datasets-with-similar-distributions.qr"),
 					StandardCharsets.UTF_8);
 			long_chain = IOUtils.toString(getResourceAsStream("benchmarkFiles/long-chain.qr"), StandardCharsets.UTF_8);
+			optional_lhs_filter = IOUtils.toString(getResourceAsStream("benchmarkFiles/optional-lhs-filter.qr"),
+					StandardCharsets.UTF_8);
+			optional_rhs_filter = IOUtils.toString(getResourceAsStream("benchmarkFiles/optional-rhs-filter.qr"),
+					StandardCharsets.UTF_8);
+			ordered_union_limit = IOUtils.toString(getResourceAsStream("benchmarkFiles/ordered-union-limit.qr"),
+					StandardCharsets.UTF_8);
 			lots_of_optional = IOUtils.toString(getResourceAsStream("benchmarkFiles/lots-of-optional.qr"),
 					StandardCharsets.UTF_8);
 			minus = IOUtils.toString(getResourceAsStream("benchmarkFiles/minus.qr"), StandardCharsets.UTF_8);
@@ -102,6 +113,9 @@ public class QueryBenchmark {
 					StandardCharsets.UTF_8);
 			wild_card_chain_with_common_ends = IOUtils.toString(
 					getResourceAsStream("benchmarkFiles/wild-card-chain-with-common-ends.qr"), StandardCharsets.UTF_8);
+			sub_select = IOUtils.toString(getResourceAsStream("benchmarkFiles/sub-select.qr"), StandardCharsets.UTF_8);
+			multiple_sub_select = IOUtils.toString(
+					getResourceAsStream("benchmarkFiles/multiple-sub-select.qr"), StandardCharsets.UTF_8);
 
 		} catch (IOException e) {
 			throw new RuntimeException(e);
@@ -241,6 +255,33 @@ public class QueryBenchmark {
 		}
 	}
 
+	@Benchmark
+	public long optional_lhs_filter() {
+		try (SailRepositoryConnection connection = repository.getConnection()) {
+			return count(connection
+					.prepareTupleQuery(optional_lhs_filter)
+					.evaluate());
+		}
+	}
+
+	@Benchmark
+	public long optional_rhs_filter() {
+		try (SailRepositoryConnection connection = repository.getConnection()) {
+			return count(connection
+					.prepareTupleQuery(optional_rhs_filter)
+					.evaluate());
+		}
+	}
+
+	@Benchmark
+	public long ordered_union_limit() {
+		try (SailRepositoryConnection connection = repository.getConnection()) {
+			return count(connection
+					.prepareTupleQuery(ordered_union_limit)
+					.evaluate());
+		}
+	}
+
 //	@Benchmark
 //	public long particularly_large_join_surface() {
 //		try (SailRepositoryConnection connection = repository.getConnection()) {
@@ -266,6 +307,24 @@ public class QueryBenchmark {
 		try (SailRepositoryConnection connection = repository.getConnection()) {
 			return count(connection
 					.prepareTupleQuery(simple_filter_not)
+					.evaluate());
+		}
+	}
+
+	@Benchmark
+	public long sub_select() {
+		try (SailRepositoryConnection connection = repository.getConnection()) {
+			return count(connection
+					.prepareTupleQuery(sub_select)
+					.evaluate());
+		}
+	}
+
+	@Benchmark
+	public long multiple_sub_select() {
+		try (SailRepositoryConnection connection = repository.getConnection()) {
+			return count(connection
+					.prepareTupleQuery(multiple_sub_select)
 					.evaluate());
 		}
 	}

--- a/core/sail/lmdb/src/test/resources/benchmarkFiles/multiple-sub-select.qr
+++ b/core/sail/lmdb/src/test/resources/benchmarkFiles/multiple-sub-select.qr
@@ -1,0 +1,41 @@
+PREFIX ex: <http://example.com/ns#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX dcat: <http://www.w3.org/ns/dcat#>
+PREFIX dc: <http://purl.org/dc/terms/>
+PREFIX skos:  <http://www.w3.org/2004/02/skos/core#>
+PREFIX foaf:  <http://xmlns.com/foaf/0.1/>
+PREFIX dct: <http://purl.org/dc/terms/>
+
+SELECT ?type1 ?type2 ?language2 ?mbox ?count ?identifier2 where {
+{
+    select * where {
+       ?a a ?type2.
+        ?b a ?type1.
+
+        ?b dcat:dataset ?a.
+
+        ?a dcat:distribution ?mbox.
+        ?a dct:language ?language.
+        FILTER (?type1 != ?type2)
+        ?a dct:identifier ?identifier.
+
+    }
+}
+
+
+    {
+        select distinct ?a (count(?dist) as ?count) ?language2 where {
+            ?a a ?type2.
+            ?a dcat:distribution ?dist.
+            ?a dct:language ?language2.
+        } group by ?a ?language2 having (?count > 2)
+    }
+
+}
+
+
+

--- a/core/sail/lmdb/src/test/resources/benchmarkFiles/optional-lhs-filter.qr
+++ b/core/sail/lmdb/src/test/resources/benchmarkFiles/optional-lhs-filter.qr
@@ -1,0 +1,24 @@
+PREFIX ex: <http://example.com/ns#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX dcat: <http://www.w3.org/ns/dcat#>
+PREFIX dc: <http://purl.org/dc/terms/>
+PREFIX skos:  <http://www.w3.org/2004/02/skos/core#>
+PREFIX foaf:  <http://xmlns.com/foaf/0.1/>
+PREFIX dct: <http://purl.org/dc/terms/>
+
+SELECT * WHERE {
+  VALUES ?distType { dcat:Distribution dcat:distribution }
+
+  ?dist a ?distType.
+  ?dist dc:license ?license .
+
+  OPTIONAL {
+        ?a dcat:distribution ?dist.
+
+        FILTER(?license = <http://wiki.data.gouv.fr/wiki/Licence_Ouverte_/_Open_Licence>)
+    }
+}

--- a/core/sail/lmdb/src/test/resources/benchmarkFiles/optional-rhs-filter.qr
+++ b/core/sail/lmdb/src/test/resources/benchmarkFiles/optional-rhs-filter.qr
@@ -1,0 +1,24 @@
+PREFIX eu-lang: <http://publications.europa.eu/resource/authority/language/>
+PREFIX ex: <http://example.com/ns#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX dcat: <http://www.w3.org/ns/dcat#>
+PREFIX dc: <http://purl.org/dc/terms/>
+PREFIX skos:  <http://www.w3.org/2004/02/skos/core#>
+PREFIX foaf:  <http://xmlns.com/foaf/0.1/>
+PREFIX dct: <http://purl.org/dc/terms/>
+
+SELECT * WHERE {
+  VALUES ?distType { dcat:Distribution dcat:distribution }
+
+  ?dist a ?distType.
+
+  OPTIONAL {
+        ?a dcat:distribution ?dist.
+        ?a dct:language $lang.
+        FILTER(?lang = eu-lang:ENG)
+    }
+}

--- a/core/sail/lmdb/src/test/resources/benchmarkFiles/ordered-union-limit.qr
+++ b/core/sail/lmdb/src/test/resources/benchmarkFiles/ordered-union-limit.qr
@@ -1,0 +1,34 @@
+PREFIX eu-filetype: <http://publications.europa.eu/resource/authority/file-type/>
+PREFIX ex: <http://example.com/ns#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX dcat: <http://www.w3.org/ns/dcat#>
+PREFIX dc: <http://purl.org/dc/terms/>
+PREFIX skos:  <http://www.w3.org/2004/02/skos/core#>
+PREFIX foaf:  <http://xmlns.com/foaf/0.1/>
+PREFIX dct: <http://purl.org/dc/terms/>
+
+SELECT ?dist ?value WHERE {
+  {
+    SELECT ?dist ?value WHERE {
+      ?dist a dcat:Distribution ;
+            dct:license ?value .
+    }
+    ORDER BY ?value ?dist
+    LIMIT 200
+  }
+  UNION
+  {
+    SELECT ?dist ?value WHERE {
+      ?dist a dcat:Distribution ;
+            dct:format ?value .
+    }
+    ORDER BY ?value ?dist
+    LIMIT 200
+  }
+}
+ORDER BY ?value ?dist
+LIMIT 250

--- a/core/sail/lmdb/src/test/resources/benchmarkFiles/sub-select.qr
+++ b/core/sail/lmdb/src/test/resources/benchmarkFiles/sub-select.qr
@@ -1,0 +1,38 @@
+PREFIX ex: <http://example.com/ns#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX dcat: <http://www.w3.org/ns/dcat#>
+PREFIX dc: <http://purl.org/dc/terms/>
+PREFIX skos:  <http://www.w3.org/2004/02/skos/core#>
+PREFIX foaf:  <http://xmlns.com/foaf/0.1/>
+PREFIX dct: <http://purl.org/dc/terms/>
+
+SELECT ?type1 ?type2 ?language2 ?mbox ?count ?identifier2 where {
+
+    ?a a ?type2.
+    ?b a ?type1.
+
+    ?b dcat:dataset ?a.
+
+    ?a dcat:distribution ?mbox.
+    ?a dct:language ?language.
+    FILTER (?type1 != ?type2)
+    ?a dct:identifier ?identifier.
+
+    BIND(?a as ?c)
+
+    {
+        select distinct ?c (count(?dist) as ?count) ?language2 where {
+            ?c a ?type2.
+            ?c dcat:distribution ?dist.
+            ?c dct:language ?language2.
+        } group by ?c ?language2 having (?count > 2)
+    }
+
+} group by ?type1 ?type2 ?language2 ?mbox ?count ?identifier2 order by ?type1 ?type2 ?language2 ?mbox ?count ?identifier2
+
+
+


### PR DESCRIPTION
## Summary
- extend `QueryBenchmarkTest` so the optional filter, ordered union limit, and sub-select benchmark queries are verified against the Belgium DCAT dataset
- add the SPARQL query files for the new benchmark scenarios
- wire the new scripts into the LMDB `QueryBenchmark` harness so they run under JMH

## Testing
- mvn -pl core/sail/lmdb -Dtest=QueryBenchmarkTest verify

------
https://chatgpt.com/codex/tasks/task_e_68dc24c30320832eb0d1aff320b6ef17