### PR TITLE
chore: bump snapshot version to 5.3.0

### DIFF
--- a/assembly-descriptors/pom.xml
+++ b/assembly-descriptors/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-assembly-descriptors</artifactId>
 	<name>RDF4J: Assembly Descriptors</name>

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-assembly</artifactId>
 	<packaging>pom</packaging>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-bom</artifactId>
 	<packaging>pom</packaging>

--- a/compliance/elasticsearch/pom.xml
+++ b/compliance/elasticsearch/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-compliance</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-elasticsearch-compliance</artifactId>
 	<name>RDF4J: Elasticsearch Sail Tests</name>

--- a/compliance/geosparql/pom.xml
+++ b/compliance/geosparql/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-compliance</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-geosparql-compliance</artifactId>
 	<name>RDF4J: GeoSPARQL compliance tests</name>

--- a/compliance/lucene/pom.xml
+++ b/compliance/lucene/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-compliance</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-lucene-compliance</artifactId>
 	<name>RDF4J: Lucene Sail Tests</name>

--- a/compliance/model/pom.xml
+++ b/compliance/model/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<artifactId>rdf4j-compliance</artifactId>
 		<groupId>org.eclipse.rdf4j</groupId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>rdf4j-model-compliance</artifactId>

--- a/compliance/pom.xml
+++ b/compliance/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-compliance</artifactId>
 	<packaging>pom</packaging>

--- a/compliance/repository/pom.xml
+++ b/compliance/repository/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-compliance</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-repository-compliance</artifactId>
 	<packaging>war</packaging>

--- a/compliance/rio/pom.xml
+++ b/compliance/rio/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-compliance</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-rio-compliance</artifactId>
 	<name>RDF4J: Rio compliance tests</name>

--- a/compliance/solr/pom.xml
+++ b/compliance/solr/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-compliance</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-solr-compliance</artifactId>
 	<name>RDF4J: Solr Sail Tests</name>

--- a/compliance/sparql/pom.xml
+++ b/compliance/sparql/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-compliance</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-sparql-compliance</artifactId>
 	<packaging>war</packaging>

--- a/core/client/pom.xml
+++ b/core/client/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-core</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-client</artifactId>
 	<name>RDF4J: Client Libraries</name>

--- a/core/collection-factory/api/pom.xml
+++ b/core/collection-factory/api/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-collection-factory</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-collection-factory-api</artifactId>
 	<name>RDF4J: Collection Factory - API</name>

--- a/core/collection-factory/mapdb/pom.xml
+++ b/core/collection-factory/mapdb/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-collection-factory</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-collection-factory-mapdb</artifactId>
 	<name>RDF4J: Collection Factory - Map DB backed</name>

--- a/core/collection-factory/mapdb3/pom.xml
+++ b/core/collection-factory/mapdb3/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-collection-factory</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-collection-factory-mapdb3</artifactId>
 	<name>RDF4J: Collection Factory - Map DB v3 backed</name>

--- a/core/collection-factory/pom.xml
+++ b/core/collection-factory/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-core</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-collection-factory</artifactId>
 	<packaging>pom</packaging>

--- a/core/common/annotation/pom.xml
+++ b/core/common/annotation/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-common</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-common-annotation</artifactId>
 	<name>RDF4J: common annotation</name>

--- a/core/common/exception/pom.xml
+++ b/core/common/exception/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-common</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-common-exception</artifactId>
 	<name>RDF4J: common exception</name>

--- a/core/common/io/pom.xml
+++ b/core/common/io/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-common</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-common-io</artifactId>
 	<name>RDF4J: common IO</name>

--- a/core/common/iterator/pom.xml
+++ b/core/common/iterator/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-common</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-common-iterator</artifactId>
 	<name>RDF4J: common iterators</name>

--- a/core/common/order/pom.xml
+++ b/core/common/order/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-common</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-common-order</artifactId>
 	<name>RDF4J: common order</name>

--- a/core/common/pom.xml
+++ b/core/common/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-core</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-common</artifactId>
 	<packaging>pom</packaging>

--- a/core/common/text/pom.xml
+++ b/core/common/text/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-common</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-common-text</artifactId>
 	<name>RDF4J: common text</name>

--- a/core/common/transaction/pom.xml
+++ b/core/common/transaction/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-common</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-common-transaction</artifactId>
 	<name>RDF4J: common transaction</name>

