### PR TITLE
Ensure copilot setup workflow uses local Maven repo

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -23,16 +23,16 @@ jobs:
           cache: maven
 
       - name: Validate formatting configuration
-        run: mvn -B -T 2C formatter:validate impsort:check xml-format:xml-check
+        run: mvn -B -T 2C -Dmaven.repo.local=.m2_repo formatter:validate impsort:check xml-format:xml-check
 
       - name: Quick compile (skip tests)
-        run: mvn -B -T 2C compile -DskipTests -Pquick
+        run: mvn -B -T 2C -Dmaven.repo.local=.m2_repo compile -DskipTests -Pquick
 
       - name: Download Maven dependencies for offline use
-        run: mvn -B -T 2C dependency:go-offline
+        run: mvn -B -T 2C -Dmaven.repo.local=.m2_repo dependency:go-offline
 
       - name: Maven install (skip tests)
-        run: mvn -B install -DskipTests -Pquick
+        run: mvn -B -Dmaven.repo.local=.m2_repo install -DskipTests -Pquick
 
       - name: Install system dependencies for E2E tests
         run: sudo apt-get update && sudo apt-get install -y libxml2-utils


### PR DESCRIPTION
## Summary
- configure the Copilot setup workflow to use the repository-local Maven cache for all Maven invocations

## Testing
- mvn -o -Dmaven.repo.local=.m2_repo -Pquick install | tail -200

------
https://chatgpt.com/codex/tasks/task_e_68e2bc450f54832e916dabd71fea23d9