### PR TITLE
Add regression tests for SPARQL MINUS edge cases

### DIFF
--- a/testsuites/sparql/src/test/java/com/example/rdf4jminus/SparqlMinusScopingTests.java
+++ b/testsuites/sparql/src/test/java/com/example/rdf4jminus/SparqlMinusScopingTests.java
@@ -1,0 +1,305 @@
+package com.example.rdf4jminus;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.StringReader;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.QueryResults;
+import org.eclipse.rdf4j.query.TupleQuery;
+import org.eclipse.rdf4j.query.TupleQueryResult;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.sail.memory.MemoryStore;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * SPARQL MINUS scoping & nondeterminism tests (RDF4J 5.1.0).
+ *
+ * Dataset:
+ *
+ * @prefix : <http://ex/> . :a :p 1 . :a :q 10 . :a :r 100 . :b :p 2 . :b :q 20 . :b :r 200 . :c :p 3 . :c :r 300 . :d
+ *         :q 40 . :d :r 400 . :e :p 5 . :e :q 50 .
+ *
+ *         Notes about expectations vs. spec: - Disjoint-variable MINUS has no effect (spec). This applies to T1, T4,
+ *         T5, T8, T9, and the 2nd MINUS in T11. - When a right-hand BIND overwrites a shared var (T2, T7),
+ *         compatibility is checked on the final right-hand bindings, so the MINUS should not remove left rows if the
+ *         overwritten value disagrees. - T6 uses RAND(); we check statistical behavior across multiple runs.
+ */
+public class SparqlMinusScopingTests {
+
+	private static final String NS = "http://ex/";
+	private static final String PREFIX = "PREFIX : <http://ex/>\n";
+
+	private static SailRepository REPO;
+
+	private static final String TTL = String.join("\n",
+			"@prefix : <http://ex/> .",
+			":a :p 1 .   :a :q 10 .  :a :r 100 .",
+			":b :p 2 .   :b :q 20 .  :b :r 200 .",
+			":c :p 3 .                 :c :r 300 .",
+			":d :q 40 .  :d :r 400 .",
+			":e :p 5 .   :e :q 50 ."
+	);
+
+	@BeforeAll
+	static void setup() throws Exception {
+		REPO = new SailRepository(new MemoryStore());
+		REPO.init();
+		try (RepositoryConnection conn = REPO.getConnection()) {
+			conn.add(new StringReader(TTL), "", RDFFormat.TURTLE);
+		}
+	}
+
+	@AfterAll
+	static void teardown() {
+		if (REPO != null) {
+			REPO.shutDown();
+		}
+	}
+
+	// ---------- Helpers
+
+	private static List<BindingSet> select(String body) {
+		String sparql = PREFIX + body;
+		try (RepositoryConnection conn = REPO.getConnection()) {
+			TupleQuery q = conn.prepareTupleQuery(sparql);
+			try (TupleQueryResult r = q.evaluate()) {
+				return QueryResults.asList(r);
+			}
+		}
+	}
+
+	private static Set<String> names(List<BindingSet> rows, String var) {
+		return rows.stream()
+				.map(bs -> bs.getValue(var))
+				.filter(Objects::nonNull)
+				.map(SparqlMinusScopingTests::name)
+				.collect(Collectors.toCollection(LinkedHashSet::new));
+	}
+
+	private static String name(Value v) {
+		if (v instanceof IRI) {
+			IRI iri = (IRI) v;
+			return iri.getLocalName(); // ex:a -> "a"
+		}
+		return v.stringValue();
+	}
+
+	private static Set<String> setOf(String... items) {
+		return new LinkedHashSet<>(Arrays.asList(items));
+	}
+
+	// ---------- T1
+
+	@Test
+	void T1_bindCreatesFreshVarInRight_NoOverlap_NoEffect() {
+		List<BindingSet> rows = select(
+				"SELECT ?s ?pVal WHERE {\n" +
+						"  ?s :p ?pVal .\n" +
+						"  MINUS { ?x :q ?qVal . BIND(?qVal*2 AS ?fresh) }\n" +
+						"}"
+		);
+		assertEquals(4, rows.size());
+		assertEquals(setOf("a", "b", "c", "e"), names(rows, "s"));
+	}
+
+	// ---------- T2
+
+	@Test
+	void T2_overwriteSharedNameOnRight_FinalBindingsUsed_ThusNoRemoval() {
+		List<BindingSet> rows = select(
+				"SELECT ?s ?qVal WHERE {\n" +
+						"  ?s :q ?qVal .\n" +
+						"  MINUS { ?t :q ?qVal . BIND(?qVal+1 AS ?qVal) }\n" +
+						"}"
+		);
+		// Spec-conformant: right overwrites ?qVal to (+1), so no final-compatible mapping remains.
+		assertEquals(4, rows.size());
+		assertEquals(setOf("a", "b", "d", "e"), names(rows, "s"));
+	}
+
+	// ---------- T3
+
+	@Test
+	void T3_bindBeforeUseIntroducesOverlap_EverythingRemoved() {
+		List<BindingSet> rows = select(
+				"SELECT ?s ?qVal WHERE {\n" +
+						"  ?s :q ?qVal .\n" +
+						"  MINUS { ?t :q ?x . BIND(?x AS ?qVal) }\n" +
+						"}"
+		);
+		assertTrue(rows.isEmpty(), "All ?qVal values appear on the right after BIND, so MINUS removes all left rows");
+	}
+
+	// ---------- T4
+
+	@Test
+	void T4_renamedVarsInsideRight_NoTrueOverlap_NoEffect() {
+		List<BindingSet> rows = select(
+				"SELECT ?s ?pVal WHERE {\n" +
+						"  ?s :p ?pVal .\n" +
+						"  MINUS { ?s2 :p ?pVal2 . BIND(?pVal2 AS ?pVal_tmp) }\n" +
+						"}"
+		);
+		assertEquals(4, rows.size());
+		assertEquals(setOf("a", "b", "c", "e"), names(rows, "s"));
+	}
+
+	// ---------- T5
+
+	@Test
+	void T5_randInsideDisjointRight_MinusHasNoEffect() {
+		List<BindingSet> rows = select(
+				"SELECT ?s WHERE {\n" +
+						"  ?s :p ?v .\n" +
+						"  MINUS { ?x :q ?w . FILTER(RAND() < 2) }\n" + // disjoint vars -> MINUS no effect by spec
+						"}"
+		);
+		assertEquals(4, rows.size(), "Disjoint-variable MINUS must not remove any rows, regardless of RAND()");
+		assertEquals(setOf("a", "b", "c", "e"), names(rows, "s"));
+	}
+
+	// ---------- T6
+
+	@Test
+	void T6_randPerSolution_RemovesAboutHalfOnAverage() {
+		final int runs = 200; // statistical check
+		int totalKept = 0;
+
+		for (int i = 0; i < runs; i++) {
+			List<BindingSet> rows = select(
+					"SELECT ?s WHERE {\n" +
+							"  ?s :q ?q .\n" +
+							"  MINUS { ?s :q ?q . FILTER(RAND() < 0.5) }\n" +
+							"}"
+			);
+			totalKept += rows.size();
+		}
+
+		// Left side has 4 ?s with :q (a,b,d,e). Expect ~2 kept on average.
+		double meanKept = (double) totalKept / runs;
+		double fraction = meanKept / 4.0;
+
+		assertTrue(fraction >= 0.35 && fraction <= 0.65,
+				"Expected mean kept fraction ~0.5, got " + fraction + " (mean kept=" + meanKept + ")");
+	}
+
+	// ---------- T7
+
+	@Test
+	void T7_overwriteSharedVarAfterOverlapIsEstablished_FinalBindingsControl_NoRemoval() {
+		List<BindingSet> rows = select(
+				"SELECT ?s ?r WHERE {\n" +
+						"  ?s :r ?r .\n" +
+						"  MINUS {\n" +
+						"    ?s :r ?r .\n" +
+						"    BIND(-1 AS ?r)\n" + // overwrites ?r; final right-hand ?r != left ?r -> incompatible
+						"  }\n" +
+						"}"
+		);
+		assertEquals(4, rows.size());
+		assertEquals(setOf("a", "b", "c", "d"), names(rows, "s"));
+	}
+
+	// ---------- T8
+
+	@Test
+	void T8_projectionExprOnLeftDoesNotAffectMinusOverlap_NoEffect() {
+		List<BindingSet> rows = select(
+				"SELECT ?s ?pVal (STR(?s) AS ?z) WHERE {\n" +
+						"  ?s :p ?pVal .\n" +
+						"  MINUS { ?x :q ?q . BIND(STR(?x) AS ?z) }\n" + // ?z only exists on the right (left ?z is
+																			// projection-time)
+						"}"
+		);
+		assertEquals(4, rows.size());
+		assertEquals(setOf("a", "b", "c", "e"), names(rows, "s"));
+	}
+
+	// ---------- T9
+
+	@Test
+	void T9_projectionBeforeMinus_NoSharedVarsAfterSubselect_NoEffect() {
+		List<BindingSet> rows = select(
+				"SELECT ?s WHERE {\n" +
+						"  { SELECT ?s WHERE { ?s :p ?v } }\n" +
+						"  MINUS { ?x :p ?v }\n" + // ?v not projected to the outer level; disjoint wrt left (?s)
+						"}"
+		);
+		assertEquals(4, rows.size());
+		assertEquals(setOf("a", "b", "c", "e"), names(rows, "s"));
+	}
+
+	// ---------- T10
+
+	@Test
+	void T10_minusVsNotExists_WithThisDataTheyCoincide() {
+		List<BindingSet> minusRows = select(
+				"SELECT ?s WHERE {\n" +
+						"  ?s :p ?v .\n" +
+						"  MINUS { ?s :q ?w }\n" +
+						"}"
+		);
+		assertEquals(setOf("c"), names(minusRows, "s"));
+
+		List<BindingSet> notExistsRows = select(
+				"SELECT ?s WHERE {\n" +
+						"  ?s :p ?v .\n" +
+						"  FILTER NOT EXISTS { ?s :q ?w }\n" +
+						"}"
+		);
+		assertEquals(setOf("c"), names(notExistsRows, "s"));
+	}
+
+	// ---------- T11
+
+	@Test
+	void T11_multipleMinus_sharedThenIndependent_onlyFirstMatters() {
+		List<BindingSet> rows = select(
+				"SELECT ?s WHERE {\n" +
+						"  ?s :p ?v .\n" +
+						"  MINUS { ?s :q ?w }   # removes a, b, e\n" +
+						"  MINUS { ?x :r ?r }   # no shared vars -> no further effect\n" +
+						"}"
+		);
+		assertEquals(setOf("c"), names(rows, "s"));
+	}
+
+	// ---------- T12
+
+	@Test
+	void T12_minusInsideOptional_affectsOnlyOptionalGroup() {
+		List<BindingSet> rows = select(
+				"SELECT ?s ?maybe WHERE {\n" +
+						"  ?s :p ?v .\n" +
+						"  OPTIONAL {\n" +
+						"    BIND(1 AS ?maybe)\n" +
+						"    MINUS { ?s :q ?w }\n" +
+						"  }\n" +
+						"}"
+		);
+
+		// Build subject -> hasMaybe mapping
+		Map<String, Boolean> hasMaybe = new LinkedHashMap<>();
+		for (BindingSet bs : rows) {
+			String s = name(bs.getValue("s"));
+			boolean bound = bs.hasBinding("maybe");
+			hasMaybe.put(s, bound);
+		}
+
+		// With the dataset, only :c lacks :q, so OPTIONAL survives only for c.
+		assertEquals(4, rows.size());
+		assertEquals(Boolean.FALSE, hasMaybe.get("a"));
+		assertEquals(Boolean.FALSE, hasMaybe.get("b"));
+		assertEquals(Boolean.TRUE, hasMaybe.get("c"));
+		assertEquals(Boolean.FALSE, hasMaybe.get("e"));
+	}
+}