--- a/core/common/xml/pom.xml
+++ b/core/common/xml/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-common</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-common-xml</artifactId>
 	<name>RDF4J: common XML</name>

--- a/core/http/client/pom.xml
+++ b/core/http/client/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-http</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-http-client</artifactId>
 	<name>RDF4J: HTTP client</name>

--- a/core/http/pom.xml
+++ b/core/http/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-core</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-http</artifactId>
 	<packaging>pom</packaging>

--- a/core/http/protocol/pom.xml
+++ b/core/http/protocol/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-http</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-http-protocol</artifactId>
 	<name>RDF4J: HTTP protocol</name>

--- a/core/model-api/pom.xml
+++ b/core/model-api/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-core</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-model-api</artifactId>
 	<name>RDF4J: Model API</name>

--- a/core/model-vocabulary/pom.xml
+++ b/core/model-vocabulary/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-core</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-model-vocabulary</artifactId>
 	<name>RDF4J: RDF Vocabularies</name>

--- a/core/model/pom.xml
+++ b/core/model/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-core</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-model</artifactId>
 	<name>RDF4J: Model</name>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-core</artifactId>
 	<packaging>pom</packaging>

--- a/core/query/pom.xml
+++ b/core/query/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-core</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-query</artifactId>
 	<name>RDF4J: Query</name>

--- a/core/queryalgebra/evaluation/pom.xml
+++ b/core/queryalgebra/evaluation/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-queryalgebra</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-queryalgebra-evaluation</artifactId>
 	<name>RDF4J: Query algebra - evaluation</name>

--- a/core/queryalgebra/geosparql/pom.xml
+++ b/core/queryalgebra/geosparql/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-queryalgebra</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-queryalgebra-geosparql</artifactId>
 	<name>RDF4J: Query algebra - GeoSPARQL</name>

--- a/core/queryalgebra/model/pom.xml
+++ b/core/queryalgebra/model/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-queryalgebra</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-queryalgebra-model</artifactId>
 	<name>RDF4J: Query algebra - model</name>

--- a/core/queryalgebra/pom.xml
+++ b/core/queryalgebra/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-core</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-queryalgebra</artifactId>
 	<packaging>pom</packaging>

--- a/core/queryparser/api/pom.xml
+++ b/core/queryparser/api/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-queryparser</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-queryparser-api</artifactId>
 	<name>RDF4J: Query parser - API</name>

--- a/core/queryparser/pom.xml
+++ b/core/queryparser/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-core</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-queryparser</artifactId>
 	<packaging>pom</packaging>

--- a/core/queryparser/sparql/pom.xml
+++ b/core/queryparser/sparql/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-queryparser</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-queryparser-sparql</artifactId>
 	<name>RDF4J: Query parser - SPARQL</name>

--- a/core/queryrender/pom.xml
+++ b/core/queryrender/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-core</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-queryrender</artifactId>
 	<name>RDF4J: Query Rendering</name>

--- a/core/queryresultio/api/pom.xml
+++ b/core/queryresultio/api/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-queryresultio</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-queryresultio-api</artifactId>
 	<name>RDF4J: Query result IO - API</name>

--- a/core/queryresultio/binary/pom.xml
+++ b/core/queryresultio/binary/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-queryresultio</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-queryresultio-binary</artifactId>
 	<name>RDF4J: Query result IO - binary</name>

--- a/core/queryresultio/ods/pom.xml
+++ b/core/queryresultio/ods/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-queryresultio</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-queryresultio-sparqlods</artifactId>
 	<name>RDF4J: Query result IO - ODS</name>

--- a/core/queryresultio/pom.xml
+++ b/core/queryresultio/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-core</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-queryresultio</artifactId>
 	<packaging>pom</packaging>

--- a/core/queryresultio/sparqljson/pom.xml
+++ b/core/queryresultio/sparqljson/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-queryresultio</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-queryresultio-sparqljson</artifactId>
 	<name>RDF4J: Query result IO - SPARQL/JSON</name>

--- a/core/queryresultio/sparqlxml/pom.xml
+++ b/core/queryresultio/sparqlxml/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-queryresultio</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-queryresultio-sparqlxml</artifactId>
 	<name>RDF4J: Query result IO - SPARQL/XML</name>

--- a/core/queryresultio/text/pom.xml
+++ b/core/queryresultio/text/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-queryresultio</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-queryresultio-text</artifactId>
 	<name>RDF4J: Query result IO - plain text booleans</name>

