### PR TITLE
Ensure LMDB store honors iteration cache sync threshold config

### DIFF
--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbStore.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbStore.java
@@ -133,6 +133,9 @@ public class LmdbStore extends AbstractNotifyingSail implements FederatedService
 				IsolationLevels.SNAPSHOT, IsolationLevels.SERIALIZABLE);
 		setDefaultIsolationLevel(IsolationLevels.SNAPSHOT_READ);
 		config.getDefaultQueryEvaluationMode().ifPresent(this::setDefaultQueryEvaluationMode);
+		if (config.getIterationCacheSyncThreshold() > 0) {
+			setIterationCacheSyncThreshold(config.getIterationCacheSyncThreshold());
+		}
 		EvaluationStrategyFactory evalStrategyFactory = config.getEvaluationStrategyFactory();
 		if (evalStrategyFactory != null) {
 			setEvaluationStrategyFactory(evalStrategyFactory);

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/config/LmdbStoreConfigTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/config/LmdbStoreConfigTest.java
@@ -22,6 +22,8 @@ import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.impl.LinkedHashModel;
 import org.eclipse.rdf4j.model.util.ModelBuilder;
 import org.eclipse.rdf4j.model.util.Values;
+import org.eclipse.rdf4j.sail.lmdb.LmdbStore;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -64,6 +66,17 @@ class LmdbStoreConfigTest {
 	}
 
 	// TODO: Add more tests for other properties
+
+	@Test
+	void setIterationCacheSyncThresholdShouldApplyToCreatedStore() {
+		final long threshold = 42;
+		final LmdbStoreConfig config = new LmdbStoreConfig();
+		config.setIterationCacheSyncThreshold(threshold);
+
+		final LmdbStore store = new LmdbStore(config);
+
+		assertThat(store.getIterationCacheSyncThreshold()).isEqualTo(threshold);
+	}
 
 	/**
 	 * Generic method to test parsing and exporting of config properties.


### PR DESCRIPTION
## Summary
- propagate the configured iteration cache sync threshold from `LmdbStoreConfig` into newly created `LmdbStore` instances

## Testing
- mvn -pl core/sail/lmdb test -Dtest=org.eclipse.rdf4j.sail.lmdb.config.LmdbStoreConfigTest#setIterationCacheSyncThresholdShouldApplyToCreatedStore


------
https://chatgpt.com/codex/tasks/task_e_68e35ca4eeec832ea24dc0445116263a