### PR TITLE
Add ModifyQuery quad pattern support

### DIFF
--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/core/QuadPatternCollection.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/core/QuadPatternCollection.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ ******************************************************************************/
+
+package org.eclipse.rdf4j.sparqlbuilder.core;
+
+import java.util.Collections;
+import java.util.function.Function;
+
+import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPattern;
+import org.eclipse.rdf4j.sparqlbuilder.util.SparqlBuilderUtils;
+
+/**
+ * Represents a collection of quad patterns (triples or named graph blocks) used in SPARQL Update operations.
+ */
+public class QuadPatternCollection extends StandardQueryElementCollection<GraphPattern> {
+	private static final Function<String, String> WRAPPER = SparqlBuilderUtils::getBracedString;
+
+	public QuadPatternCollection(GraphPattern... patterns) {
+		super("\n");
+		setWrapperMethod(WRAPPER);
+		and(patterns);
+	}
+
+	/**
+	 * Add graph patterns to this collection.
+	 *
+	 * @param patterns the patterns to add
+	 * @return this collection
+	 */
+	public QuadPatternCollection and(GraphPattern... patterns) {
+		Collections.addAll(elements, patterns);
+
+		return this;
+	}
+}

--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/core/query/ModifyQuery.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/core/query/ModifyQuery.java
@@ -16,9 +16,9 @@ import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
 import java.util.Optional;
 
 import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.sparqlbuilder.core.QuadPatternCollection;
 import org.eclipse.rdf4j.sparqlbuilder.core.QueryPattern;
 import org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder;
