### PR TITLE
Handle default isolation level propagation

### DIFF
--- a/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/SailRepositoryConnection.java
+++ b/core/repository/sail/src/main/java/org/eclipse/rdf4j/repository/sail/SailRepositoryConnection.java
@@ -49,6 +49,7 @@ import org.eclipse.rdf4j.repository.UnknownTransactionStateException;
 import org.eclipse.rdf4j.repository.base.AbstractRepositoryConnection;
 import org.eclipse.rdf4j.rio.RDFHandler;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
+import org.eclipse.rdf4j.sail.Sail;
 import org.eclipse.rdf4j.sail.SailConnection;
 import org.eclipse.rdf4j.sail.SailException;
 import org.eclipse.rdf4j.sail.SailReadOnlyException;
@@ -69,6 +70,7 @@ public class SailRepositoryConnection extends AbstractRepositoryConnection imple
 	/**
 	 * The Sail connection wrapped by this repository connection object.
 	 */
+	private final SailRepository sailRepository;
 	private final SailConnection sailConnection;
 
 	/*--------------*
@@ -81,6 +83,7 @@ public class SailRepositoryConnection extends AbstractRepositoryConnection imple
 	 */
 	protected SailRepositoryConnection(SailRepository repository, SailConnection sailConnection) {
 		super(repository);
+		this.sailRepository = repository;
 		this.sailConnection = sailConnection;
 	}
 
@@ -155,8 +158,14 @@ public class SailRepositoryConnection extends AbstractRepositoryConnection imple
 			// always call receiveTransactionSettings(...) before calling begin();
 			sailConnection.setTransactionSettings();
 
-			if (getIsolationLevel() != null) {
-				sailConnection.begin(getIsolationLevel());
+			IsolationLevel isolationLevel = getIsolationLevel();
+			if (isolationLevel == null) {
+				isolationLevel = resolveDefaultIsolationLevel();
+				super.setIsolationLevel(isolationLevel);
+			}
+
+			if (isolationLevel != null) {
+				sailConnection.begin(isolationLevel);
 			} else {
 				sailConnection.begin();
 			}
@@ -167,12 +176,17 @@ public class SailRepositoryConnection extends AbstractRepositoryConnection imple
 
 	@Override
 	public void begin(IsolationLevel level) throws RepositoryException {
+		IsolationLevel isolationLevel = level;
+		if (isolationLevel == null) {
+			isolationLevel = resolveDefaultIsolationLevel();
+		}
+		super.setIsolationLevel(isolationLevel);
 		try {
 			// always call receiveTransactionSettings(...) before calling begin();
 			sailConnection.setTransactionSettings();
 
-			if (level != null) {
-				sailConnection.begin(level);
+			if (isolationLevel != null) {
+				sailConnection.begin(isolationLevel);
 			} else {
 				sailConnection.begin();
 			}
@@ -195,17 +209,29 @@ public class SailRepositoryConnection extends AbstractRepositoryConnection imple
 
 			for (TransactionSetting setting : settings) {
 				if (setting instanceof IsolationLevel) {
+					super.setIsolationLevel((IsolationLevel) setting);
 					sailConnection.begin((IsolationLevel) setting);
 					return;
 				}
 			}
 
+			IsolationLevel isolationLevel = resolveDefaultIsolationLevel();
+			super.setIsolationLevel(isolationLevel);
 			// if none of the transaction settings are isolation levels
-			sailConnection.begin();
+			if (isolationLevel != null) {
+				sailConnection.begin(isolationLevel);
+			} else {
+				sailConnection.begin();
+			}
 
 		} catch (SailException e) {
 			throw new RepositoryException(e);
 		}
+	}
+
+	private IsolationLevel resolveDefaultIsolationLevel() {
+		Sail sail = sailRepository != null ? sailRepository.getSail() : null;
+		return sail != null ? sail.getDefaultIsolationLevel() : null;
 	}
 
 	@Override

--- a/core/repository/sail/src/test/java/org/eclipse/rdf4j/repository/sail/SailRepositoryConnectionTest.java
+++ b/core/repository/sail/src/test/java/org/eclipse/rdf4j/repository/sail/SailRepositoryConnectionTest.java
@@ -22,6 +22,8 @@ import static org.mockito.Mockito.when;
 import java.util.Optional;
 
 import org.eclipse.rdf4j.common.iteration.EmptyIteration;
+import org.eclipse.rdf4j.common.transaction.IsolationLevel;
+import org.eclipse.rdf4j.common.transaction.IsolationLevels;
 import org.eclipse.rdf4j.query.BooleanQuery;
 import org.eclipse.rdf4j.query.GraphQuery;
 import org.eclipse.rdf4j.query.Query;
@@ -29,6 +31,7 @@ import org.eclipse.rdf4j.query.TupleQuery;
 import org.eclipse.rdf4j.query.algebra.QueryRoot;
 import org.eclipse.rdf4j.query.algebra.TupleExpr;
 import org.eclipse.rdf4j.query.explanation.Explanation;
+import org.eclipse.rdf4j.sail.Sail;
 import org.eclipse.rdf4j.sail.SailConnection;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -43,13 +46,36 @@ public class SailRepositoryConnectionTest {
 	private SailRepositoryConnection subject;
 	private SailConnection sailConnection;
 	private SailRepository sailRepository;
+	private Sail sail;
 
 	@BeforeEach
 	public void setUp() {
 		sailConnection = mock(SailConnection.class);
 		sailRepository = mock(SailRepository.class);
+		sail = mock(Sail.class);
+
+		when(sailRepository.getSail()).thenReturn(sail);
 
 		subject = new SailRepositoryConnection(sailRepository, sailConnection);
+	}
+
+	@Test
+	public void beginIsolationLevelIsVisibleFromConnection() {
+		IsolationLevel isolationLevel = IsolationLevels.SERIALIZABLE;
+
+		subject.begin(isolationLevel);
+
+		assertThat(subject.getIsolationLevel()).isEqualTo(isolationLevel);
+	}
+
+	@Test
+	public void beginUsesDefaultIsolationLevelWhenNoneConfigured() {
+		IsolationLevel defaultIsolationLevel = IsolationLevels.READ_COMMITTED;
+		when(sail.getDefaultIsolationLevel()).thenReturn(defaultIsolationLevel);
+
+		subject.begin();
+
+		assertThat(subject.getIsolationLevel()).isEqualTo(defaultIsolationLevel);
 	}
 
 	@Test


### PR DESCRIPTION
## Summary
- ensure `SailRepositoryConnection` resolves the repository's default isolation level when starting a transaction without an explicit level
- propagate the resolved level for both direct `begin()` calls and transactions started from `TransactionSetting` arrays
- add a regression test confirming the default isolation level is visible via `RepositoryConnection#getIsolationLevel`

## Testing
- mvn -pl core/repository/sail -DskipITs test

------
https://chatgpt.com/codex/tasks/task_e_68e2d51a2dcc832e80aab4e874def7a7