### PR TITLE
GH-3681 Fix TurtleWriter inline list handling

### DIFF
--- a/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleWriter.java
+++ b/core/rio/turtle/src/main/java/org/eclipse/rdf4j/rio/turtle/TurtleWriter.java
@@ -305,6 +305,11 @@ public class TurtleWriter extends AbstractRDFWriter implements CharSink {
 
 		try {
 			if (inlineBNodes) {
+				if (pred.equals(RDF.TYPE) && obj.equals(RDF.LIST) && subj instanceof BNode
+						&& isWellFormedCollection(subj)) {
+					// skip explicit rdf:type rdf:List for collections we will inline as Turtle lists
+					return;
+				}
 				if ((pred.equals(RDF.FIRST) || pred.equals(RDF.REST)) && isWellFormedCollection(subj)) {
 					// we only use list shorthand syntax if the collection is considered well-formed
 					handleList(st, canShortenObjectBNode);
@@ -357,6 +362,9 @@ public class TurtleWriter extends AbstractRDFWriter implements CharSink {
 							// second rdf:rest statement on same subject is invalid.
 							return false;
 						}
+					} else if (pred.equals(RDF.TYPE) && RDF.LIST.equals(st.getObject())) {
+						// allow explicit rdf:type rdf:List
+						continue;
 					} else {
 						// non-list-structure statement connected to collection subject blank node
 						return false;


### PR DESCRIPTION
## Summary
- allow TurtleWriter to inline RDF collections that include explicit `rdf:type rdf:List` statements
- skip serializing redundant `rdf:type rdf:List` triples when writing well-formed collections in list form

## Testing
- `mvn -pl core/rio/turtle -Dtest=TurtleWriterTest#testRdfCollectionsListNotFullyInlined test`


------
https://chatgpt.com/codex/tasks/task_e_68e553585c7c832e8ea7df50c0d60a25