### PR TITLE
GH-4856 ensure CSV tuple MIME type declares UTF-8 charset

### DIFF
--- a/core/queryresultio/api/src/main/java/org/eclipse/rdf4j/query/resultio/TupleQueryResultFormat.java
+++ b/core/queryresultio/api/src/main/java/org/eclipse/rdf4j/query/resultio/TupleQueryResultFormat.java
@@ -81,8 +81,9 @@ public class TupleQueryResultFormat extends QueryResultFormat {
 	/**
 	 * SPARQL Query Result CSV Format.
 	 */
-	public static final TupleQueryResultFormat CSV = new TupleQueryResultFormat("SPARQL/CSV", List.of("text/csv"),
-			StandardCharsets.UTF_8, List.of("csv"), SPARQL_RESULTS_CSV_URI, NO_RDF_STAR);
+	public static final TupleQueryResultFormat CSV = new TupleQueryResultFormat("SPARQL/CSV",
+			List.of("text/csv;charset=UTF-8", "text/csv"), StandardCharsets.UTF_8, List.of("csv"),
+			SPARQL_RESULTS_CSV_URI, NO_RDF_STAR);
 
 	/**
 	 * SPARQL Query Result TSV Format.

--- a/core/queryresultio/api/src/test/java/org/eclipse/rdf4j/query/resultio/TupleQueryResultFormatTest.java
+++ b/core/queryresultio/api/src/test/java/org/eclipse/rdf4j/query/resultio/TupleQueryResultFormatTest.java
@@ -1,0 +1,17 @@
+package org.eclipse.rdf4j.query.resultio;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class TupleQueryResultFormatTest {
+
+	@Test
+	@DisplayName("CSV default MIME type should include UTF-8 charset parameter as required by spec")
+	void csvMimeTypeShouldIncludeCharsetParameter() {
+		assertThat(TupleQueryResultFormat.CSV.getDefaultMIMEType())
+				.as("MIME type should advertise UTF-8 charset")
+				.isEqualTo("text/csv;charset=UTF-8");
+	}
+}


### PR DESCRIPTION
## Summary
- ensure the SPARQL CSV tuple result default MIME type advertises charset=UTF-8 while retaining text/csv as an alias

## Testing
- `mvn -pl core/queryresultio/api test`
- `mvn -pl core/queryresultio/api formatter:format impsort:sort -Dfmt.skip=false -Dimpsort.skip=false`


------
https://chatgpt.com/codex/tasks/task_e_68e56b02cde8832e96af77f4ef837103