### PR TITLE
Enable JUnit extension auto-detection for SHACL test logging

### DIFF
--- a/core/sail/shacl/pom.xml
+++ b/core/sail/shacl/pom.xml
@@ -86,6 +86,11 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.junit.platform</groupId>
+			<artifactId>junit-platform-launcher</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>rdf4j-sail-lmdb</artifactId>
 			<version>${project.version}</version>

--- a/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/TestStartLoggerExtensionIntegrationTest.java
+++ b/core/sail/shacl/src/test/java/org/eclipse/rdf4j/sail/shacl/TestStartLoggerExtensionIntegrationTest.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.shacl;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.Test;
+import org.junit.platform.engine.discovery.DiscoverySelectors;
+import org.junit.platform.launcher.Launcher;
+import org.junit.platform.launcher.LauncherDiscoveryRequest;
+import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
+import org.junit.platform.launcher.core.LauncherFactory;
+
+class TestStartLoggerExtensionIntegrationTest {
+
+	@Test
+	void extensionAutoDetectionPrintsStartAndSuccess() {
+		PrintStream originalOut = System.out;
+		ByteArrayOutputStream outputBuffer = new ByteArrayOutputStream();
+		PrintStream capturingStream = new PrintStream(outputBuffer, true, StandardCharsets.UTF_8);
+
+		System.setOut(capturingStream);
+		try {
+			LauncherDiscoveryRequest request = LauncherDiscoveryRequestBuilder.request()
+					.selectors(DiscoverySelectors.selectClass(SampleTest.class))
+					.build();
+
+			Launcher launcher = LauncherFactory.create();
+			launcher.execute(request);
+		} finally {
+			System.setOut(originalOut);
+		}
+
+		capturingStream.flush();
+
+		String output = outputBuffer.toString(StandardCharsets.UTF_8);
+
+		assertTrue(output.contains("[TEST] Start"), () -> "Expected start log entry in output, but was: " + output);
+		assertTrue(output.contains("[TEST] Success"), () -> "Expected success log entry in output, but was: " + output);
+	}
+
+	static class SampleTest {
+
+		@Test
+		void succeeds() {
+			// no-op test
+		}
+	}
+}

--- a/core/sail/shacl/src/test/resources/junit-platform.properties
+++ b/core/sail/shacl/src/test/resources/junit-platform.properties
@@ -4,5 +4,7 @@ junit.jupiter.execution.parallel.enabled = true
 junit.jupiter.execution.parallel.config.strategy = fixed
 junit.jupiter.execution.parallel.config.fixed.parallelism = 4
 
+junit.jupiter.extensions.autodetection.enabled = true
+
 junit.jupiter.execution.timeout.default = 10m
 junit.jupiter.execution.timeout.mode = disabled_on_debug


### PR DESCRIPTION
## Summary
- add an integration-style test that launches a sample class and asserts the TestStartLoggerExtension emits start/success messages
- enable JUnit Jupiter extension auto-detection in the SHACL test suite so the logging extension is discovered automatically
- add the junit-platform-launcher test dependency required to build and run the new integration test

## Testing
- mvn -Dtest=TestStartLoggerExtensionIntegrationTest test
- mvn -Dtest=ShutdownTest test


------
https://chatgpt.com/codex/tasks/task_e_68eb80a038c4832ea7b67daebe136490