### PR TITLE
Implement write-ahead logging for ValueStore mint operations

### DIFF
--- a/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/ValueStoreWriteAheadLog.java
+++ b/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/ValueStoreWriteAheadLog.java
@@ -1,0 +1,445 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.nativerdf;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.time.Duration;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.eclipse.rdf4j.model.BNode;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Value;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Append-only write-ahead log for {@link ValueStore} mint operations. Log entries are written in NDJSON format and
+ * flushed from a background thread.
+ */
+final class ValueStoreWriteAheadLog implements Closeable {
+
+	static final String DEFAULT_FILENAME = "values.wal";
+	private static final Logger logger = LoggerFactory.getLogger(ValueStoreWriteAheadLog.class);
+	private static final int DEFAULT_QUEUE_CAPACITY = 8192;
+	private static final int DEFAULT_MAX_BATCH = 256;
+	private static final Duration DEFAULT_FLUSH_INTERVAL = Duration.ofMillis(50);
+
+	private final FileChannel channel;
+	private final BlockingQueue<WalEntry> queue;
+	private final Thread writerThread;
+	private final AtomicLong sequence;
+	private final boolean forceSync;
+	private final int maxBatch;
+	private final long flushIntervalNanos;
+	private final AtomicReference<IOException> failure = new AtomicReference<>();
+
+	private volatile boolean shutdownRequested;
+
+	ValueStoreWriteAheadLog(File dataDir, boolean forceSync) throws IOException {
+		this(dataDir.toPath().resolve(DEFAULT_FILENAME), forceSync, DEFAULT_QUEUE_CAPACITY, DEFAULT_MAX_BATCH,
+				DEFAULT_FLUSH_INTERVAL);
+	}
+
+	ValueStoreWriteAheadLog(Path walPath, boolean forceSync, int queueCapacity, int maxBatch, Duration flushInterval)
+			throws IOException {
+		Objects.requireNonNull(walPath, "walPath");
+		this.forceSync = forceSync;
+		this.maxBatch = Math.max(1, maxBatch);
+		this.flushIntervalNanos = Math.max(0L, flushInterval.toNanos());
+		Files.createDirectories(walPath.getParent());
+		this.channel = FileChannel.open(walPath, StandardOpenOption.CREATE, StandardOpenOption.WRITE,
+				StandardOpenOption.APPEND);
+		this.sequence = new AtomicLong(determineStartingSequence(walPath.toFile()));
+		this.queue = new LinkedBlockingQueue<>(queueCapacity);
+		this.writerThread = new Thread(this::runWriter, "ValueStoreWalWriter-" + walPath.getFileName());
+		this.writerThread.setDaemon(true);
+		this.writerThread.start();
+	}
+
+	void recordValue(int id, Value value) throws IOException {
+		Objects.requireNonNull(value, "value");
+		enqueue(WalEntry.data(serializeValue(sequence.incrementAndGet(), id, value)));
+	}
+
+	void recordNamespace(int id, String namespace) throws IOException {
+		Objects.requireNonNull(namespace, "namespace");
+		enqueue(WalEntry.data(serializeNamespace(sequence.incrementAndGet(), id, namespace)));
+	}
+
+	void sync() throws IOException {
+		CountDownLatch latch = new CountDownLatch(1);
+		enqueue(WalEntry.sync(latch));
+		await(latch);
+	}
+
+	void reset() throws IOException {
+		CountDownLatch latch = new CountDownLatch(1);
+		enqueue(WalEntry.truncate(latch));
+		await(latch);
+	}
+
+	@Override
+	public void close() throws IOException {
+		if (shutdownRequested) {
+			waitForShutdown();
+			return;
+		}
+
+		shutdownRequested = true;
+		CountDownLatch latch = new CountDownLatch(1);
+		enqueue(WalEntry.shutdown(latch));
+		await(latch);
+		waitForShutdown();
+	}
+
+	private void waitForShutdown() throws IOException {
+		boolean interrupted = false;
+		try {
+			while (writerThread.isAlive()) {
+				try {
+					writerThread.join();
+				} catch (InterruptedException e) {
+					interrupted = true;
+				}
+			}
+		} finally {
+			if (interrupted) {
+				Thread.currentThread().interrupt();
+			}
+		}
+		propagateFailureIfPresent();
+	}
+
+	private void enqueue(WalEntry entry) throws IOException {
+		propagateFailureIfPresent();
+		try {
+			queue.put(entry);
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			throw new IOException("Interrupted while enqueuing WAL entry", e);
+		}
+	}
+
+	private void await(CountDownLatch latch) throws IOException {
+		boolean interrupted = false;
+		try {
+			while (true) {
+				try {
+					if (latch.await(5, TimeUnit.SECONDS)) {
+						break;
+					}
+				} catch (InterruptedException e) {
+					interrupted = true;
+				}
+				propagateFailureIfPresent();
+			}
+		} finally {
+			if (interrupted) {
+				Thread.currentThread().interrupt();
+			}
+		}
+		propagateFailureIfPresent();
+	}
+
+	private void runWriter() {
+		int pendingEntries = 0;
+		long lastFlush = System.nanoTime();
+		try {
+			while (true) {
+				WalEntry entry = queue.poll(100, TimeUnit.MILLISECONDS);
+				if (entry == null) {
+					if (!forceSync && pendingEntries > 0 && shouldFlush(lastFlush)) {
+						forceChannel();
+						pendingEntries = 0;
+						lastFlush = System.nanoTime();
+					}
+					if (shutdownRequested && queue.isEmpty()) {
+						break;
+					}
+					continue;
+				}
+
+				try {
+					if (entry.payload != null) {
+						write(entry.payload);
+						pendingEntries++;
+					}
+
+					boolean flushNow = forceSync || entry.flush || pendingEntries >= maxBatch
+							|| (pendingEntries > 0 && shouldFlush(lastFlush));
+
+					if (flushNow) {
+						forceChannel();
+						pendingEntries = 0;
+						lastFlush = System.nanoTime();
+					}
+
+					if (entry.truncate) {
+						channel.truncate(0L);
+						channel.position(0L);
+						pendingEntries = 0;
+						lastFlush = System.nanoTime();
+					}
+
+					if (entry.shutdown) {
+						break;
+					}
+				} finally {
+					if (entry.completion != null) {
+						entry.completion.countDown();
+					}
+				}
+			}
+			if (pendingEntries > 0) {
+				forceChannel();
+			}
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			failure.compareAndSet(null, new IOException("WAL writer interrupted", e));
+		} catch (IOException e) {
+			failure.compareAndSet(null, e);
+		} catch (RuntimeException e) {
+			failure.compareAndSet(null, new IOException("Unexpected WAL writer failure", e));
+		} finally {
+			try {
+				channel.force(true);
+			} catch (IOException e) {
+				failure.compareAndSet(null, e);
+			}
+			try {
+				channel.close();
+			} catch (IOException e) {
+				failure.compareAndSet(null, e);
+			}
+			drainPendingEntries();
+		}
+	}
+
+	private void drainPendingEntries() {
+		WalEntry entry;
+		while ((entry = queue.poll()) != null) {
+			if (entry.completion != null) {
+				entry.completion.countDown();
+			}
+		}
+	}
+
+	private boolean shouldFlush(long lastFlush) {
+		if (flushIntervalNanos == 0) {
+			return false;
+		}
+		return System.nanoTime() - lastFlush >= flushIntervalNanos;
+	}
+
+	private void write(byte[] payload) throws IOException {
+		ByteBuffer buffer = ByteBuffer.wrap(payload);
+		while (buffer.hasRemaining()) {
+			channel.write(buffer);
+		}
+	}
+
+	private void forceChannel() throws IOException {
+		channel.force(true);
+	}
+
+	private void propagateFailureIfPresent() throws IOException {
+		IOException ex = failure.get();
+		if (ex != null) {
+			throw ex;
+		}
+	}
+
+	private static long determineStartingSequence(File walFile) {
+		if (!walFile.exists() || walFile.length() == 0) {
+			return 0L;
+		}
+
+		try (RandomAccessFile raf = new RandomAccessFile(walFile, "r")) {
+			long filePointer = raf.length() - 1;
+			if (filePointer < 0) {
+				return 0L;
+			}
+
+			// seek to start of last line
+			while (filePointer >= 0) {
+				raf.seek(filePointer);
+				if (raf.read() == '\n' && filePointer != raf.length() - 1) {
+					break;
+				}
+				filePointer--;
+			}
+			if (filePointer < 0) {
+				raf.seek(0);
+			} else {
+				raf.seek(filePointer + 1);
+			}
+			String line = raf.readLine();
+			if (line == null) {
+				return 0L;
+			}
+			int seqIndex = line.indexOf("\"seq\":");
+			if (seqIndex < 0) {
+				return 0L;
+			}
+			int start = seqIndex + 6;
+			int end = start;
+			while (end < line.length() && Character.isDigit(line.charAt(end))) {
+				end++;
+			}
+			if (start == end) {
+				return 0L;
+			}
+			return Long.parseLong(line.substring(start, end));
+		} catch (IOException | NumberFormatException e) {
+			logger.warn("Failed to determine last WAL sequence number, starting from 0", e);
+			return 0L;
+		}
+	}
+
+	private static byte[] serializeValue(long seq, int id, Value value) {
+		StringBuilder sb = new StringBuilder(128);
+		sb.append('{');
+		appendNumberField(sb, "seq", seq);
+		appendNumberField(sb, "id", id);
+		appendStringField(sb, "valueType", valueType(value));
+		appendStringField(sb, "value", value.stringValue());
+		if (value instanceof Literal) {
+			Literal literal = (Literal) value;
+			appendStringField(sb, "datatype", literal.getDatatype().stringValue());
+			literal.getLanguage().ifPresent(lang -> appendStringField(sb, "language", lang));
+		}
+		sb.append('}').append('\n');
+		return sb.toString().getBytes(StandardCharsets.UTF_8);
+	}
+
+	private static byte[] serializeNamespace(long seq, int id, String namespace) {
+		StringBuilder sb = new StringBuilder(96);
+		sb.append('{');
+		appendNumberField(sb, "seq", seq);
+		appendNumberField(sb, "id", id);
+		appendStringField(sb, "valueType", "NAMESPACE");
+		appendStringField(sb, "value", namespace);
+		sb.append('}').append('\n');
+		return sb.toString().getBytes(StandardCharsets.UTF_8);
+	}
+
+	private static void appendNumberField(StringBuilder sb, String name, long value) {
+		if (sb.charAt(sb.length() - 1) != '{') {
+			sb.append(',');
+		}
+		sb.append('"').append(name).append('"').append(':').append(value);
+	}
+
+	private static void appendStringField(StringBuilder sb, String name, String value) {
+		if (sb.charAt(sb.length() - 1) != '{') {
+			sb.append(',');
+		}
+		sb.append('"').append(name).append('"').append(':').append('"');
+		appendEscaped(sb, value);
+		sb.append('"');
+	}
+
+	private static String valueType(Value value) {
+		if (value instanceof IRI) {
+			return "IRI";
+		} else if (value instanceof BNode) {
+			return "BNODE";
+		} else if (value instanceof Literal) {
+			return "LITERAL";
+		}
+		return value.getClass().getSimpleName();
+	}
+
+	private static void appendEscaped(StringBuilder sb, String value) {
+		for (int i = 0, len = value.length(); i < len; i++) {
+			char ch = value.charAt(i);
+			switch (ch) {
+			case '\\':
+				sb.append("\\\\");
+				break;
+			case '\"':
+				sb.append("\\\"");
+				break;
+			case '\b':
+				sb.append("\\b");
+				break;
+			case '\f':
+				sb.append("\\f");
+				break;
+			case '\n':
+				sb.append("\\n");
+				break;
+			case '\r':
+				sb.append("\\r");
+				break;
+			case '\t':
+				sb.append("\\t");
+				break;
+			default:
+				if (ch < 0x20 || Character.isSurrogate(ch)) {
+					sb.append(String.format(Locale.ROOT, "\\u%04x", (int) ch));
+				} else {
+					sb.append(ch);
+				}
+				break;
+			}
+		}
+	}
+
+	private static final class WalEntry {
+		final byte[] payload;
+		final boolean flush;
+		final boolean truncate;
+		final boolean shutdown;
+		final CountDownLatch completion;
+
+		private WalEntry(byte[] payload, boolean flush, boolean truncate, boolean shutdown, CountDownLatch completion) {
+			this.payload = payload;
+			this.flush = flush;
+			this.truncate = truncate;
+			this.shutdown = shutdown;
+			this.completion = completion;
+		}
+
+		static WalEntry data(byte[] payload) {
+			return new WalEntry(payload, false, false, false, null);
+		}
+
+		static WalEntry sync(CountDownLatch latch) {
+			return new WalEntry(null, true, false, false, latch);
+		}
+
+		static WalEntry truncate(CountDownLatch latch) {
+			return new WalEntry(null, true, true, false, latch);
+		}
+
+		static WalEntry shutdown(CountDownLatch latch) {
+			return new WalEntry(null, true, false, true, latch);
+		}
+	}
+}

