### PR TITLE
Add SparqlBuilder VALUES factory and coverage

### DIFF
--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/graphpattern/GraphPatterns.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/graphpattern/GraphPatterns.java
@@ -17,6 +17,7 @@ import org.eclipse.rdf4j.model.BNode;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.sparqlbuilder.constraint.Values;
 import org.eclipse.rdf4j.sparqlbuilder.constraint.propertypath.builder.EmptyPropertyPathBuilder;
 import org.eclipse.rdf4j.sparqlbuilder.core.Projectable;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf;
@@ -158,6 +159,12 @@ public class GraphPatterns {
 		GroupGraphPattern and = new GroupGraphPattern();
 
 		return new GraphPatternNotTriples(and.and(patterns));
+	}
+
+	public static Values values(Consumer<Values.VariablesBuilder> valuesConfigurer) {
+		Values.Builder builder = (Values.Builder) Values.builder();
+		valuesConfigurer.accept(builder);
+		return builder.build();
 	}
 
 	/**

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section10Test.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section10Test.java
@@ -28,6 +28,7 @@ import org.eclipse.rdf4j.sparqlbuilder.core.Variable;
 import org.eclipse.rdf4j.sparqlbuilder.core.query.Queries;
 import org.eclipse.rdf4j.sparqlbuilder.examples.BaseExamples;
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPattern;
+import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns;
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.TriplePattern;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Iri;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf;
@@ -148,6 +149,45 @@ public class Section10Test extends BaseExamples {
 						+ "}"
 		));
 
+	}
+
+	@Test
+	public void example_10_values_inline_via_graphpattern_method() {
+		String str = Queries.SELECT(book)
+				.prefix(prefixBook, ns)
+				.where(book.has(ns.iri("type"), ns.iri("Hardcover"))
+						.values(v -> v.variables(book).values(prefixBook.iri("book1"), prefixBook.iri("book2"))))
+				.getQueryString();
+		assertThat(str).is(stringEqualsIgnoreCaseAndWhitespace(
+				"PREFIX :     <http://example.org/book/>\n"
+						+ "PREFIX ns:   <http://example.org/ns#>\n"
+						+ "\n"
+						+ "SELECT ?book\n"
+						+ "WHERE {\n"
+						+ "  ?book ns:type ns:Hardcover .\n"
+						+ "  VALUES ?book { :book1 :book2 }\n"
+						+ "}"
+		));
+	}
+
+	@Test
+	public void example_10_values_using_graphpatterns_factory() {
+		String str = Queries.SELECT(book)
+				.prefix(prefixBook, ns)
+				.where(book.has(ns.iri("type"), ns.iri("Hardcover")),
+						GraphPatterns.values(
+								v -> v.variables(book).values(prefixBook.iri("book1"), prefixBook.iri("book2"))))
+				.getQueryString();
+		assertThat(str).is(stringEqualsIgnoreCaseAndWhitespace(
+				"PREFIX :     <http://example.org/book/>\n"
+						+ "PREFIX ns:   <http://example.org/ns#>\n"
+						+ "\n"
+						+ "SELECT ?book\n"
+						+ "WHERE {\n"
+						+ "  ?book ns:type ns:Hardcover .\n"
+						+ "  VALUES ?book { :book1 :book2 }\n"
+						+ "}"
+		));
 	}
 
 }

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section12Test.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/examples/sparql11spec/Section12Test.java
@@ -21,6 +21,7 @@ import org.eclipse.rdf4j.sparqlbuilder.core.Variable;
 import org.eclipse.rdf4j.sparqlbuilder.examples.BaseExamples;
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns;
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.SubSelect;
+import org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf;
 import org.junit.jupiter.api.Test;
 
 public class Section12Test extends BaseExamples {
@@ -28,8 +29,8 @@ public class Section12Test extends BaseExamples {
 	public void example_12() {
 		Prefix base = SparqlBuilder.prefix(iri("http://people.example/"));
 
-		// using this method of variable creation, as ?y and ?minName will be
-		// used in both the outer and inner queries
+// using this method of variable creation, as ?y and ?minName will be
+// used in both the outer and inner queries
 		Variable y = SparqlBuilder.var("y"), minName = SparqlBuilder.var("minName"), name = SparqlBuilder.var("name");
 
 		SubSelect sub = GraphPatterns.select();
@@ -49,6 +50,73 @@ public class Section12Test extends BaseExamples {
 						+ "      ?y :name ?name .\n"
 						+ "    } GROUP BY ?y\n"
 						+ "  }\n"
+						+ "}"));
+	}
+
+	@Test
+	public void example_12_values_clause() {
+		Prefix base = SparqlBuilder.prefix(iri("http://people.example/"));
+		Variable y = SparqlBuilder.var("y");
+		Variable name = SparqlBuilder.var("name");
+
+		SubSelect sub = GraphPatterns.select();
+		sub.select(y)
+				.where(y.has(base.iri("name"), name))
+				.values(v -> v.variables(y).value(base.iri("alice")));
+
+		query.prefix(base)
+				.select(y)
+				.where(base.iri("alice").has(base.iri("knows"), y), sub);
+
+		assertThat(query.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
+				"PREFIX : <http://people.example/>\n"
+						+ "SELECT ?y\n"
+						+ "WHERE {\n"
+						+ "  :alice :knows ?y .\n"
+						+ "  {\n"
+						+ "    SELECT ?y\n"
+						+ "    WHERE {\n"
+						+ "      ?y :name ?name .\n"
+						+ "    }\n"
+						+ "    VALUES ?y { :alice }\n"
+						+ "  }\n"
+						+ "}"));
+	}
+
+	@Test
+	public void example_12_inline_values_in_where_clause() {
+		Prefix base = SparqlBuilder.prefix(iri("http://people.example/"));
+		Variable y = SparqlBuilder.var("y");
+		Variable name = SparqlBuilder.var("name");
+
+		SubSelect sub = GraphPatterns.select();
+		sub.select(y)
+				.where(y.has(base.iri("name"), name)
+						.values(v -> v.variables(name).value(Rdf.literalOf("Alice"))));
+
+		assertThat(sub.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
+				"{\n"
+						+ "  SELECT ?y\n"
+						+ "  WHERE {\n"
+						+ "    ?y :name ?name .\n"
+						+ "    VALUES ?name { \"Alice\" }\n"
+						+ "  }\n"
+						+ "}"));
+	}
+
+	@Test
+	public void example_12_values_clause_without_where_patterns() {
+		Prefix base = SparqlBuilder.prefix(iri("http://people.example/"));
+		Variable y = SparqlBuilder.var("y");
+
+		SubSelect sub = GraphPatterns.select();
+		sub.select(y).values(v -> v.variables(y).value(base.iri("alice")));
+
+		assertThat(sub.getQueryString()).is(stringEqualsIgnoreCaseAndWhitespace(
+				"{\n"
+						+ "  SELECT ?y\n"
+						+ "  WHERE { }\n"
+						+ "  VALUES ?y { :alice }\n"
 						+ "}"));
 	}
 }


### PR DESCRIPTION
## Summary
- add a `GraphPatterns.values` factory so inline VALUES clauses can be created without manually building the constraint
- expand SPARQL 1.1 specification examples to cover inline VALUES chaining and standalone VALUES usage in subselects

## Testing
- mvn -o -pl core/sparqlbuilder -Dtest=org.eclipse.rdf4j.sparqlbuilder.examples.sparql11spec.Section10Test,org.eclipse.rdf4j.sparqlbuilder.examples.sparql11spec.Section12Test verify

------
https://chatgpt.com/codex/tasks/task_e_68db3e7e28f8832eab897e3feadcf2a8