--- a/core/queryresultio/xlsx/pom.xml
+++ b/core/queryresultio/xlsx/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-queryresultio</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-queryresultio-sparqlxlsx</artifactId>
 	<name>RDF4J: Query result IO - XSLX</name>

--- a/core/repository/api/pom.xml
+++ b/core/repository/api/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-repository</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-repository-api</artifactId>
 	<name>RDF4J: Repository - API</name>

--- a/core/repository/contextaware/pom.xml
+++ b/core/repository/contextaware/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-repository</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-repository-contextaware</artifactId>
 	<name>RDF4J: Repository - context aware (wrapper)</name>

--- a/core/repository/dataset/pom.xml
+++ b/core/repository/dataset/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-repository</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-repository-dataset</artifactId>
 	<name>RDF4J: DatasetRepository (wrapper)</name>

--- a/core/repository/event/pom.xml
+++ b/core/repository/event/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-repository</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-repository-event</artifactId>
 	<name>RDF4J: Repository - event (wrapper)</name>

--- a/core/repository/http/pom.xml
+++ b/core/repository/http/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-repository</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-repository-http</artifactId>
 	<name>RDF4J: HTTPRepository</name>

--- a/core/repository/manager/pom.xml
+++ b/core/repository/manager/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-repository</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-repository-manager</artifactId>
 	<name>RDF4J: Repository manager</name>

--- a/core/repository/pom.xml
+++ b/core/repository/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-core</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-repository</artifactId>
 	<packaging>pom</packaging>

--- a/core/repository/sail/pom.xml
+++ b/core/repository/sail/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-repository</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-repository-sail</artifactId>
 	<name>RDF4J: SailRepository</name>

--- a/core/repository/sparql/pom.xml
+++ b/core/repository/sparql/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-repository</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-repository-sparql</artifactId>
 	<name>RDF4J: SPARQL Repository</name>

--- a/core/rio/api/pom.xml
+++ b/core/rio/api/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-rio</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-rio-api</artifactId>
 	<name>RDF4J: Rio - API</name>

--- a/core/rio/binary/pom.xml
+++ b/core/rio/binary/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-rio</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-rio-binary</artifactId>
 	<name>RDF4J: Rio - Binary</name>

--- a/core/rio/datatypes/pom.xml
+++ b/core/rio/datatypes/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-rio</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-rio-datatypes</artifactId>
 	<name>RDF4J: Rio - Datatypes</name>

--- a/core/rio/hdt/pom.xml
+++ b/core/rio/hdt/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-rio</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-rio-hdt</artifactId>
 	<packaging>jar</packaging>

--- a/core/rio/jsonld-legacy/pom.xml
+++ b/core/rio/jsonld-legacy/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-rio</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-rio-jsonld-legacy</artifactId>
 	<name>RDF4J: Rio - JSON-LD 1.0 (legacy)</name>

--- a/core/rio/jsonld/pom.xml
+++ b/core/rio/jsonld/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-rio</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-rio-jsonld</artifactId>
 	<name>RDF4J: Rio - JSON-LD</name>

--- a/core/rio/languages/pom.xml
+++ b/core/rio/languages/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-rio</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-rio-languages</artifactId>
 	<name>RDF4J: Rio - Languages</name>

--- a/core/rio/n3/pom.xml
+++ b/core/rio/n3/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-rio</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-rio-n3</artifactId>
 	<name>RDF4J: Rio - N3 (writer-only)</name>

--- a/core/rio/nquads/pom.xml
+++ b/core/rio/nquads/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-rio</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-rio-nquads</artifactId>
 	<name>RDF4J: Rio - N-Quads</name>

--- a/core/rio/ntriples/pom.xml
+++ b/core/rio/ntriples/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-rio</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-rio-ntriples</artifactId>
 	<name>RDF4J: Rio - N-Triples</name>

--- a/core/rio/pom.xml
+++ b/core/rio/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-core</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-rio</artifactId>
 	<packaging>pom</packaging>

--- a/core/rio/rdfjson/pom.xml
+++ b/core/rio/rdfjson/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-rio</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-rio-rdfjson</artifactId>
 	<name>RDF4J: Rio - RDF/JSON</name>

--- a/core/rio/rdfxml/pom.xml
+++ b/core/rio/rdfxml/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-rio</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-rio-rdfxml</artifactId>
 	<name>RDF4J: Rio - RDF/XML</name>