--- a/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/datastore/DataStore.java
+++ b/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/datastore/DataStore.java
@@ -123,18 +123,42 @@ public class DataStore implements Closeable {
 	 * @throws IOException If an I/O error occurred.
 	 */
 	public int storeData(byte[] data) throws IOException {
+		return storeDataWithInfo(data).getId();
+	}
+
+	public StoreResult storeDataWithInfo(byte[] data) throws IOException {
 		assert data != null : "data must not be null";
 
 		int id = getID(data);
+		boolean created = false;
 
 		if (id == -1) {
 			// Data not stored yet, store it under a new ID.
 			long offset = dataFile.storeData(data);
 			id = idFile.storeOffset(offset);
 			hashFile.storeID(getDataHash(data), id);
+			created = true;
 		}
 
-		return id;
+		return new StoreResult(id, created);
+	}
+
+	public static final class StoreResult {
+		private final int id;
+		private final boolean newlyCreated;
+
+		StoreResult(int id, boolean newlyCreated) {
+			this.id = id;
+			this.newlyCreated = newlyCreated;
+		}
+
+		public int getId() {
+			return id;
+		}
+
+		public boolean isNewlyCreated() {
+			return newlyCreated;
+		}
 	}
 
 	/**

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreTxnTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/NativeStoreTxnTest.java
@@ -17,9 +17,11 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.nio.file.Files;
+import java.util.Arrays;
 
 import org.eclipse.rdf4j.common.io.NioFile;
 import org.eclipse.rdf4j.model.IRI;
@@ -83,10 +85,20 @@ public class NativeStoreTxnTest {
 		File repoDir = repo.getDataDir();
 		System.out.println("Data dir: " + repoDir);
 
-		for (File file : repoDir.listFiles()) {
+		File[] repoFiles = repoDir.listFiles();
+		assertNotNull(repoFiles);
+
+		for (File file : repoFiles) {
 			System.out.println("# " + file.getName());
 		}
-		assertEquals(15, repoDir.listFiles().length);
+		assertTrue(Arrays.stream(repoFiles)
+				.anyMatch(file -> ValueStoreWriteAheadLog.DEFAULT_FILENAME.equals(file.getName())));
+
+		long nonWalCount = Arrays.stream(repoFiles)
+				.filter(file -> !ValueStoreWriteAheadLog.DEFAULT_FILENAME.equals(file.getName()))
+				.count();
+
+		assertEquals(15, nonWalCount);
 
 		// make sure there is no txncacheXXX.dat file
 		assertFalse(Files.list(repoDir.getAbsoluteFile().toPath())

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/ValueStoreWalTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/ValueStoreWalTest.java
@@ -1,0 +1,35 @@
+package org.eclipse.rdf4j.sail.nativerdf;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ValueStoreWalTest {
+
+	private final ValueFactory vf = SimpleValueFactory.getInstance();
+
+	@TempDir
+	Path dataDir;
+
+	@Test
+	void writesWalEntryWhenValueMinted() throws Exception {
+		ValueStore valueStore = new ValueStore(dataDir.toFile());
+		try {
+			valueStore.storeValue(vf.createIRI("urn:test"));
+			valueStore.sync();
+		} finally {
+			valueStore.close();
+		}
+
+		Path walPath = dataDir.resolve("values.wal");
+		assertThat(Files.exists(walPath)).isTrue();
+		String walContent = Files.readString(walPath);
+		assertThat(walContent).contains("\"value\":\"urn:test\"");
+	}
+}

--- a/site/content/documentation/developer/valuestore-wal.md
+++ b/site/content/documentation/developer/valuestore-wal.md
@@ -1,0 +1,89 @@
+---
+title: "Designing a Write-Ahead Log for the ValueStore"
+layout: "doc"
+toc: true
+autonumbering: true
+---
+
+## Motivation and overview
+
+The NativeStore maps each RDF value (subject, predicate, object, and context) to an integer identifier that is stored on disk. If these ValueStore files become corrupt, the mapping between identifiers and values can be lost. RDF4J can repair corrupt indexes with the `softFailOnCorruptDataAndRepairIndexes` flag, but it cannot currently restore lost identifier-to-value mappings. A write-ahead log (WAL) records every logical change before it is applied to the main store and can be replayed to recover the mappings. For the ValueStore this means logging every minted identifier together with its RDF value, enabling recovery if the underlying files are damaged.
+
+The design goals for a ValueStore WAL are:
+
+- **Fast and append-only.** Log entries are written using sequential I/O and never rewritten so that appends remain inexpensive.
+- **Asynchronous and non-blocking.** ID minting should not block on disk I/O; logging work is delegated to a background component that performs asynchronous writes.
+- **Durable.** Written log entries are flushed to persistent storage using `fsync`/`FileChannel.force()` to survive crashes. Group commit batches multiple entries to amortize flush costs.
+- **Simple serialization.** JSON Lines (NDJSON) is the baseline format thanks to its readability and mature tooling, though binary alternatives are evaluated below.
+
+## General write-ahead logging principles
+
+WAL is a well-established technique in systems such as PostgreSQL, RocksDB, SQLite, and LSM-tree engines. Key principles include:
+
+1. **Log before applying changes.** Each logical change is appended to the WAL before the main data structures are updated so that recovery can replay the change after a crash.
+2. **Append-only sequential I/O.** WALs rely on sequential writes, which are faster than random I/O, and are therefore kept append-only.
+3. **Atomicity and durability.** Each record must be written atomically and flushed to durable storage with `fsync`/`FileChannel.force()`.
+4. **Checkpointing and compaction.** Periodic checkpoints apply the WAL contents to the main store and prune or roll over log segments.
+
+## Capturing ValueStore mint operations
+
+ValueStore methods such as `storeValue` mint identifiers when new RDF values are inserted. WAL support requires:
+
+1. **Intercepting the ID assignment.** Extend the ValueStore so that once an ID is minted and persisted, a WAL record is produced with the identifier and its RDF value.
+2. **Defining the WAL record structure.** Each entry contains a monotonically increasing sequence number or timestamp, the minted identifier, the lexical value, value type (IRI, blank node, literal), and literal-specific datatype and language fields. A checksum is optional for integrity verification.
+3. **Appending to the WAL.** The serialized record is appended to a dedicated log file (for example `valuestore.wal`) without interfering with the existing B-tree indexes used for lookups.
+
+## Serialization format options
+
+### JSON Lines / NDJSON
+
+JSON Lines stores one JSON object per line and is widely used for append-only logs. Advantages include:
+
+- Stream-friendly and easily appendable, allowing parallel or partial recovery.
+- Works with standard tooling such as `grep`, `jq`, and log aggregation systems.
+- Schema flexibility that tolerates additional fields.
+
+Drawbacks are the space and CPU overhead of textual encoding, lack of enforced schema, and slower parsing compared to binary formats. Compression (for example, `.jsonl.gz`) mitigates size overhead. JSON Lines is recommended as the default because of its simplicity and debuggability.
+
+### Binary alternatives
+
+Binary formats such as Protocol Buffers or Apache Avro encode data compactly and provide strong schema evolution features at the cost of added dependencies and reduced human readability. A custom binary layout—length-prefixed records with checksums—achieves minimal overhead and fast sequential writes, similar to RocksDB’s WAL, but lacks standard tooling. Binary formats are suitable when disk space or extremely high throughput is critical; otherwise JSON Lines is sufficient.
+
+## Asynchronous logging strategies
+
+### Why asynchronous?
+
+Synchronous logging forces the minting thread to wait for disk I/O and increases latency. Asynchronous logging decouples the application thread from disk writes so that the caller enqueues a record and proceeds immediately.
+
+### Implementation sketch
+
+- **Threading model.** Introduce an `AsyncWalWriter` that accepts WAL entries through a bounded thread-safe queue. Minting threads enqueue records; a dedicated writer thread drains the queue, serializes entries, and appends them to the WAL.
+- **Asynchronous I/O.** Java NIO.2’s `AsynchronousFileChannel` can perform non-blocking writes, though implementations may rely on background executors. The interface allows the caller to continue without waiting for completion.
+- **Back-pressure.** The queue has a configurable capacity. When full, producers either block, drop to synchronous writes, or signal pressure to callers.
+- **Durability.** The writer batches pending entries and flushes them with `FileChannel.force(true)` or `fsync` at configurable intervals to guarantee durability.
+
+### Synchronisation strategies
+
+1. **Immediate flush.** Flush after every record for maximum durability at the expense of throughput.
+2. **Frequency-based flush (group commit).** Batch multiple entries and flush periodically (for example every N entries or milliseconds) to amortize fsync costs, similar to LevelDB, RocksDB, and PostgreSQL.
+3. **Asynchronous commit.** Optionally acknowledge commits before the flush completes, trading durability for throughput. Unflushed entries are lost on crashes, so this mode must be opt-in and clearly documented.
+
+## Recovery and maintenance
+
+### Crash recovery
+
+1. **Locate the WAL.** On startup the ValueStore finds the latest WAL segment (for example `valuestore.wal` plus rolled segments).
+2. **Replay entries.** Parse the WAL from the beginning and rebuild a map of identifiers to values. Missing or divergent values in the store are rewritten.
+3. **Handle duplicates.** Sequence numbers or timestamps ensure the newest record for each identifier wins.
+4. **Verify integrity.** Optional checksums protect against log corruption.
+
+### Log rotation and compaction
+
+The WAL must not grow indefinitely. Checkpoints flush cached state, guarantee that log entries are materialized in the primary files, and then roll the WAL to a new segment. Old segments are archived or deleted once they are safely incorporated. This mirrors checkpointing in systems like SQLite and PostgreSQL and also enables point-in-time recovery.
+
+## Summary of approaches
+
+- JSON Lines is a strong default thanks to its simplicity and tooling support, while binary formats should be considered when throughput and disk efficiency dominate.
+- Asynchronous logging with group commit balances durability and performance for ValueStore ID minting.
+- Recovery relies on replaying WAL records and periodic checkpoints to bound log size and ensure durability.
+


### PR DESCRIPTION
## Summary
- add an asynchronous JSON-lines write-ahead log that records minted values and namespaces in the Native ValueStore
- integrate the WAL into ValueStore lifecycle so new identifiers are logged, sync/clear/close operations flush the log, and DataStore exposes whether inserts are new
- exercise the WAL with a new unit test and update the NativeStore transaction cache test to account for the WAL file

## Testing
- mvn -pl core/sail/nativerdf -Dtest=ValueStoreWalTest test
- mvn -pl core/sail/nativerdf -Dtest=ValueStoreWalTest,NativeStoreTxnTest test

------
https://chatgpt.com/codex/tasks/task_e_68e6934a4284832e81de56f4ebb3a3e9