### PR TITLE
Add missing Hugo alert shortcode and regression test

### DIFF
--- a/site/layouts/shortcodes/alert.html
+++ b/site/layouts/shortcodes/alert.html
@@ -1,0 +1,19 @@
+{{- $type := lower (default "info" (.Get "type")) -}}
+{{- $title := .Get "title" -}}
+{{- $icons := dict "info" "fa-info-circle" "warning" "fa-exclamation-triangle" "danger" "fa-exclamation-circle" "success" "fa-check-circle" -}}
+{{- $backgrounds := dict "info" "#e0f4ff" "warning" "#fff4e0" "danger" "#ffe3e3" "success" "#e7f5e7" -}}
+{{- $borders := dict "info" "#228be6" "warning" "#f08c00" "danger" "#c92a2a" "success" "#2f9e44" -}}
+{{- $icon := index $icons $type | default (index $icons "info") -}}
+{{- $background := index $backgrounds $type | default (index $backgrounds "info") -}}
+{{- $border := index $borders $type | default (index $borders "info") -}}
+<div class="alert-box alert-box-{{$type}}" role="alert" style="border-left:4px solid {{$border}}; background-color: {{$background}}; padding:1rem; margin:1rem 0; border-radius:0.5rem;">
+  <div style="display:flex; align-items:flex-start; gap:0.75rem;">
+    <i class="fa {{$icon}}" aria-hidden="true" style="font-size:1.75rem; line-height:1;"></i>
+    <div class="alert-box-content">
+      {{- if $title -}}
+        <p style="font-weight:600; margin:0 0 0.25rem 0;">{{$title}}</p>
+      {{- end -}}
+      <div>{{ .Inner | markdownify }}</div>
+    </div>
+  </div>
+</div>

--- a/site/tests/hugo-alert-shortcode.sh
+++ b/site/tests/hugo-alert-shortcode.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HUGO_BIN="${HUGO_BIN:-hugo}"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+TEMP_CONTENT_PATH="$REPO_ROOT/site/content/_alert-shortcode-test.md"
+
+cleanup() {
+  local exit_code=$?
+  rm -f "$TEMP_CONTENT_PATH"
+  exit $exit_code
+}
+trap cleanup EXIT
+
+cat <<'CONTENT' > "$TEMP_CONTENT_PATH"
+---
+title: "Alert Shortcode Test"
+date: 2025-01-01
+---
+
+{{< alert type="info" >}}
+This is a shortcode validation test.
+{{< /alert >}}
+CONTENT
+
+"$HUGO_BIN" --source "$REPO_ROOT/site" --minify --baseURL "https://example.com/" >/tmp/hugo-alert-test.log
+
+trap - EXIT
+rm -f "$TEMP_CONTENT_PATH"
+echo "Hugo alert shortcode test completed successfully."


### PR DESCRIPTION
## Summary
- add a reusable `alert` shortcode so Hugo can render callouts used in site content
- provide default styles and icons per alert type and allow optional title text
- add a lightweight regression script that exercises the shortcode with Hugo 0.128

## Testing
- HUGO_BIN=/tmp/hugo site/tests/hugo-alert-shortcode.sh

------
https://chatgpt.com/codex/tasks/task_e_68e4a9bb850c832eb8211ee4c359797b