### PR TITLE
Add regression test for optional named graph

### DIFF
--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/graphpattern/GroupGraphPattern.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/graphpattern/GroupGraphPattern.java
@@ -94,14 +94,7 @@ class GroupGraphPattern extends QueryElementCollection<GraphPattern> implements 
 
 	@Override
 	public String getQueryString() {
-		StringBuilder pattern = new StringBuilder();
 		StringBuilder innerPattern = new StringBuilder();
-
-		if (isOptional) {
-			pattern.append(OPTIONAL).append(" ");
-		}
-
-		SparqlBuilderUtils.appendQueryElementIfPresent(from, pattern, GRAPH, " ");
 
 		innerPattern.append(super.getQueryString());
 
@@ -109,10 +102,29 @@ class GroupGraphPattern extends QueryElementCollection<GraphPattern> implements 
 				Optional.of(filter),
 				innerPattern, "\n", null));
 
+		String innerPatternString = innerPattern.toString();
+
+		if (isOptional && from.isPresent()) {
+			StringBuilder graphClause = new StringBuilder();
+
+			SparqlBuilderUtils.appendQueryElementIfPresent(from, graphClause, GRAPH, " ");
+			graphClause.append(SparqlBuilderUtils.getBracedString(innerPatternString));
+
+			return OPTIONAL + " " + SparqlBuilderUtils.getBracedString(graphClause.toString());
+		}
+
+		StringBuilder pattern = new StringBuilder();
+
+		if (isOptional) {
+			pattern.append(OPTIONAL).append(" ");
+		}
+
+		SparqlBuilderUtils.appendQueryElementIfPresent(from, pattern, GRAPH, " ");
+
 		if (bracketInner()) {
-			pattern.append(SparqlBuilderUtils.getBracedString(innerPattern.toString()));
+			pattern.append(SparqlBuilderUtils.getBracedString(innerPatternString));
 		} else {
-			pattern.append(innerPattern.toString());
+			pattern.append(innerPatternString);
 		}
 
 		return pattern.toString();

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/core/SparqlBuilderTest.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/core/SparqlBuilderTest.java
@@ -152,4 +152,23 @@ public class SparqlBuilderTest {
 				.contains("FILTER ( ?price > 30 )");
 	}
 
+	@Test
+	public void optionalGraphPatternShouldBeBracketedWhenUsingFrom() {
+		Prefix ns = SparqlBuilder.prefix("ns", iri(EXAMPLE_ORG_NS));
+		Variable x = SparqlBuilder.var("x"), o = SparqlBuilder.var("o");
+
+		GraphPatternNotTriples optionalGraphPattern = GraphPatterns.and(x.has(ns.iri("p"), o))
+				.from(ns.iri("graph"))
+				.optional();
+
+		query.prefix(ns)
+				.select(x)
+				.where(optionalGraphPattern);
+
+		String normalizedQuery = query.getQueryString().replaceAll("\\s+", " ").trim();
+
+		assertThat(normalizedQuery)
+				.contains("OPTIONAL { GRAPH ns:graph { ?x ns:p ?o . } }");
+	}
+
 }


### PR DESCRIPTION
## Summary
- add a regression test covering OPTIONAL with a named graph in SparqlBuilder
- fix GroupGraphPattern rendering so OPTIONAL and GRAPH clauses are correctly wrapped

## Testing
- mvn -pl core/sparqlbuilder -Dtest=org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilderTest#optionalGraphPatternShouldBeBracketedWhenUsingFrom test

------
https://chatgpt.com/codex/tasks/task_e_68db3f344448832e938988e88e69ac8f