--- a/testsuites/sparql/src/test/java/dev/you/sparql/MinusEdgeCasesRdf4j510Test.java
+++ b/testsuites/sparql/src/test/java/dev/you/sparql/MinusEdgeCasesRdf4j510Test.java
@@ -1,0 +1,390 @@
+package dev.you.sparql;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.StringReader;
+import java.util.*;
+
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.query.*;
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.sail.memory.MemoryStore;
+import org.junit.jupiter.api.*;
+
+/**
+ * A battery of tests designed to catch wrong MINUS/correlation/graph-scope rewrites. Verified against RDF4J 5.1.0 APIs.
+ * See RDF4J Javadocs for Repository/TupleQuery, etc. https://rdf4j.org/javadoc/5.1.0/ (Repository,
+ * RepositoryConnection, TupleQuery).
+ */
+public class MinusEdgeCasesRdf4j510Test {
+
+	private Repository repo;
+	private RepositoryConnection cxn;
+
+	private static final String BASE = "http://ex/";
+
+	@BeforeEach
+	void setup() {
+		repo = new SailRepository(new MemoryStore());
+		repo.init();
+		cxn = repo.getConnection();
+	}
+
+	@AfterEach
+	void teardown() {
+		if (cxn != null)
+			cxn.close();
+		if (repo != null)
+			repo.shutDown();
+	}
+
+	// ---------- helpers ----------
+
+	private void load(String data, RDFFormat fmt) throws Exception {
+		cxn.clear();
+		cxn.add(new StringReader(data), BASE, fmt);
+	}
+
+	private Set<Map<String, String>> runSelect(String sparql) {
+		TupleQuery tq = cxn.prepareTupleQuery(QueryLanguage.SPARQL, sparql);
+		try (TupleQueryResult tqr = tq.evaluate()) {
+			List<String> names = tqr.getBindingNames();
+			Set<Map<String, String>> out = new LinkedHashSet<>();
+			while (tqr.hasNext()) {
+				BindingSet bs = tqr.next();
+				Map<String, String> m = new LinkedHashMap<>();
+				for (String n : names) {
+					Value v = bs.getValue(n);
+					if (v != null)
+						m.put(n, v.stringValue());
+				}
+				out.add(m);
+			}
+			return out;
+		}
+	}
+
+	private static Map<String, String> row(Object... kv) {
+		if (kv.length % 2 != 0)
+			throw new IllegalArgumentException("odd kv length");
+		Map<String, String> m = new LinkedHashMap<>();
+		for (int i = 0; i < kv.length; i += 2) {
+			m.put(kv[i].toString(), kv[i + 1].toString());
+		}
+		return m;
+	}
+
+	private static String ex(String local) {
+		return BASE + local;
+	}
+
+	// ---------- TESTS ----------
+
+	@Test
+	void minus_no_shared_vars_is_noop_select() throws Exception {
+		String ttl = "@prefix : <http://ex/> .\n" +
+				":a :p 1 . :a :q 1 . :b :p 1 .";
+		load(ttl, RDFFormat.TURTLE);
+
+		String q = "PREFIX : <http://ex/>\n" +
+				"SELECT ?s WHERE { ?s :p 1 MINUS { ?x :q 1 } }";
+
+		Set<Map<String, String>> got = runSelect(q);
+		Set<Map<String, String>> exp = Set.of(
+				row("s", ex("a")),
+				row("s", ex("b"))
+		);
+		assertEquals(exp, got, "MINUS with disjoint var-sets must keep the LHS intact (§8.3).");
+	}
+
+	@Test
+	void not_exists_contrast_to_minus_no_shared_vars() throws Exception {
+		String ttl = "@prefix : <http://ex/> .\n" +
+				":a :p 1 . :a :q 1 . :b :p 1 .";
+		load(ttl, RDFFormat.TURTLE);
+
+		String q = "PREFIX : <http://ex/>\n" +
+				"SELECT ?s WHERE { ?s :p 1 FILTER NOT EXISTS { ?x :q 1 } }";
+
+		Set<Map<String, String>> got = runSelect(q);
+		assertTrue(got.isEmpty(), "NOT EXISTS is correlated and removes all rows when { ?x :q 1 } exists (§8.3).");
+	}
+
+	@Test
+	void rhs_filter_referencing_outer_var_is_unbound_and_ignored() throws Exception {
+		String ttl = "@prefix : <http://ex/> .\n" +
+				":a :p 1 ; :q 1, 2 .\n" +
+				":b :p 3 ; :q 4 .";
+		load(ttl, RDFFormat.TURTLE);
+
+		String q = "PREFIX : <http://ex/>\n" +
+				"SELECT ?x ?n WHERE {\n" +
+				"  ?x :p ?n .\n" +
+				"  MINUS { ?x :q ?m . FILTER(?m = ?n) }  # ?n is unbound on RHS → filter errors → RHS empty\n" +
+				"} ORDER BY ?x";
+
+		Set<Map<String, String>> got = runSelect(q);
+		Set<Map<String, String>> exp = Set.of(
+				row("x", ex("a"), "n", "1"),
+				row("x", ex("b"), "n", "3")
+		);
+		assertEquals(exp, got, "RHS filter sees no outer vars under MINUS; subtract nothing (§8.3).");
+	}
+
+	@Test
+	void rhs_bind_of_outer_var_produces_unbound_then_overremoves_on_shared_subset() throws Exception {
+		String ttl = "@prefix : <http://ex/> .\n" +
+				":a :p 1 ; :q 1, 2 .\n" +
+				":b :p 3 ; :q 4 .\n" +
+				":c :p 7 .";
+		load(ttl, RDFFormat.TURTLE);
+
+		String q = "PREFIX : <http://ex/>\n" +
+				"SELECT ?x WHERE {\n" +
+				"  ?x :p ?n .\n" +
+				"  MINUS { BIND(?n AS ?k) ?x :q ?k }   # ?n unbound in RHS; BIND keeps row with ?k unbound; ?x :q ?k binds any ?k; shared vars = {?x}\n"
+				+
+				"} ORDER BY ?x";
+
+		Set<Map<String, String>> got = runSelect(q);
+		Set<Map<String, String>> exp = Set.of(
+				row("x", ex("c")) // only :c has no :q → survives
+		);
+		assertEquals(exp, got,
+				"RHS BIND on unbound outer var must not correlate; shared-vars logic should remove :a,:b only.");
+	}
+
+	@Test
+	void rhs_bind_creates_intentional_shared_var_equalities() throws Exception {
+		String ttl = "@prefix : <http://ex/> .\n" +
+				":e :p 10 ; :q 42 .\n" +
+				":f :p 20 ; :q 20 .\n" +
+				":g :p 30 ; :q 99 .";
+		load(ttl, RDFFormat.TURTLE);
+
+		String q = "PREFIX : <http://ex/>\n" +
+				"SELECT ?x WHERE {\n" +
+				"  ?x :p ?v .\n" +
+				"  MINUS { ?x :q ?m . BIND(?m AS ?v) }  # removes only when q==p\n" +
+				"} ORDER BY ?x";
+
+		Set<Map<String, String>> got = runSelect(q);
+		Set<Map<String, String>> exp = Set.of(row("x", ex("e")), row("x", ex("g")));
+		assertEquals(exp, got, "Only :f should be removed (q==p). Early projection must NOT change shared vars.");
+	}
+
+	@Test
+	void early_projection_should_not_change_minus_semantics() throws Exception {
+		// Same data as previous test
+		String ttl = "@prefix : <http://ex/> .\n" +
+				":e :p 10 ; :q 42 .\n" +
+				":f :p 20 ; :q 20 .\n" +
+				":g :p 30 ; :q 99 .";
+		load(ttl, RDFFormat.TURTLE);
+
+		String q = "PREFIX : <http://ex/>\n" +
+				"SELECT ?x WHERE { ?x :p ?v MINUS { ?x :q ?v } } ORDER BY ?x";
+
+		Set<Map<String, String>> got = runSelect(q);
+		Set<Map<String, String>> exp = Set.of(row("x", ex("e")), row("x", ex("g")));
+		assertEquals(exp, got, "Pushing projection before MINUS would wrongly remove :e and :g; don't do that.");
+	}
+
+	@Test
+	void subquery_pins_shared_var_against_optimizer() throws Exception {
+		String ttl = "@prefix : <http://ex/> .\n" +
+				":e :p 10 ; :q 42 .\n" +
+				":f :p 20 ; :q 20 .\n" +
+				":g :p 30 ; :q 99 .";
+		load(ttl, RDFFormat.TURTLE);
+
+		String q = "PREFIX : <http://ex/>\n" +
+				"SELECT ?x WHERE {\n" +
+				"  { SELECT ?x ?v WHERE { ?x :p ?v } }   # box the LHS\n" +
+				"  MINUS { ?x :q ?v }\n" +
+				"} ORDER BY ?x";
+
+		Set<Map<String, String>> got = runSelect(q);
+		Set<Map<String, String>> exp = Set.of(row("x", ex("e")), row("x", ex("g")));
+		assertEquals(exp, got, "Subquery must preserve shared vars until MINUS.");
+	}
+
+	@Test
+	void optional_inside_minus_only_removes_when_optional_matches() throws Exception {
+		String ttl = "@prefix : <http://ex/> .\n" +
+				":e :name \"Alice\" ; :formerName \"Alice\" .\n" +
+				":f :name \"Carol\" .";
+		load(ttl, RDFFormat.TURTLE);
+
+		String q = "PREFIX : <http://ex/>\n" +
+				"SELECT ?x WHERE {\n" +
+				"  ?x :name ?n .\n" +
+				"  MINUS { OPTIONAL { ?x :formerName ?n } }\n" +
+				"} ORDER BY ?x";
+
+		Set<Map<String, String>> got = runSelect(q);
+		Set<Map<String, String>> exp = Set.of(row("x", ex("f")));
+		assertEquals(exp, got, "OPTIONAL inside MINUS: only rows for which the OPTIONAL binds compatibly are removed.");
+	}
+
+	@Test
+	void not_exists_over_optional_is_always_false_here() throws Exception {
+		// Same data as previous test
+		String ttl = "@prefix : <http://ex/> .\n" +
+				":e :name \"Alice\" ; :formerName \"Alice\" .\n" +
+				":f :name \"Carol\" .";
+		load(ttl, RDFFormat.TURTLE);
+
+		String q = "PREFIX : <http://ex/>\n" +
+				"SELECT ?x WHERE {\n" +
+				"  ?x :name ?n .\n" +
+				"  FILTER NOT EXISTS { OPTIONAL { ?x :formerName ?n } }\n" +
+				"}";
+
+		Set<Map<String, String>> got = runSelect(q);
+		assertTrue(got.isEmpty(),
+				"Rewriting MINUS{OPTIONAL{…}} to NOT EXISTS { OPTIONAL{…} } is wrong: the inner group always yields at least the empty mapping.");
+	}
+
+	@Test
+	void graph_isolation_same_g_on_both_sides_no_removal_when_values_differ() throws Exception {
+		String trig = "@prefix : <http://ex/> .\n" +
+				"GRAPH :g1 { :a :p 1 . }\n" +
+				"GRAPH :g2 { :a :q 1 . :a :p 2 . }";
+		load(trig, RDFFormat.TRIG);
+
+		String q = "PREFIX : <http://ex/>\n" +
+				"SELECT ?g ?x ?n WHERE {\n" +
+				"  GRAPH ?g { ?x :p ?n }\n" +
+				"  MINUS { GRAPH ?g { ?x :q ?n } }\n" +
+				"} ORDER BY ?g ?x ?n";
+
+		Set<Map<String, String>> got = runSelect(q);
+		Set<Map<String, String>> exp = Set.of(
+				row("g", ex("g1"), "x", ex("a"), "n", "1"),
+				row("g", ex("g2"), "x", ex("a"), "n", "2")
+		);
+		assertEquals(exp, got, "Active graph must be respected on the RHS as well (§13.3).");
+	}
+
+	@Test
+	void graph_isolation_removes_only_in_graph_where_match_exists() throws Exception {
+		String trig = "@prefix : <http://ex/> .\n" +
+				"GRAPH :g1 { :a :p 1 . }\n" +
+				"GRAPH :g2 { :a :q 1 . :a :p 2 . :a :q 2 . }";
+		load(trig, RDFFormat.TRIG);
+
+		String q = "PREFIX : <http://ex/>\n" +
+				"SELECT ?g ?x ?n WHERE {\n" +
+				"  GRAPH ?g { ?x :p ?n }\n" +
+				"  MINUS { GRAPH ?g { ?x :q ?n } }\n" +
+				"} ORDER BY ?g";
+
+		Set<Map<String, String>> got = runSelect(q);
+		Set<Map<String, String>> exp = Set.of(
+				row("g", ex("g1"), "x", ex("a"), "n", "1")
+		);
+		assertEquals(exp, got, "Only the :g2 row should be removed because :q 2 exists in :g2.");
+	}
+
+	@Test
+	void minus_disjoint_varsets_is_noop_even_with_union_on_lhs() throws Exception {
+		String ttl = "@prefix : <http://ex/> .\n" +
+				":a :p 1 ; :q 1 .\n" +
+				":b :p 1 .\n" +
+				":c :p 2 .";
+		load(ttl, RDFFormat.TURTLE);
+
+		String q = "PREFIX : <http://ex/>\n" +
+				"SELECT ?x WHERE {\n" +
+				"  { ?x :p 1 } UNION { ?x :p 2 }\n" +
+				"  MINUS { ?y :q 1 }\n" +
+				"} ORDER BY ?x";
+
+		Set<Map<String, String>> got = runSelect(q);
+		Set<Map<String, String>> exp = Set.of(row("x", ex("a")), row("x", ex("b")), row("x", ex("c")));
+		assertEquals(exp, got, "No shared vars → MINUS must be a no-op (§8.3).");
+	}
+
+	@Test
+	void values_left_only_no_shared_vars_is_noop() throws Exception {
+		String ttl = "@prefix : <http://ex/> . :a :q 1 .";
+		load(ttl, RDFFormat.TURTLE);
+
+		String q = "PREFIX : <http://ex/>\n" +
+				"SELECT ?a WHERE { VALUES ?a { 1 2 } MINUS { ?x :q 1 } } ORDER BY ?a";
+
+		Set<Map<String, String>> got = runSelect(q);
+		Set<Map<String, String>> exp = Set.of(row("a", "1"), row("a", "2"));
+		assertEquals(exp, got, "VALUES introduces no shared vars with RHS, so MINUS removes nothing.");
+	}
+
+	@Test
+	void minus_shared_subset_only_subject_shared_removes_all_rows_for_that_subject() throws Exception {
+		String ttl = "@prefix : <http://ex/> .\n" +
+				":a :p 1 ; :q 99 .\n" +
+				":b :p 2 .";
+		load(ttl, RDFFormat.TURTLE);
+
+		String q = "PREFIX : <http://ex/>\n" +
+				"SELECT ?x ?n WHERE { ?x :p ?n MINUS { ?x :q ?m } } ORDER BY ?x";
+
+		Set<Map<String, String>> got = runSelect(q);
+		Set<Map<String, String>> exp = Set.of(row("x", ex("b"), "n", "2"));
+		assertEquals(exp, got, "Since only ?x is shared, any :q for :a kills *all* its :p rows.");
+	}
+
+	@Test
+	void rhs_subselect_order_by_limit_one_global_elimination() throws Exception {
+		String ttl = "@prefix : <http://ex/> .\n" +
+				":a :p 1 ; :q 1 .\n" +
+				":b :p 2 ; :q 2 .\n" +
+				":c :p 3 ; :q 3 .";
+		load(ttl, RDFFormat.TURTLE);
+
+		String q = "PREFIX : <http://ex/>\n" +
+				"SELECT ?x WHERE {\n" +
+				"  ?x :p ?n .\n" +
+				"  MINUS {\n" +
+				"    { SELECT ?x WHERE { ?x :q ?m } ORDER BY ?m LIMIT 1 }\n" +
+				"  }\n" +
+				"} ORDER BY ?x";
+
+		Set<Map<String, String>> got = runSelect(q);
+		// the RHS selects only the globally smallest ?m → ?x=:a → remove :a
+		Set<Map<String, String>> exp = Set.of(row("x", ex("b")), row("x", ex("c")));
+		assertEquals(exp, got, "Flattening/pushing ORDER BY/LIMIT across MINUS would change which row is removed.");
+	}
+
+	@Test
+	void bnode_function_on_rhs_cannot_match_data_terms() throws Exception {
+		// We'll avoid comparing bnode IDs by not selecting ?id at all.
+		String ttl = "@prefix : <http://ex/> .\n" +
+				"_:b1 a [] . _:b2 a [] .  # just to have bnodes around\n" +
+				":k :p _:b1 . :l :p _:b2 .";
+		load(ttl, RDFFormat.TURTLE);
+
+		String q = "PREFIX : <http://ex/>\n" +
+				"SELECT ?s WHERE { ?s :p ?id MINUS { BIND(BNODE() AS ?id) } } ORDER BY ?s";
+
+		Set<Map<String, String>> got = runSelect(q);
+		Set<Map<String, String>> exp = Set.of(row("s", ex("k")), row("s", ex("l")));
+		assertEquals(exp, got,
+				"BNODE() creates fresh, distinct bnodes – cannot match dataset objects, so MINUS is a no-op here.");
+	}
+
+	@Test
+	void syntax_error_rebinding_in_rhs_must_fail_to_parse() {
+		String q = "PREFIX : <http://ex/>\n" +
+				"SELECT * WHERE {\n" +
+				"  ?x :p ?v .\n" +
+				"  MINUS { ?x :q ?v . BIND(1 AS ?v) }   # re-binding ?v inside same RHS group is illegal\n" +
+				"}";
+
+		assertThrows(MalformedQueryException.class, () -> cxn.prepareTupleQuery(QueryLanguage.SPARQL, q),
+				"BIND target must not have been used earlier in the same group; parser should reject.");
+	}
+}


### PR DESCRIPTION
## Summary
- add MinusEdgeCasesRdf4j510Test covering MINUS correlation, OPTIONAL, and GRAPH semantics edge cases
- add SparqlMinusScopingTests capturing additional MINUS scoping, BIND overwrites, and RAND() nondeterminism behavior

## Testing
- mvn -pl testsuites/sparql -Dtest="dev.you.sparql.MinusEdgeCasesRdf4j510Test,com.example.rdf4jminus.SparqlMinusScopingTests" verify *(fails: MinusEdgeCasesRdf4j510Test#rhs_bind_of_outer_var_produces_unbound_then_overremoves_on_shared_subset, MinusEdgeCasesRdf4j510Test#not_exists_over_optional_is_always_false_here, SparqlMinusScopingTests#T2_overwriteSharedNameOnRight_FinalBindingsUsed_ThusNoRemoval, SparqlMinusScopingTests#T7_overwriteSharedVarAfterOverlapIsEstablished_FinalBindingsControl_NoRemoval)*

------
https://chatgpt.com/codex/tasks/task_e_68dc26ca4914832ea6d7104a30867d5f