### PR TITLE
Fix Values.literal support for Instant

### DIFF
--- a/core/model/src/test/java/org/eclipse/rdf4j/model/util/LiteralsTest.java
+++ b/core/model/src/test/java/org/eclipse/rdf4j/model/util/LiteralsTest.java
@@ -11,6 +11,7 @@
 package org.eclipse.rdf4j.model.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -18,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import java.time.Instant;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.IllformedLocaleException;
@@ -105,6 +107,17 @@ public class LiteralsTest {
 		// invalid
 		assertThatExceptionOfType(IllformedLocaleException.class)
 				.isThrownBy(() -> Literals.normalizeLanguageTag("ru-ua-latn"));
+	}
+
+	@Test
+	public void valuesLiteralSupportsInstant() {
+		Instant instant = Instant.parse("2022-08-01T21:14:38.470534100Z");
+
+		Literal literal = Values.literal(instant);
+
+		assertThat(Instant.parse(literal.getLabel())).isEqualTo(instant);
+		assertThat(literal.getDatatype()).isEqualTo(XSD.DATETIME);
+		assertThat(literal.temporalAccessorValue()).isEqualTo(instant);
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- normalize Instant inputs in `TemporalAccessorLiteral` by formatting them via an `OffsetDateTime` so XML Schema datatype resolution succeeds
- expand `valuesLiteralSupportsInstant` to assert the resulting literal's lexical form, datatype, and temporal value

## Testing
- mvn -pl core/model-api test
- mvn -pl core/model test -Dtest=org.eclipse.rdf4j.model.util.LiteralsTest#valuesLiteralSupportsInstant

------
https://chatgpt.com/codex/tasks/task_e_68e533edff78832ea304df1f49b1ea59