### PR TITLE
Add ValueStore WAL and stabilize shutdown handling

### DIFF
--- a/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/wal/ValueKind.java
+++ b/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/wal/ValueKind.java
@@ -1,0 +1,35 @@
+package org.eclipse.rdf4j.sail.nativerdf.wal;
+
+/**
+ * Enumeration of value kinds that may be persisted in the value store WAL.
+ */
+public enum ValueKind {
+
+	IRI('I'),
+	BNODE('B'),
+	LITERAL('L'),
+	NAMESPACE('N');
+
+	private final char code;
+
+	ValueKind(char code) {
+		this.code = code;
+	}
+
+	public char code() {
+		return code;
+	}
+
+	public static ValueKind fromCode(String code) {
+		if (code == null || code.isEmpty()) {
+			throw new IllegalArgumentException("Missing value kind code");
+		}
+		char c = code.charAt(0);
+		for (ValueKind kind : values()) {
+			if (kind.code == c) {
+				return kind;
+			}
+		}
+		throw new IllegalArgumentException("Unknown value kind code: " + code);
+	}
+}

--- a/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/wal/ValueStoreWAL.java
+++ b/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/wal/ValueStoreWAL.java
@@ -1,0 +1,438 @@
+package org.eclipse.rdf4j.sail.nativerdf.wal;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.ClosedChannelException;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.zip.CRC32C;
+
+public final class ValueStoreWAL implements AutoCloseable {
+
+	static final Charset UTF8 = StandardCharsets.UTF_8;
+
+	public static final long NO_LSN = -1L;
+
+	private static final Pattern SEGMENT_PATTERN = Pattern.compile("wal-(\\d{8})\\.v1");
+
+	private final WalConfig config;
+	private final BlockingQueue<WalRecord> queue;
+	private final AtomicLong nextLsn = new AtomicLong();
+	private final AtomicLong lastAppendedLsn = new AtomicLong(NO_LSN);
+	private final AtomicLong lastForcedLsn = new AtomicLong(NO_LSN);
+	private final AtomicLong requestedForceLsn = new AtomicLong(NO_LSN);
+
+	private final Object ackMonitor = new Object();
+
+	private final LogWriter logWriter;
+	private final Thread writerThread;
+
+	private volatile boolean closed;
+	private volatile Throwable writerFailure;
+
+	private final FileChannel lockChannel;
+	private final FileLock directoryLock;
+
+	private ValueStoreWAL(WalConfig config) throws IOException {
+		this.config = Objects.requireNonNull(config, "config");
+		Files.createDirectories(config.walDirectory());
+		Files.createDirectories(config.snapshotsDirectory());
+
+		Path lockFile = config.walDirectory().resolve("lock");
+		lockChannel = FileChannel.open(lockFile, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+		try {
+			directoryLock = lockChannel.tryLock();
+		} catch (IOException e) {
+			lockChannel.close();
+			throw e;
+		}
+		if (directoryLock == null) {
+			throw new IOException("WAL directory is already locked: " + config.walDirectory());
+		}
+
+		this.queue = new ArrayBlockingQueue<>(config.queueCapacity());
+		int nextSegment = determineNextSegmentSequence(config.walDirectory());
+		this.logWriter = new LogWriter(nextSegment);
+		this.writerThread = new Thread(logWriter, "ValueStoreWalWriter-" + config.storeUuid());
+		this.writerThread.setDaemon(true);
+		this.writerThread.start();
+	}
+
+	public static ValueStoreWAL open(WalConfig config) throws IOException {
+		return new ValueStoreWAL(config);
+	}
+
+	public WalConfig config() {
+		return config;
+	}
+
+	public long logMint(int id, ValueKind kind, String lexical, String datatype, String language, int hash)
+			throws IOException {
+		ensureOpen();
+		long lsn = nextLsn.incrementAndGet();
+		WalRecord record = new WalRecord(lsn, id, kind, lexical, datatype, language, hash);
+		enqueue(record);
+		return lsn;
+	}
+
+	public void awaitDurable(long lsn) throws InterruptedException, IOException {
+		if (lsn <= NO_LSN || closed) {
+			return;
+		}
+		ensureOpen();
+		if (lastForcedLsn.get() >= lsn) {
+			return;
+		}
+		requestForce(lsn);
+		synchronized (ackMonitor) {
+			while (lastForcedLsn.get() < lsn && writerFailure == null && !closed) {
+				ackMonitor.wait(TimeUnit.MILLISECONDS.toMillis(10));
+			}
+		}
+		if (writerFailure != null) {
+			throw propagate(writerFailure);
+		}
+	}
+
+	public long lastForcedLsn() {
+		return lastForcedLsn.get();
+	}
+
+	@Override
+	public void close() throws IOException {
+		if (closed) {
+			return;
+		}
+		closed = true;
+		logWriter.shutdown();
+		try {
+			writerThread.join();
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+		}
+		try {
+			logWriter.close();
+		} finally {
+			try {
+				if (directoryLock != null && directoryLock.isValid()) {
+					directoryLock.release();
+				}
+			} finally {
+				if (lockChannel != null && lockChannel.isOpen()) {
+					lockChannel.close();
+				}
+			}
+		}
+		if (writerFailure != null) {
+			throw propagate(writerFailure);
+		}
+	}
+
+	private void requestForce(long lsn) {
+		requestedForceLsn.updateAndGet(prev -> Math.max(prev, lsn));
+	}
+
+	private void enqueue(WalRecord record) throws IOException {
+		boolean offered = false;
+		int spins = 0;
+		while (!offered) {
+			offered = queue.offer(record);
+			if (!offered) {
+				if (spins < 100) {
+					Thread.onSpinWait();
+					spins++;
+				} else {
+					try {
+						queue.put(record);
+						offered = true;
+					} catch (InterruptedException e) {
+						Thread.currentThread().interrupt();
+						throw new IOException("Interrupted while enqueueing WAL record", e);
+					}
+				}
+			}
+		}
+	}
+
+	private void ensureOpen() throws IOException {
+		if (closed) {
+			throw new IOException("WAL is closed");
+		}
+		if (writerFailure != null) {
+			throw propagate(writerFailure);
+		}
+	}
+
+	private IOException propagate(Throwable throwable) {
+		if (throwable instanceof IOException) {
+			return (IOException) throwable;
+		}
+		return new IOException("WAL writer failure", throwable);
+	}
+
+	private int determineNextSegmentSequence(Path walDirectory) throws IOException {
+		if (!Files.isDirectory(walDirectory)) {
+			return 1;
+		}
+		int max = 0;
+		try (var stream = Files.list(walDirectory)) {
+			for (Path path : stream.collect(Collectors.toList())) {
+				Matcher matcher = SEGMENT_PATTERN.matcher(path.getFileName().toString());
+				if (matcher.matches()) {
+					int seq = Integer.parseInt(matcher.group(1));
+					if (seq > max) {
+						max = seq;
+					}
+				}
+			}
+		}
+		return max + 1;
+	}
+
+	private final class LogWriter implements Runnable {
+
+		private final CRC32C crc32c = new CRC32C();
+		private final int batchSize;
+		private FileChannel segmentChannel;
+		private Path segmentPath;
+		private int segmentSequence;
+		private long segmentBytes;
+		private final ByteBuffer ioBuffer;
+		private volatile boolean running = true;
+
+		LogWriter(int initialSegment) throws IOException {
+			this.segmentSequence = initialSegment - 1;
+			this.batchSize = config.batchBufferBytes();
+			this.ioBuffer = ByteBuffer.allocateDirect(batchSize).order(ByteOrder.LITTLE_ENDIAN);
+			openNextSegment();
+		}
+
+		@Override
+		public void run() {
+			try {
+				long lastSyncCheck = System.nanoTime();
+				while (running || !queue.isEmpty()) {
+					WalRecord record;
+					try {
+						record = queue.poll(config.idlePollInterval().toNanos(), TimeUnit.NANOSECONDS);
+					} catch (InterruptedException e) {
+						if (!running) {
+							break;
+						}
+						continue;
+					}
+					if (record != null) {
+						append(record);
+					}
+					boolean pendingForce = requestedForceLsn.get() > NO_LSN
+							&& requestedForceLsn.get() > lastForcedLsn.get();
+					boolean syncIntervalElapsed = config.syncPolicy() == WalConfig.SyncPolicy.INTERVAL
+							&& System.nanoTime() - lastSyncCheck >= config.syncInterval().toNanos();
+					if (record == null) {
+						if (pendingForce || config.syncPolicy() == WalConfig.SyncPolicy.ALWAYS || syncIntervalElapsed) {
+							flushAndForce();
+							lastSyncCheck = System.nanoTime();
+						}
+					} else if (config.syncPolicy() == WalConfig.SyncPolicy.ALWAYS) {
+						flushAndForce();
+						lastSyncCheck = System.nanoTime();
+					} else if (pendingForce && requestedForceLsn.get() <= lastAppendedLsn.get()) {
+						flushAndForce();
+						lastSyncCheck = System.nanoTime();
+					}
+				}
+				flushAndForce();
+			} catch (Throwable t) {
+				writerFailure = t;
+			} finally {
+				try {
+					flushAndForce();
+				} catch (Throwable t) {
+					writerFailure = t;
+				}
+				closeQuietly(segmentChannel);
+				synchronized (ackMonitor) {
+					ackMonitor.notifyAll();
+				}
+			}
+		}
+
+		void shutdown() {
+			running = false;
+		}
+
+		void close() throws IOException {
+			closeQuietly(segmentChannel);
+		}
+
+		private void append(WalRecord record) throws IOException {
+			byte[] jsonBytes = encode(record);
+			int framedLength = 4 + jsonBytes.length + 4;
+			if (segmentBytes + framedLength > config.maxSegmentBytes()) {
+				flushBuffer();
+				rotateSegment();
+			}
+			if (ioBuffer.remaining() < framedLength) {
+				flushBuffer();
+			}
+			ioBuffer.putInt(jsonBytes.length);
+			ioBuffer.put(jsonBytes);
+			int crc = checksum(jsonBytes);
+			ioBuffer.putInt(crc);
+			segmentBytes += framedLength;
+			lastAppendedLsn.set(record.lsn());
+		}
+
+		private void flushAndForce() throws IOException {
+			if (lastAppendedLsn.get() <= lastForcedLsn.get()) {
+				return;
+			}
+			flushBuffer();
+			if (segmentChannel != null && segmentChannel.isOpen()) {
+				try {
+					segmentChannel.force(false);
+				} catch (ClosedChannelException e) {
+					// ignore; channel already closed during shutdown
+				}
+			}
+			long forced = lastAppendedLsn.get();
+			lastForcedLsn.set(forced);
+			if (requestedForceLsn.get() <= forced) {
+				requestedForceLsn.set(NO_LSN);
+			}
+			synchronized (ackMonitor) {
+				ackMonitor.notifyAll();
+			}
+		}
+
+		private void flushBuffer() throws IOException {
+			ioBuffer.flip();
+			while (ioBuffer.hasRemaining()) {
+				segmentChannel.write(ioBuffer);
+			}
+			ioBuffer.clear();
+		}
+
+		private void rotateSegment() throws IOException {
+			closeQuietly(segmentChannel);
+			openNextSegment();
+		}
+
+		private void openNextSegment() throws IOException {
+			segmentSequence++;
+			String fileName = String.format("wal-%08d.v1", segmentSequence);
+			segmentPath = config.walDirectory().resolve(fileName);
+			segmentChannel = FileChannel.open(segmentPath, StandardOpenOption.CREATE, StandardOpenOption.WRITE,
+					StandardOpenOption.APPEND);
+			segmentBytes = Files.size(segmentPath);
+			if (segmentBytes == 0L) {
+				writeHeader();
+			}
+		}
+
+		private void writeHeader() throws IOException {
+			String json = String.format(
+					"{\"t\":\"V\",\"ver\":1,\"store\":\"%s\",\"engine\":\"valuestore\",\"created\":%d,\"segment\":%d}",
+					config.storeUuid(), Instant.now().getEpochSecond(), segmentSequence);
+			byte[] jsonBytes = json.getBytes(UTF8);
+			ByteBuffer buffer = ByteBuffer.allocate(4 + jsonBytes.length + 4).order(ByteOrder.LITTLE_ENDIAN);
+			buffer.putInt(jsonBytes.length);
+			buffer.put(jsonBytes);
+			int crc = checksum(jsonBytes);
+			buffer.putInt(crc);
+			buffer.flip();
+			while (buffer.hasRemaining()) {
+				segmentChannel.write(buffer);
+			}
+			segmentBytes += buffer.limit();
+		}
+
+		private int checksum(byte[] data) {
+			crc32c.reset();
+			crc32c.update(data, 0, data.length);
+			return (int) crc32c.getValue();
+		}
+
+		private byte[] encode(WalRecord record) {
+			StringBuilder sb = new StringBuilder();
+			sb.append('{');
+			sb.append("\"t\":\"M\",");
+			sb.append("\"lsn\":").append(record.lsn()).append(',');
+			sb.append("\"id\":").append(record.id()).append(',');
+			sb.append("\"vk\":\"").append(record.valueKind().code()).append("\",");
+			appendStringField(sb, "lex", record.lexical());
+			sb.append(',');
+			appendStringField(sb, "dt", record.datatype());
+			sb.append(',');
+			appendStringField(sb, "lang", record.language());
+			sb.append(',');
+			sb.append("\"hash\":").append(record.hash());
+			sb.append('}');
+			return sb.toString().getBytes(UTF8);
+		}
+
+		private void appendStringField(StringBuilder sb, String name, String value) {
+			sb.append('"').append(name).append('"').append(':').append('"');
+			if (value != null) {
+				for (int i = 0; i < value.length(); i++) {
+					char c = value.charAt(i);
+					switch (c) {
+					case '\\':
+						sb.append("\\\\");
+						break;
+					case '"':
+						sb.append("\\\"");
+						break;
+					case '\b':
+						sb.append("\\b");
+						break;
+					case '\f':
+						sb.append("\\f");
+						break;
+					case '\n':
+						sb.append("\\n");
+						break;
+					case '\r':
+						sb.append("\\r");
+						break;
+					case '\t':
+						sb.append("\\t");
+						break;
+					default:
+						if (c < 0x20) {
+							sb.append(String.format("\\u%04x", (int) c));
+						} else {
+							sb.append(c);
+						}
+					}
+				}
+			}
+			sb.append('"');
+		}
+
+		private void closeQuietly(FileChannel channel) {
+			if (channel != null) {
+				try {
+					channel.close();
+				} catch (IOException ignore) {
+					// ignore
+				}
+			}
+		}
+	}
+}

--- a/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/wal/WalConfig.java
+++ b/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/wal/WalConfig.java
@@ -1,0 +1,162 @@
+package org.eclipse.rdf4j.sail.nativerdf.wal;
+
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Objects;
+
+public final class WalConfig {
+
+	public enum SyncPolicy {
+		ALWAYS,
+		INTERVAL,
+		COMMIT
+	}
+
+	private final Path walDirectory;
+	private final Path snapshotsDirectory;
+	private final String storeUuid;
+	private final long maxSegmentBytes;
+	private final int queueCapacity;
+	private final int batchBufferBytes;
+	private final SyncPolicy syncPolicy;
+	private final Duration syncInterval;
+	private final Duration idlePollInterval;
+
+	private WalConfig(Builder builder) {
+		this.walDirectory = builder.walDirectory;
+		this.snapshotsDirectory = builder.snapshotsDirectory;
+		this.storeUuid = builder.storeUuid;
+		this.maxSegmentBytes = builder.maxSegmentBytes;
+		this.queueCapacity = builder.queueCapacity;
+		this.batchBufferBytes = builder.batchBufferBytes;
+		this.syncPolicy = builder.syncPolicy;
+		this.syncInterval = builder.syncInterval;
+		this.idlePollInterval = builder.idlePollInterval;
+	}
+
+	public Path walDirectory() {
+		return walDirectory;
+	}
+
+	public Path snapshotsDirectory() {
+		return snapshotsDirectory;
+	}
+
+	public String storeUuid() {
+		return storeUuid;
+	}
+
+	public long maxSegmentBytes() {
+		return maxSegmentBytes;
+	}
+
+	public int queueCapacity() {
+		return queueCapacity;
+	}
+
+	public int batchBufferBytes() {
+		return batchBufferBytes;
+	}
+
+	public SyncPolicy syncPolicy() {
+		return syncPolicy;
+	}
+
+	public Duration syncInterval() {
+		return syncInterval;
+	}
+
+	public Duration idlePollInterval() {
+		return idlePollInterval;
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public static final class Builder {
+
+		private Path walDirectory;
+		private Path snapshotsDirectory;
+		private String storeUuid;
+		private long maxSegmentBytes = 1L << 30; // 1 GB
+		private int queueCapacity = 262_144;
+		private int batchBufferBytes = 1 << 20; // 1 MB
+		private SyncPolicy syncPolicy = SyncPolicy.COMMIT;
+		private Duration syncInterval = Duration.ofMillis(2);
+		private Duration idlePollInterval = Duration.ofMillis(1);
+
+		private Builder() {
+		}
+
+		public Builder walDirectory(Path walDirectory) {
+			this.walDirectory = Objects.requireNonNull(walDirectory, "walDirectory");
+			if (this.snapshotsDirectory == null) {
+				this.snapshotsDirectory = walDirectory.resolve("snapshots");
+			}
+			return this;
+		}
+
+		public Builder snapshotsDirectory(Path snapshotsDirectory) {
+			this.snapshotsDirectory = Objects.requireNonNull(snapshotsDirectory, "snapshotsDirectory");
+			return this;
+		}
+
+		public Builder storeUuid(String storeUuid) {
+			this.storeUuid = Objects.requireNonNull(storeUuid, "storeUuid");
+			return this;
+		}
+
+		public Builder maxSegmentBytes(long maxSegmentBytes) {
+			this.maxSegmentBytes = maxSegmentBytes;
+			return this;
+		}
+
+		public Builder queueCapacity(int queueCapacity) {
+			this.queueCapacity = queueCapacity;
+			return this;
+		}
+
+		public Builder batchBufferBytes(int batchBufferBytes) {
+			this.batchBufferBytes = batchBufferBytes;
+			return this;
+		}
+
+		public Builder syncPolicy(SyncPolicy syncPolicy) {
+			this.syncPolicy = Objects.requireNonNull(syncPolicy, "syncPolicy");
+			return this;
+		}
+
+		public Builder syncInterval(Duration syncInterval) {
+			this.syncInterval = Objects.requireNonNull(syncInterval, "syncInterval");
+			return this;
+		}
+
+		public Builder idlePollInterval(Duration idlePollInterval) {
+			this.idlePollInterval = Objects.requireNonNull(idlePollInterval, "idlePollInterval");
+			return this;
+		}
+
+		public WalConfig build() {
+			if (walDirectory == null) {
+				throw new IllegalStateException("walDirectory must be set");
+			}
+			if (snapshotsDirectory == null) {
+				snapshotsDirectory = walDirectory.resolve("snapshots");
+			}
+			if (storeUuid == null || storeUuid.isEmpty()) {
+				throw new IllegalStateException("storeUuid must be set");
+			}
+			if (maxSegmentBytes <= 0) {
+				throw new IllegalStateException("maxSegmentBytes must be positive");
+			}
+			if (queueCapacity <= 0) {
+				throw new IllegalStateException("queueCapacity must be positive");
+			}
+			if (batchBufferBytes <= 4096) {
+				throw new IllegalStateException("batchBufferBytes must be > 4KB");
+			}
+			return new WalConfig(this);
+		}
+	}
+}

--- a/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/wal/WalReader.java
+++ b/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/wal/WalReader.java
@@ -1,0 +1,259 @@
+package org.eclipse.rdf4j.sail.nativerdf.wal;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.regex.Pattern;
+import java.util.zip.CRC32C;
+
+public final class WalReader implements AutoCloseable {
+
+	private static final Pattern SEGMENT_PATTERN = Pattern.compile("wal-\\d{8}\\.v1");
+
+	private final WalConfig config;
+
+	private WalReader(WalConfig config) {
+		this.config = Objects.requireNonNull(config, "config");
+	}
+
+	public static WalReader open(WalConfig config) {
+		return new WalReader(config);
+	}
+
+	public ScanResult scan() throws IOException {
+		List<Path> segments = listSegments();
+		List<WalRecord> records = new ArrayList<>();
+		long lastValidLsn = ValueStoreWAL.NO_LSN;
+
+		for (Path segment : segments) {
+			try (FileChannel channel = FileChannel.open(segment, StandardOpenOption.READ)) {
+				ByteBuffer header = ByteBuffer.allocate(4).order(ByteOrder.LITTLE_ENDIAN);
+				while (true) {
+					header.clear();
+					int read = channel.read(header);
+					if (read == -1) {
+						break;
+					}
+					if (read < 4) {
+						// truncated record, stop scanning
+						return new ScanResult(records, lastValidLsn);
+					}
+					header.flip();
+					int length = header.getInt();
+					if (length <= 0 || length > config.batchBufferBytes() * 4) {
+						return new ScanResult(records, lastValidLsn);
+					}
+
+					ByteBuffer dataBuffer = ByteBuffer.allocate(length);
+					int bytesRead = channel.read(dataBuffer);
+					if (bytesRead < length) {
+						return new ScanResult(records, lastValidLsn);
+					}
+
+					ByteBuffer crcBuffer = ByteBuffer.allocate(4).order(ByteOrder.LITTLE_ENDIAN);
+					int crcRead = channel.read(crcBuffer);
+					if (crcRead < 4) {
+						return new ScanResult(records, lastValidLsn);
+					}
+					crcBuffer.flip();
+					int expectedCrc = crcBuffer.getInt();
+
+					byte[] jsonBytes = dataBuffer.array();
+					CRC32C crc32c = new CRC32C();
+					crc32c.update(jsonBytes, 0, jsonBytes.length);
+					if ((int) crc32c.getValue() != expectedCrc) {
+						return new ScanResult(records, lastValidLsn);
+					}
+
+					String json = new String(jsonBytes, ValueStoreWAL.UTF8);
+					char type = extractType(json);
+					if (type == 'M') {
+						WalRecord record = parseMintRecord(json);
+						records.add(record);
+						lastValidLsn = record.lsn();
+					} else {
+						// ignore other record types for now
+						long lsn = parseLong(json, "lsn", ValueStoreWAL.NO_LSN);
+						if (lsn > lastValidLsn) {
+							lastValidLsn = lsn;
+						}
+					}
+				}
+			}
+		}
+
+		return new ScanResult(records, lastValidLsn);
+	}
+
+	private List<Path> listSegments() throws IOException {
+		List<Path> segments = new ArrayList<>();
+		if (!Files.isDirectory(config.walDirectory())) {
+			return segments;
+		}
+		try (var stream = Files.list(config.walDirectory())) {
+			stream.filter(path -> SEGMENT_PATTERN.matcher(path.getFileName().toString()).matches())
+					.sorted(Comparator.naturalOrder())
+					.forEach(segments::add);
+		}
+		return segments;
+	}
+
+	private static char extractType(String json) {
+		int idx = json.indexOf("\"t\"");
+		if (idx < 0) {
+			return '?';
+		}
+		int colon = json.indexOf(':', idx);
+		if (colon < 0) {
+			return '?';
+		}
+		for (int i = colon + 1; i < json.length(); i++) {
+			char c = json.charAt(i);
+			if (c == '"') {
+				int end = json.indexOf('"', i + 1);
+				if (end > i) {
+					return json.charAt(i + 1);
+				}
+				return '?';
+			} else if (!Character.isWhitespace(c)) {
+				return c;
+			}
+		}
+		return '?';
+	}
+
+	private WalRecord parseMintRecord(String json) {
+		long lsn = parseLong(json, "lsn", 0L);
+		int id = (int) parseLong(json, "id", 0L);
+		String valueKindCode = parseString(json, "vk");
+		ValueKind kind = ValueKind.fromCode(valueKindCode);
+		String lexical = parseString(json, "lex");
+		String datatype = parseString(json, "dt");
+		String language = parseString(json, "lang");
+		int hash = (int) parseLong(json, "hash", 0L);
+		return new WalRecord(lsn, id, kind, lexical, datatype, language, hash);
+	}
+
+	private static long parseLong(String json, String key, long defaultValue) {
+		int idx = json.indexOf('"' + key + '"');
+		if (idx < 0) {
+			return defaultValue;
+		}
+		int colon = json.indexOf(':', idx);
+		if (colon < 0) {
+			return defaultValue;
+		}
+		int start = colon + 1;
+		while (start < json.length() && Character.isWhitespace(json.charAt(start))) {
+			start++;
+		}
+		int end = start;
+		while (end < json.length()) {
+			char c = json.charAt(end);
+			if (c == ',' || c == '}') {
+				break;
+			}
+			end++;
+		}
+		if (start >= end) {
+			return defaultValue;
+		}
+		try {
+			return Long.parseLong(json.substring(start, end).trim());
+		} catch (NumberFormatException e) {
+			return defaultValue;
+		}
+	}
+
+	private static String parseString(String json, String key) {
+		int idx = json.indexOf('"' + key + '"');
+		if (idx < 0) {
+			return "";
+		}
+		int colon = json.indexOf(':', idx);
+		if (colon < 0) {
+			return "";
+		}
+		int quote = json.indexOf('"', colon);
+		if (quote < 0) {
+			return "";
+		}
+		StringBuilder sb = new StringBuilder();
+		for (int i = quote + 1; i < json.length(); i++) {
+			char c = json.charAt(i);
+			if (c == '"') {
+				return sb.toString();
+			} else if (c == '\\') {
+				if (i + 1 >= json.length()) {
+					break;
+				}
+				char esc = json.charAt(++i);
+				switch (esc) {
+				case '"':
+				case '\\':
+				case '/':
+					sb.append(esc);
+					break;
+				case 'b':
+					sb.append('\b');
+					break;
+				case 'f':
+					sb.append('\f');
+					break;
+				case 'n':
+					sb.append('\n');
+					break;
+				case 'r':
+					sb.append('\r');
+					break;
+				case 't':
+					sb.append('\t');
+					break;
+				case 'u':
+					if (i + 4 < json.length()) {
+						String hex = json.substring(i + 1, i + 5);
+						sb.append((char) Integer.parseInt(hex, 16));
+						i += 4;
+					}
+					break;
+				default:
+					sb.append(esc);
+				}
+			} else {
+				sb.append(c);
+			}
+		}
+		return sb.toString();
+	}
+
+	@Override
+	public void close() {
+		// no state to close
+	}
+
+	public static final class ScanResult {
+		private final List<WalRecord> records;
+		private final long lastValidLsn;
+
+		public ScanResult(List<WalRecord> records, long lastValidLsn) {
+			this.records = List.copyOf(records);
+			this.lastValidLsn = lastValidLsn;
+		}
+
+		public List<WalRecord> records() {
+			return records;
+		}
+
+		public long lastValidLsn() {
+			return lastValidLsn;
+		}
+	}
+}

--- a/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/wal/WalRecord.java
+++ b/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/wal/WalRecord.java
@@ -1,0 +1,56 @@
+package org.eclipse.rdf4j.sail.nativerdf.wal;
+
+import java.util.Objects;
+
+/**
+ * Representation of a single WAL record describing a minted value.
+ */
+public final class WalRecord {
+
+	private final long lsn;
+	private final int id;
+	private final ValueKind valueKind;
+	private final String lexical;
+	private final String datatype;
+	private final String language;
+	private final int hash;
+
+	public WalRecord(long lsn, int id, ValueKind valueKind, String lexical, String datatype, String language,
+			int hash) {
+		this.lsn = lsn;
+		this.id = id;
+		this.valueKind = Objects.requireNonNull(valueKind, "valueKind");
+		this.lexical = lexical == null ? "" : lexical;
+		this.datatype = datatype == null ? "" : datatype;
+		this.language = language == null ? "" : language;
+		this.hash = hash;
+	}
+
+	public long lsn() {
+		return lsn;
+	}
+
+	public int id() {
+		return id;
+	}
+
+	public ValueKind valueKind() {
+		return valueKind;
+	}
+
+	public String lexical() {
+		return lexical;
+	}
+
+	public String datatype() {
+		return datatype;
+	}
+
+	public String language() {
+		return language;
+	}
+
+	public int hash() {
+		return hash;
+	}
+}

--- a/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/wal/WalRecovery.java
+++ b/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/wal/WalRecovery.java
@@ -1,0 +1,17 @@
+package org.eclipse.rdf4j.sail.nativerdf.wal;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public final class WalRecovery {
+
+	public Map<Integer, WalRecord> replay(WalReader reader) throws IOException {
+		WalReader.ScanResult scan = reader.scan();
+		Map<Integer, WalRecord> dictionary = new LinkedHashMap<>();
+		for (WalRecord record : scan.records()) {
+			dictionary.putIfAbsent(record.id(), record);
+		}
+		return dictionary;
+	}
+}

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/wal/ValueStoreWalIntegrationTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/wal/ValueStoreWalIntegrationTest.java
@@ -1,0 +1,108 @@
+package org.eclipse.rdf4j.sail.nativerdf.wal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.OptionalLong;
+import java.util.UUID;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.XMLSchema;
+import org.eclipse.rdf4j.sail.nativerdf.ValueStore;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ValueStoreWalIntegrationTest {
+
+	private static final ValueFactory VF = SimpleValueFactory.getInstance();
+
+	@TempDir
+	Path tempDir;
+
+	@Test
+	void logsMintedValueRecords() throws Exception {
+		Path walDir = tempDir.resolve("wal");
+		Files.createDirectories(walDir);
+		WalConfig config = WalConfig.builder()
+				.walDirectory(walDir)
+				.storeUuid(UUID.randomUUID().toString())
+				.build();
+
+		try (ValueStoreWAL wal = ValueStoreWAL.open(config)) {
+			File valueDir = tempDir.resolve("values").toFile();
+			Files.createDirectories(valueDir.toPath());
+			try (ValueStore store = new ValueStore(valueDir, false, ValueStore.VALUE_CACHE_SIZE,
+					ValueStore.VALUE_ID_CACHE_SIZE, ValueStore.NAMESPACE_CACHE_SIZE,
+					ValueStore.NAMESPACE_ID_CACHE_SIZE, wal)) {
+				Literal literal = VF.createLiteral("hello");
+				store.storeValue(literal);
+
+				OptionalLong lsn = store.drainPendingWalHighWaterMark();
+				assertThat(lsn).isPresent();
+
+				wal.awaitDurable(lsn.getAsLong());
+			}
+
+			WalReader reader = WalReader.open(config);
+			WalReader.ScanResult scan = reader.scan();
+			reader.close();
+
+			assertThat(scan.records()).hasSize(3);
+			assertThat(scan.records())
+					.anyMatch(record -> record.valueKind() == ValueKind.NAMESPACE
+							&& record.lexical().equals(XMLSchema.NAMESPACE));
+			assertThat(scan.records())
+					.anyMatch(record -> record.valueKind() == ValueKind.IRI
+							&& record.lexical().equals(XMLSchema.STRING.stringValue()));
+			assertThat(scan.records())
+					.anyMatch(record -> record.valueKind() == ValueKind.LITERAL
+							&& record.lexical().equals("hello")
+							&& record.datatype().equals(XMLSchema.STRING.stringValue()));
+		}
+	}
+
+	@Test
+	void recoveryRebuildsMintedEntries() throws Exception {
+		Path walDir = tempDir.resolve("wal2");
+		Files.createDirectories(walDir);
+		WalConfig config = WalConfig.builder()
+				.walDirectory(walDir)
+				.storeUuid(UUID.randomUUID().toString())
+				.build();
+
+		Literal literal = VF.createLiteral("world", "en");
+		IRI datatype = VF.createIRI("http://example.com/datatype");
+
+		try (ValueStoreWAL wal = ValueStoreWAL.open(config)) {
+			File valueDir = tempDir.resolve("values2").toFile();
+			Files.createDirectories(valueDir.toPath());
+			try (ValueStore store = new ValueStore(valueDir, false, ValueStore.VALUE_CACHE_SIZE,
+					ValueStore.VALUE_ID_CACHE_SIZE, ValueStore.NAMESPACE_CACHE_SIZE,
+					ValueStore.NAMESPACE_ID_CACHE_SIZE, wal)) {
+				store.storeValue(literal);
+				store.storeValue(VF.createIRI("http://example.com/resource"));
+				store.storeValue(datatype);
+				OptionalLong lsn = store.drainPendingWalHighWaterMark();
+				assertThat(lsn).isPresent();
+				wal.awaitDurable(lsn.getAsLong());
+			}
+		}
+
+		try (WalReader reader = WalReader.open(config)) {
+			WalRecovery recovery = new WalRecovery();
+			Map<Integer, WalRecord> dictionary = recovery.replay(reader);
+			assertThat(dictionary).isNotEmpty();
+			assertThat(dictionary.values())
+					.anyMatch(record -> record.valueKind() == ValueKind.LITERAL && record.lexical().equals("world"));
+			assertThat(dictionary.values())
+					.anyMatch(record -> record.valueKind() == ValueKind.IRI
+							&& record.lexical().equals("http://example.com/resource"));
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add a framed JSON write-ahead log implementation for the NativeStore value dictionary, including the supporting reader and recovery tooling
- integrate the ValueStore and NativeSailStore with the WAL so minted value and namespace IDs are logged and commits can await durability
- cover the WAL with an integration test that verifies logging and recovery behaviour, accounting for namespace and datatype entries, and avoid interrupting the logging thread during durability waits

## Testing
- mvn -pl core/sail/nativerdf test -Dtest=ValueStoreWalIntegrationTest

------
https://chatgpt.com/codex/tasks/task_e_68e6929c0bcc832eb0c5a459cdf8c4c1