--- a/core/rio/trig/pom.xml
+++ b/core/rio/trig/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-rio</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-rio-trig</artifactId>
 	<name>RDF4J: Rio - TriG</name>

--- a/core/rio/trix/pom.xml
+++ b/core/rio/trix/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-rio</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-rio-trix</artifactId>
 	<name>RDF4J: Rio - TriX</name>

--- a/core/rio/turtle/pom.xml
+++ b/core/rio/turtle/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-rio</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-rio-turtle</artifactId>
 	<name>RDF4J: Rio - Turtle</name>

--- a/core/sail/api/pom.xml
+++ b/core/sail/api/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-sail</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-sail-api</artifactId>
 	<name>RDF4J: Sail API</name>

--- a/core/sail/base/pom.xml
+++ b/core/sail/base/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-sail</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-sail-base</artifactId>
 	<name>RDF4J: Sail base implementations</name>

--- a/core/sail/elasticsearch-store/pom.xml
+++ b/core/sail/elasticsearch-store/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-sail</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-sail-elasticsearch-store</artifactId>
 	<name>RDF4J: Elasticsearch Store</name>

--- a/core/sail/elasticsearch/pom.xml
+++ b/core/sail/elasticsearch/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-sail</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-sail-elasticsearch</artifactId>
 	<name>RDF4J: Elastic Search Sail Index</name>

--- a/core/sail/extensible-store/pom.xml
+++ b/core/sail/extensible-store/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-sail</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-sail-extensible-store</artifactId>
 	<name>RDF4J: Extensible Store</name>

--- a/core/sail/inferencer/pom.xml
+++ b/core/sail/inferencer/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-sail</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-sail-inferencer</artifactId>
 	<name>RDF4J: Inferencer Sails</name>

--- a/core/sail/lmdb/pom.xml
+++ b/core/sail/lmdb/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-sail</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-sail-lmdb</artifactId>
 	<name>RDF4J: LmdbStore</name>

--- a/core/sail/lucene-api/pom.xml
+++ b/core/sail/lucene-api/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-sail</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-sail-lucene-api</artifactId>
 	<name>RDF4J: Lucene Sail API</name>

--- a/core/sail/lucene/pom.xml
+++ b/core/sail/lucene/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-sail</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-sail-lucene</artifactId>
 	<name>RDF4J: Lucene Sail Index</name>

--- a/core/sail/memory/pom.xml
+++ b/core/sail/memory/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-sail</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-sail-memory</artifactId>
 	<name>RDF4J: MemoryStore</name>

--- a/core/sail/model/pom.xml
+++ b/core/sail/model/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-sail</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-sail-model</artifactId>
 	<name>RDF4J: Sail Model</name>

--- a/core/sail/nativerdf/pom.xml
+++ b/core/sail/nativerdf/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-sail</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-sail-nativerdf</artifactId>
 	<name>RDF4J: NativeStore</name>

--- a/core/sail/pom.xml
+++ b/core/sail/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-core</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-sail</artifactId>
 	<packaging>pom</packaging>

--- a/core/sail/shacl/pom.xml
+++ b/core/sail/shacl/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-sail</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-shacl</artifactId>
 	<name>RDF4J: SHACL</name>

--- a/core/sail/solr/pom.xml
+++ b/core/sail/solr/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-sail</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-sail-solr</artifactId>
 	<name>RDF4J: Solr Sail Index</name>

--- a/core/sparqlbuilder/pom.xml
+++ b/core/sparqlbuilder/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-core</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-sparqlbuilder</artifactId>
 	<name>RDF4J: SparqlBuilder</name>

--- a/core/spin/pom.xml
+++ b/core/spin/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-core</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-spin</artifactId>
 	<name>RDF4J: SPIN</name>

--- a/core/storage/pom.xml
+++ b/core/storage/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-core</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-storage</artifactId>
 	<name>RDF4J: Storage Libraries</name>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<dependencies>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.eclipse.rdf4j</groupId>
 	<artifactId>rdf4j</artifactId>
-	<version>5.2.0-SNAPSHOT</version>
+	<version>5.3.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>Eclipse RDF4J</name>
 	<description>An extensible Java framework for RDF and SPARQL</description>

--- a/spring-components/pom.xml
+++ b/spring-components/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<packaging>pom</packaging>
 	<modules>

