### PR TITLE
Add SERVICE graph pattern helpers to SPARQLBuilder

### DIFF
--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/graphpattern/GraphPattern.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/graphpattern/GraphPattern.java
@@ -194,6 +194,14 @@ public interface GraphPattern extends QueryElement {
 		return and(GraphPatterns.minus(patterns));
 	}
 
+	default GraphPattern service(GraphName service, GraphPattern... patterns) {
+		return and(GraphPatterns.service(service, patterns));
+	}
+
+	default GraphPattern service(boolean silent, GraphName service, GraphPattern... patterns) {
+		return and(GraphPatterns.service(silent, service, patterns));
+	}
+
 	/**
 	 * Convert this graph pattern into a named group graph pattern: <br>
 	 *

--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/graphpattern/GraphPatternNotTriples.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/graphpattern/GraphPatternNotTriples.java
@@ -100,6 +100,20 @@ public class GraphPatternNotTriples implements GraphPattern {
 		return this;
 	}
 
+	@Override
+	public GraphPatternNotTriples service(GraphName service, GraphPattern... patterns) {
+		gp = gp.service(service, patterns);
+
+		return this;
+	}
+
+	@Override
+	public GraphPatternNotTriples service(boolean silent, GraphName service, GraphPattern... patterns) {
+		gp = gp.service(silent, service, patterns);
+
+		return this;
+	}
+
 	/**
 	 * Like {@link GraphPattern#from(GraphName)}, but mutates and returns this instance
 	 *

--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/graphpattern/GraphPatterns.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/graphpattern/GraphPatterns.java
@@ -216,6 +216,17 @@ public class GraphPatterns {
 		return new GraphPatternNotTriples(minus);
 	}
 
+	public static GraphPatternNotTriples service(GraphName service, GraphPattern... patterns) {
+		return service(false, service, patterns);
+	}
+
+	public static GraphPatternNotTriples service(boolean silent, GraphName service, GraphPattern... patterns) {
+		ServiceGraphPattern servicePattern = new ServiceGraphPattern(service, silent);
+		servicePattern.and(patterns);
+
+		return new GraphPatternNotTriples(servicePattern);
+	}
+
 	public static GraphPatternNotTriples filterExists(boolean exists, GraphPattern... patterns) {
 		FilterExistsGraphPattern filterExists = new FilterExistsGraphPattern().exists(exists);
 		filterExists.and(patterns);

--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/graphpattern/GroupGraphPattern.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/graphpattern/GroupGraphPattern.java
@@ -57,7 +57,7 @@ class GroupGraphPattern extends QueryElementCollection<GraphPattern> implements 
 
 	@Override
 	public GroupGraphPattern and(GraphPattern... patterns) {
-		if (isEmpty() && patterns.length == 1 && (isGGP(patterns[0]))) {
+		if (isEmpty() && patterns.length == 1 && isGGP(patterns[0]) && !isService(patterns[0])) {
 			copy(GraphPatterns.extractOrConvertToGGP(patterns[0]));
 		} else {
 			addElements(patterns);
@@ -124,6 +124,18 @@ class GroupGraphPattern extends QueryElementCollection<GraphPattern> implements 
 		}
 		if (pattern instanceof GraphPatternNotTriples) {
 			return ((GraphPatternNotTriples) pattern).gp instanceof GroupGraphPattern;
+		}
+
+		return false;
+	}
+
+	private static boolean isService(GraphPattern pattern) {
+		if (pattern instanceof ServiceGraphPattern) {
+			return true;
+		}
+		if (pattern instanceof GraphPatternNotTriples) {
+			GraphPatternNotTriples gp = (GraphPatternNotTriples) pattern;
+			return gp.gp instanceof ServiceGraphPattern;
 		}
 
 		return false;

--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/graphpattern/ServiceGraphPattern.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/graphpattern/ServiceGraphPattern.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ ******************************************************************************/
+package org.eclipse.rdf4j.sparqlbuilder.graphpattern;
+
+class ServiceGraphPattern extends GroupGraphPattern {
+
+	private static final String SERVICE = "SERVICE ";
+	private static final String SILENT = "SILENT ";
+
+	private final GraphName serviceName;
+	private final boolean silent;
+
+	ServiceGraphPattern(GraphName serviceName, boolean silent) {
+		this.serviceName = serviceName;
+		this.silent = silent;
+	}
+
+	@Override
+	public String getQueryString() {
+		StringBuilder builder = new StringBuilder(SERVICE);
+		if (silent) {
+			builder.append(SILENT);
+		}
+		builder.append(serviceName.getQueryString()).append(" ");
+		builder.append(super.getQueryString());
+		return builder.toString();
+	}
+}

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/graphpattern/GraphPatternsServiceTest.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/graphpattern/GraphPatternsServiceTest.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ ******************************************************************************/
+package org.eclipse.rdf4j.sparqlbuilder.graphpattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
+
+import java.lang.reflect.Method;
+
+import org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder;
+import org.eclipse.rdf4j.sparqlbuilder.core.Variable;
+import org.eclipse.rdf4j.sparqlbuilder.core.query.Queries;
+import org.eclipse.rdf4j.sparqlbuilder.core.query.SelectQuery;
+import org.junit.jupiter.api.Test;
+
+class GraphPatternsServiceTest {
+
+	@Test
+	void serviceClauseRendered() {
+		SelectQuery query = Queries.SELECT();
+		Variable subject = SparqlBuilder.var("s");
+		Variable object = SparqlBuilder.var("o");
+		Variable endpoint = SparqlBuilder.var("serviceEndpoint");
+
+		query.select(subject)
+				.where(GraphPatterns.service(endpoint, subject.has(iri("http://example.org/p"), object)));
+
+		assertThat(query.getQueryString())
+				.contains("SERVICE ?serviceEndpoint { ?s <http://example.org/p> ?o . }");
+	}
+
+	@Test
+	void serviceSilentClauseRendered() {
+		SelectQuery query = Queries.SELECT();
+		Variable subject = SparqlBuilder.var("s");
+		Variable object = SparqlBuilder.var("o");
+
+		query.select(subject)
+				.where(GraphPatterns.service(true, iri("http://example.org/service"),
+						subject.has(iri("http://example.org/p"), object)));
+
+		assertThat(query.getQueryString())
+				.contains("SERVICE SILENT <http://example.org/service> { ?s <http://example.org/p> ?o . }");
+	}
+
+	@Test
+	void graphPatternInterfaceExposesServiceShortcuts() throws Exception {
+		Method nonSilent = GraphPattern.class.getMethod("service", GraphName.class, GraphPattern[].class);
+		Method silent = GraphPattern.class.getMethod("service", boolean.class, GraphName.class,
+				GraphPattern[].class);
+
+		assertThat(nonSilent.getReturnType()).isEqualTo(GraphPattern.class);
+		assertThat(silent.getReturnType()).isEqualTo(GraphPattern.class);
+	}
+}


### PR DESCRIPTION
## Summary
- add SERVICE and SERVICE SILENT helpers to GraphPattern and GraphPatterns
- introduce ServiceGraphPattern so SERVICE clauses retain metadata when grouped
- cover rendering and API exposure with GraphPatternsServiceTest

## Testing
- mvn -pl core/sparqlbuilder -Dtest=GraphPatternsServiceTest test

------
https://chatgpt.com/codex/tasks/task_e_68db3e899eb0832eb96f5e935ddb9801