### PR TITLE
Add Elasticsearch licensing caution to documentation

### DIFF
--- a/site/content/about.md
+++ b/site/content/about.md
@@ -31,6 +31,10 @@ This is useful if you are already using Elasticsearch for other things in your p
 A good usecase is if you need reference data or an ontology for your application. The built-in read cache makes it a good choice for data that updates infrequently,
 though for most usecases the NativeStore will be considerably faster.
 
+{{< alert title="Licensing note" color="warning" >}}
+Elasticsearch itself is distributed under the Elastic License (with SSPL as an alternative). If you intend to use the optional Elasticsearch-backed features in RDF4J, please make sure to evaluate whether the licensing terms of Elasticsearch align with the needs of your project before adopting it.
+{{< /alert >}}
+
 On top of these core databases, RDF4J offers a number of functional extensions. These extensions add functionality such as improved full-text search, RDFS inferencing, rule-based reasoning and validation using SHACL/SPIN, and geospatial querying support. For more information see the [RDF4J documentation](/documentation).
 
 ### Third party database solutions

--- a/site/content/documentation/programming/repository.md
+++ b/site/content/documentation/programming/repository.md
@@ -113,8 +113,8 @@ The ElasticsearchStore stores RDF data in Elasticsearch. Not to be confused with
 The ElasticsearchStore is experimental and future releases may be incompatible with the current version. Write-ahead-logging is not supported.
 This means that a write operation can appear to have partially succeeded if the ElasticsearchStore looses its connection to Elasticsearch during a commit.
 
-Note that, while RDF4J is licensed under the EDL, several ElasticSearch dependencies are licensed under the Elastic License or the SSPL,
-which may have implications for some projects.
+Note that, while RDF4J is licensed under the EDL, Elasticsearch itself is distributed under the Elastic License (with SSPL as an alternative).
+The Elasticsearch-backed functionality in RDF4J is optional, and adopters should carefully evaluate the Elasticsearch licensing terms to ensure they meet the needs of their projects before enabling it.
 Please consult the ElasticSearch website and [license FAQ](https://www.elastic.co/licensing/elastic-license/faq) for more information.
  
 Transaction isolation is not as strong as for the other stores. The highest supported level is READ_COMMITTED, and even this


### PR DESCRIPTION
## Summary
- highlight Elasticsearch licensing considerations in the about page
- clarify that adopters should evaluate Elasticsearch licensing before enabling optional integrations

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e425ec2c9c832e9a28111129234352