--- a/spring-components/rdf4j-spring-demo/pom.xml
+++ b/spring-components/rdf4j-spring-demo/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-spring-components</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<dependencies>
 		<dependency>

--- a/spring-components/rdf4j-spring/pom.xml
+++ b/spring-components/rdf4j-spring/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-spring-components</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-spring</artifactId>
 	<name>RDF4J: Spring</name>

--- a/spring-components/spring-boot-sparql-web/pom.xml
+++ b/spring-components/spring-boot-sparql-web/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-spring-components</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-spring-boot-sparql-web</artifactId>
 	<name>RDF4J: Spring boot component for a HTTP sparql server</name>

--- a/testsuites/benchmark/pom.xml
+++ b/testsuites/benchmark/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-testsuites</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-benchmark</artifactId>
 	<name>RDF4J: benchmarks</name>

--- a/testsuites/geosparql/pom.xml
+++ b/testsuites/geosparql/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-testsuites</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-geosparql-testsuite</artifactId>
 	<name>RDF4J: GeoSPARQL compliance test suite</name>

--- a/testsuites/lucene/pom.xml
+++ b/testsuites/lucene/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-testsuites</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-lucene-testsuite</artifactId>
 	<name>RDF4J: Lucene Sail Tests</name>

--- a/testsuites/model/pom.xml
+++ b/testsuites/model/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-testsuites</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-model-testsuite</artifactId>
 	<name>RDF4J: Model API testsuite</name>

--- a/testsuites/pom.xml
+++ b/testsuites/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-testsuites</artifactId>
 	<packaging>pom</packaging>

--- a/testsuites/queryresultio/pom.xml
+++ b/testsuites/queryresultio/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-testsuites</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-queryresultio-testsuite</artifactId>
 	<name>RDF4J: QueryResultIO testsuite</name>

--- a/testsuites/repository/pom.xml
+++ b/testsuites/repository/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-testsuites</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-repository-testsuite</artifactId>
 	<name>RDF4J: Repository API testsuite</name>

--- a/testsuites/rio/pom.xml
+++ b/testsuites/rio/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-testsuites</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-rio-testsuite</artifactId>
 	<name>RDF4J: Rio compliance test suite</name>

--- a/testsuites/sail/pom.xml
+++ b/testsuites/sail/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-testsuites</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-sail-testsuite</artifactId>
 	<name>RDF4J: Sail API testsuite</name>

--- a/testsuites/sparql/pom.xml
+++ b/testsuites/sparql/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-testsuites</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-sparql-testsuite</artifactId>
 	<name>RDF4J: SPARQL compliance test suite</name>

--- a/tools/config/pom.xml
+++ b/tools/config/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-tools</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-config</artifactId>
 	<name>RDF4J: application configuration</name>

--- a/tools/console/pom.xml
+++ b/tools/console/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-tools</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-console</artifactId>
 	<name>RDF4J: Console</name>

--- a/tools/federation/pom.xml
+++ b/tools/federation/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-tools</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<build>
 		<plugins>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-tools</artifactId>
 	<packaging>pom</packaging>

--- a/tools/runtime-osgi/pom.xml
+++ b/tools/runtime-osgi/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-tools</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-runtime-osgi</artifactId>
 	<packaging>bundle</packaging>

--- a/tools/runtime/pom.xml
+++ b/tools/runtime/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-tools</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-runtime</artifactId>
 	<name>RDF4J: Runtime</name>

--- a/tools/server-spring/pom.xml
+++ b/tools/server-spring/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-tools</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-http-server-spring</artifactId>
 	<name>RDF4J: HTTP server - core</name>

--- a/tools/server/pom.xml
+++ b/tools/server/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-tools</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-http-server</artifactId>
 	<packaging>war</packaging>

--- a/tools/workbench/pom.xml
+++ b/tools/workbench/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.rdf4j</groupId>
 		<artifactId>rdf4j-tools</artifactId>
-		<version>5.2.0-SNAPSHOT</version>
+		<version>5.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>rdf4j-http-workbench</artifactId>
 	<packaging>war</packaging>


### PR DESCRIPTION
## Summary
- update the Maven parent and all module POMs to use version 5.3.0-SNAPSHOT in preparation for the next minor release cycle

## Testing
- mvn -N -Dexpression=project.version help:evaluate

------
https://chatgpt.com/codex/tasks/task_e_68e2d48c3fc8832ebb671037b3ab9308