### PR TITLE
Support RDF-star triples in GraphPatterns

### DIFF
--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/graphpattern/GraphPatterns.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/graphpattern/GraphPatterns.java
@@ -13,7 +13,6 @@ package org.eclipse.rdf4j.sparqlbuilder.graphpattern;
 
 import java.util.function.Consumer;
 
-import org.eclipse.rdf4j.model.BNode;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Value;
@@ -80,10 +79,7 @@ public class GraphPatterns {
 	 * @see <a href="http://www.w3.org/TR/2013/REC-sparql11-query-20130321/#QSynTriples"> Triple pattern syntax</a>
 	 */
 	public static TriplePattern tp(Resource subject, RdfPredicate predicate, RdfObject... objects) {
-		if (subject instanceof IRI) {
-			return tp(Rdf.iri((IRI) subject), predicate, objects);
-		}
-		return tp(Rdf.bNode(((BNode) subject).getID()), predicate, objects);
+		return tp(Rdf.subject(subject), predicate, objects);
 	}
 
 	public static TriplePattern tp(Resource subject, RdfPredicate predicate, Value... objects) {

--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/rdf/Rdf.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/rdf/Rdf.java
@@ -12,11 +12,14 @@
 package org.eclipse.rdf4j.sparqlbuilder.rdf;
 
 import java.util.Arrays;
+import java.util.Objects;
 
 import org.eclipse.rdf4j.common.net.ParsedIRI;
 import org.eclipse.rdf4j.model.BNode;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Triple;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.RdfBlankNode.AnonymousBlankNode;
@@ -116,6 +119,52 @@ public class Rdf {
 	 */
 	public static AnonymousBlankNode bNode() {
 		return new AnonymousBlankNode();
+	}
+
+	/**
+	 * creates an embedded RDF-star triple
+	 *
+	 * @param subject   the triple subject
+	 * @param predicate the triple predicate
+	 * @param object    the triple object
+	 * @return a new {@link RdfTriple}
+	 */
+	public static RdfTriple triple(RdfSubject subject, RdfPredicate predicate, RdfObject object) {
+		return new RdfTriple(Objects.requireNonNull(subject, "subject"),
+				Objects.requireNonNull(predicate, "predicate"),
+				Objects.requireNonNull(object, "object"));
+	}
+
+	/**
+	 * creates an embedded RDF-star triple from an RDF4J {@link Triple}
+	 *
+	 * @param triple the RDF4J triple
+	 * @return a new {@link RdfTriple}
+	 */
+	public static RdfTriple triple(Triple triple) {
+		return triple(subject(triple.getSubject()), iri(triple.getPredicate()), object(triple.getObject()));
+	}
+
+	/**
+	 * creates a subject representation from an RDF4J {@link Resource}
+	 *
+	 * @param resource the RDF resource
+	 * @return a {@link RdfSubject}
+	 */
+	public static RdfSubject subject(Resource resource) {
+		if (resource instanceof IRI) {
+			return iri((IRI) resource);
+		}
+
+		if (resource instanceof BNode) {
+			return bNode(((BNode) resource).getID());
+		}
+
+		if (resource instanceof Triple) {
+			return triple((Triple) resource);
+		}
+
+		throw new IllegalArgumentException("Unsupported resource type: " + resource.getClass());
 	}
 
 	/**
@@ -261,6 +310,10 @@ public class Rdf {
 
 		if (value instanceof BNode) {
 			return bNode(((BNode) value).getID());
+		}
+
+		if (value instanceof Triple) {
+			return triple((Triple) value);
 		}
 
 		Literal lit = (Literal) value;

--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/rdf/RdfTriple.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/rdf/RdfTriple.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+
+package org.eclipse.rdf4j.sparqlbuilder.rdf;
+
+import java.util.Objects;
+
+/**
+ * Represents an embedded RDF-star triple.
+ */
+class RdfTriple implements RdfResource {
+
+	private final RdfSubject subject;
+	private final RdfPredicate predicate;
+	private final RdfObject object;
+
+	RdfTriple(RdfSubject subject, RdfPredicate predicate, RdfObject object) {
+		this.subject = Objects.requireNonNull(subject, "subject");
+		this.predicate = Objects.requireNonNull(predicate, "predicate");
+		this.object = Objects.requireNonNull(object, "object");
+	}
+
+	@Override
+	public String getQueryString() {
+		return "<<" + subject.getQueryString() + " " + predicate.getQueryString() + " " + object.getQueryString()
+				+ ">>";
+	}
+}

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/graphpattern/GraphPatternsRdfStarTest.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/graphpattern/GraphPatternsRdfStarTest.java
@@ -1,0 +1,66 @@
+package org.eclipse.rdf4j.sparqlbuilder.graphpattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Triple;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf;
+import org.eclipse.rdf4j.sparqlbuilder.rdf.RdfObject;
+import org.eclipse.rdf4j.sparqlbuilder.rdf.RdfPredicate;
+import org.junit.jupiter.api.Test;
+
+class GraphPatternsRdfStarTest {
+
+	private static final ValueFactory VF = SimpleValueFactory.getInstance();
+	private static final String NS = "http://example.org/";
+
+	@Test
+	void tripleResourceSubjectIsSupported() {
+		Triple subject = VF.createTriple(iri("subject"), iri("predicate"), iri("object"));
+		RdfPredicate predicate = Rdf.iri(iri("has"));
+		RdfObject object = Rdf.iri(iri("value"));
+
+		TriplePattern pattern = GraphPatterns.tp(subject, predicate, object);
+
+		String expected = toEmbeddedTripleString(subject) + " " + predicate.getQueryString() + " "
+				+ object.getQueryString() + " .";
+
+		assertThat(pattern.getQueryString()).isEqualTo(expected);
+	}
+
+	@Test
+	void tripleValueObjectIsSupported() {
+		IRI subject = iri("resource");
+		IRI predicate = iri("predicate");
+		Triple object = VF.createTriple(iri("embeddedSubject"), iri("embeddedPredicate"), iri("embeddedObject"));
+
+		TriplePattern pattern = GraphPatterns.tp(subject, predicate, object);
+
+		String expected = Rdf.iri(subject).getQueryString() + " " + Rdf.iri(predicate).getQueryString() + " "
+				+ toEmbeddedTripleString(object) + " .";
+
+		assertThat(pattern.getQueryString()).isEqualTo(expected);
+	}
+
+	private static IRI iri(String localName) {
+		return VF.createIRI(NS, localName);
+	}
+
+	private static String toEmbeddedTripleString(Triple triple) {
+		return "<<" + toQueryString(triple.getSubject()) + " " + toQueryString(triple.getPredicate()) + " "
+				+ toQueryString(triple.getObject()) + ">>";
+	}
+
+	private static String toQueryString(Value value) {
+		if (value instanceof Triple) {
+			return toEmbeddedTripleString((Triple) value);
+		}
+		if (value instanceof IRI) {
+			return Rdf.iri((IRI) value).getQueryString();
+		}
+		throw new IllegalArgumentException("Unexpected value type: " + value.getClass());
+	}
+}


### PR DESCRIPTION
## Summary
- allow GraphPatterns.tp to accept RDF-star triple resources by delegating to new conversion helpers in Rdf
- add Rdf.triple/subject support and the internal RdfTriple representation for embedded triple rendering
- cover RDF-star subjects and objects with GraphPatternsRdfStarTest

## Testing
- mvn -pl core/sparqlbuilder -Dtest=GraphPatternsRdfStarTest test

------
https://chatgpt.com/codex/tasks/task_e_68db3e676ea0832eb0127d693a627c4e