### PR TITLE
Remove Hugo alert regression test

### DIFF
--- a/site/layouts/shortcodes/alert.html
+++ b/site/layouts/shortcodes/alert.html
@@ -1,0 +1,19 @@
+{{- $type := lower (default "info" (.Get "type")) -}}
+{{- $title := .Get "title" -}}
+{{- $icons := dict "info" "fa-info-circle" "warning" "fa-exclamation-triangle" "danger" "fa-exclamation-circle" "success" "fa-check-circle" -}}
+{{- $backgrounds := dict "info" "#e0f4ff" "warning" "#fff4e0" "danger" "#ffe3e3" "success" "#e7f5e7" -}}
+{{- $borders := dict "info" "#228be6" "warning" "#f08c00" "danger" "#c92a2a" "success" "#2f9e44" -}}
+{{- $icon := index $icons $type | default (index $icons "info") -}}
+{{- $background := index $backgrounds $type | default (index $backgrounds "info") -}}
+{{- $border := index $borders $type | default (index $borders "info") -}}
+<div class="alert-box alert-box-{{$type}}" role="alert" style="border-left:4px solid {{$border}}; background-color: {{$background}}; padding:1rem; margin:1rem 0; border-radius:0.5rem;">
+  <div style="display:flex; align-items:flex-start; gap:0.75rem;">
+    <i class="fa {{$icon}}" aria-hidden="true" style="font-size:1.75rem; line-height:1;"></i>
+    <div class="alert-box-content">
+      {{- if $title -}}
+        <p style="font-weight:600; margin:0 0 0.25rem 0;">{{$title}}</p>
+      {{- end -}}
+      <div>{{ .Inner | markdownify }}</div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- remove the Hugo alert shortcode regression shell test that is no longer required

## Testing
- not run (test removed per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68e4a9bb850c832eb8211ee4c359797b