### PR TITLE
GH-1503 Fix filterNotExists braces

### DIFF
--- a/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/graphpattern/FilterExistsGraphPattern.java
+++ b/core/sparqlbuilder/src/main/java/org/eclipse/rdf4j/sparqlbuilder/graphpattern/FilterExistsGraphPattern.java
@@ -11,6 +11,8 @@
 
 package org.eclipse.rdf4j.sparqlbuilder.graphpattern;
 
+import org.eclipse.rdf4j.sparqlbuilder.util.SparqlBuilderUtils;
+
 /**
  * A SPARQL Graph Pattern Filter
  *
@@ -43,6 +45,13 @@ class FilterExistsGraphPattern extends GroupGraphPattern {
 		}
 		filterExists.append(EXISTS).append(" ");
 
-		return filterExists.append(super.getQueryString()).toString();
+		String innerPattern = super.getQueryString();
+		String trimmedPattern = innerPattern.trim();
+
+		if (!trimmedPattern.startsWith("{")) {
+			innerPattern = SparqlBuilderUtils.getBracedString(innerPattern);
+		}
+
+		return filterExists.append(innerPattern).toString();
 	}
 }

--- a/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/core/query/ConstructQueryFilterNotExistsTest.java
+++ b/core/sparqlbuilder/src/test/java/org/eclipse/rdf4j/sparqlbuilder/core/query/ConstructQueryFilterNotExistsTest.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.sparqlbuilder.core.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder.var;
+import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
+
+import org.eclipse.rdf4j.sparqlbuilder.core.Variable;
+import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns;
+import org.eclipse.rdf4j.sparqlbuilder.rdf.Iri;
+import org.junit.jupiter.api.Test;
+
+class ConstructQueryFilterNotExistsTest {
+
+	@Test
+	void filterNotExistsGraphPatternIsWrappedInBraces() {
+		Variable s = var("s");
+		Variable p = var("p");
+		Variable o = var("o");
+		Iri sourceGraph = iri("http://example.com/source");
+		Iri targetGraph = iri("http://example.com/target");
+
+		ConstructQuery query = Queries.CONSTRUCT()
+				.construct(GraphPatterns.tp(s, p, o))
+				.where(GraphPatterns.and(s.has(p, o).from(sourceGraph))
+						.filterNotExists(s.has(p, o).from(targetGraph)));
+
+		assertThat(query.getQueryString())
+				.contains("FILTER NOT EXISTS { GRAPH <http://example.com/target> { ?s ?p ?o . } }");
+	}
+}


### PR DESCRIPTION
## Summary
- add ConstructQueryFilterNotExistsTest to capture the missing braces bug in filterNotExists named graph patterns
- ensure FilterExistsGraphPattern braces the inner graph pattern when missing to make filterNotExists emit valid SPARQL
- update the regression test header year to 2025

## Testing
- mvn -pl core/sparqlbuilder -Dtest=ConstructQueryFilterNotExistsTest test

------
https://chatgpt.com/codex/tasks/task_e_68e569a635d0832ebe60fa2df5fb1276