-import org.eclipse.rdf4j.sparqlbuilder.core.TriplesTemplate;
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphName;
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPattern;
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.TriplePattern;
@@ -41,8 +41,8 @@ public class ModifyQuery extends UpdateQuery<ModifyQuery> {
 	private Optional<Iri> using = Optional.empty();
 	private boolean usingNamed = false;
 
-	private Optional<TriplesTemplate> deleteTriples = Optional.empty();
-	private Optional<TriplesTemplate> insertTriples = Optional.empty();
+	private Optional<QuadPatternCollection> deletePatterns = Optional.empty();
+	private Optional<QuadPatternCollection> insertPatterns = Optional.empty();
 	private Optional<GraphName> deleteGraph = Optional.empty();
 	private Optional<GraphName> insertGraph = Optional.empty();
 
@@ -81,8 +81,21 @@ public class ModifyQuery extends UpdateQuery<ModifyQuery> {
 	 * @see <a href="https://www.w3.org/TR/sparql11-update/#deleteWhere"> SPARQL DELETE WHERE shortcut</a>
 	 */
 	public ModifyQuery delete(TriplePattern... triples) {
-		deleteTriples = SparqlBuilderUtils.getOrCreateAndModifyOptional(deleteTriples, SparqlBuilder::triplesTemplate,
-				tt -> tt.and(triples));
+		deletePatterns = SparqlBuilderUtils.getOrCreateAndModifyOptional(deletePatterns, QuadPatternCollection::new,
+				qp -> qp.and(triples));
+
+		return this;
+	}
+
+	/**
+	 * Specify quad patterns to delete (allows named GRAPH blocks)
+	 *
+	 * @param patterns the graph patterns to delete
+	 * @return this modify query instance
+	 */
+	public ModifyQuery delete(GraphPattern... patterns) {
+		deletePatterns = SparqlBuilderUtils.getOrCreateAndModifyOptional(deletePatterns, QuadPatternCollection::new,
+				qp -> qp.and(patterns));
 
 		return this;
 	}
@@ -106,8 +119,21 @@ public class ModifyQuery extends UpdateQuery<ModifyQuery> {
 	 * @return this modify query instance
 	 */
 	public ModifyQuery insert(TriplePattern... triples) {
-		insertTriples = SparqlBuilderUtils.getOrCreateAndModifyOptional(insertTriples, SparqlBuilder::triplesTemplate,
-				tt -> tt.and(triples));
+		insertPatterns = SparqlBuilderUtils.getOrCreateAndModifyOptional(insertPatterns, QuadPatternCollection::new,
+				qp -> qp.and(triples));
+
+		return this;
+	}
+
+	/**
+	 * Specify quad patterns to insert (allows named GRAPH blocks)
+	 *
+	 * @param patterns the graph patterns to insert
+	 * @return this modify query instance
+	 */
+	public ModifyQuery insert(GraphPattern... patterns) {
+		insertPatterns = SparqlBuilderUtils.getOrCreateAndModifyOptional(insertPatterns, QuadPatternCollection::new,
+				qp -> qp.and(patterns));
 
 		return this;
 	}
@@ -186,20 +212,20 @@ public class ModifyQuery extends UpdateQuery<ModifyQuery> {
 
 		with.ifPresent(withIri -> modifyQuery.append(WITH).append(" ").append(withIri.getQueryString()).append("\n"));
 
-		deleteTriples.ifPresent(delTriples -> {
+		deletePatterns.ifPresent(delPatterns -> {
 			modifyQuery.append(DELETE).append(" ");
 
 			// DELETE WHERE shortcut
 			// https://www.w3.org/TR/sparql11-update/#deleteWhere
-			if (!delTriples.isEmpty()) {
-				appendNamedTriplesTemplates(modifyQuery, deleteGraph, delTriples);
+			if (!delPatterns.isEmpty()) {
+				appendNamedGraphPatterns(modifyQuery, deleteGraph, delPatterns);
 			}
 			modifyQuery.append("\n");
 		});
 
-		insertTriples.ifPresent(insTriples -> {
+		insertPatterns.ifPresent(insPatterns -> {
 			modifyQuery.append(INSERT).append(" ");
-			appendNamedTriplesTemplates(modifyQuery, insertGraph, insTriples);
+			appendNamedGraphPatterns(modifyQuery, insertGraph, insPatterns);
 			modifyQuery.append("\n");
 		});
 

--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/core/query/UpdateQuery.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/core/query/UpdateQuery.java
@@ -142,4 +142,12 @@ abstract class UpdateQuery<T extends UpdateQuery<T>> implements QueryElement {
 						.getBracedString("GRAPH " + graph.getQueryString() + " " + triples.getQueryString()))
 				.orElseGet(triples::getQueryString));
 	}
+
+	protected void appendNamedGraphPatterns(StringBuilder queryString, Optional<GraphName> graphName,
+			QueryElement patterns) {
+		queryString.append(graphName
+				.map(graph -> SparqlBuilderUtils
+						.getBracedString("GRAPH " + graph.getQueryString() + " " + patterns.getQueryString()))
+				.orElseGet(patterns::getQueryString));
+	}
 }

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/core/query/ModifyQueryQuadSupportTest.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/core/query/ModifyQueryQuadSupportTest.java
@@ -1,0 +1,88 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ ******************************************************************************/
+
+package org.eclipse.rdf4j.sparqlbuilder.core.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns.tp;
+import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
+import org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder;
+import org.eclipse.rdf4j.sparqlbuilder.core.query.Queries;
+import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPattern;
+import org.eclipse.rdf4j.sparqlbuilder.graphpattern.TriplePattern;
+import org.eclipse.rdf4j.sparqlbuilder.rdf.Iri;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression coverage for https://github.com/eclipse-rdf4j/rdf4j/issues/2615.
+ */
+class ModifyQueryQuadSupportTest {
+
+	@Test
+	@DisplayName("ModifyQuery should expose a delete overload accepting graph patterns")
+	void modifyDeleteShouldSupportGraphPatterns() {
+		boolean hasDeleteOverload = hasMethodWithParameter(ModifyQuery.class, "delete", GraphPattern[].class);
+
+		assertThat(hasDeleteOverload).as("ModifyQuery.delete(GraphPattern...) should exist to support quads").isTrue();
+	}
+
+	@Test
+	@DisplayName("ModifyQuery should expose an insert overload accepting graph patterns")
+	void modifyInsertShouldSupportGraphPatterns() {
+		boolean hasInsertOverload = hasMethodWithParameter(ModifyQuery.class, "insert", GraphPattern[].class);
+
+		assertThat(hasInsertOverload).as("ModifyQuery.insert(GraphPattern...) should exist to support quads").isTrue();
+	}
+
+	@Test
+	@DisplayName("ModifyQuery.delete accepts named graph patterns and renders quads")
+	void modifyDeleteRendersNamedGraphPatterns() {
+		Iri graph = iri("http://example.com/graph");
+		TriplePattern triple = tp(SparqlBuilder.var("s"), SparqlBuilder.var("p"), SparqlBuilder.var("o"));
+		GraphPattern quadPattern = triple.from(graph);
+
+		ModifyQuery modify = Queries.MODIFY().delete(quadPattern).where(triple);
+
+		String queryString = modify.getQueryString();
+
+		assertThat(queryString).contains("DELETE {");
+		assertThat(queryString).contains("GRAPH <http://example.com/graph> {");
+		assertThat(queryString).contains("?s ?p ?o .");
+	}
+
+	@Test
+	@DisplayName("ModifyQuery.insert accepts named graph patterns and renders quads")
+	void modifyInsertRendersNamedGraphPatterns() {
+		Iri graph = iri("http://example.com/graph");
+		TriplePattern triple = tp(SparqlBuilder.var("s"), SparqlBuilder.var("p"), SparqlBuilder.var("o"));
+		GraphPattern quadPattern = triple.from(graph);
+
+		ModifyQuery modify = Queries.MODIFY().insert(quadPattern).where(triple);
+
+		String queryString = modify.getQueryString();
+
+		assertThat(queryString).contains("INSERT {");
+		assertThat(queryString).contains("GRAPH <http://example.com/graph> {");
+		assertThat(queryString).contains("?s ?p ?o .");
+	}
+
+	private boolean hasMethodWithParameter(Class<?> type, String methodName, Class<?> parameterType) {
+		return Arrays.stream(type.getMethods())
+				.filter(method -> method.getName().equals(methodName))
+				.map(Method::getParameterTypes)
+				.anyMatch(params -> params.length == 1 && params[0].equals(parameterType));
+	}
+}


### PR DESCRIPTION
## Summary
- add a quad pattern collection so ModifyQuery can track both triple and named graph patterns
- add overloads for ModifyQuery.delete/insert that accept GraphPattern instances and reuse the new collection
- cover the new quad support with ModifyQueryQuadSupportTest derived from issue #2615

## Testing
- mvn -pl core/sparqlbuilder -Dtest=ModifyQueryQuadSupportTest verify


------
https://chatgpt.com/codex/tasks/task_e_68db3f72d388832eb4d50f2998bd37e3