### PR TITLE
Add LMDB compaction support and integration test

### DIFF
--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbCompactionMetrics.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbCompactionMetrics.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.lmdb;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Metrics describing a compaction run.
+ */
+public final class LmdbCompactionMetrics {
+
+	private final Duration copyDuration;
+	private final List<DatabaseStats> databases;
+
+	public LmdbCompactionMetrics(Duration copyDuration, List<DatabaseStats> databases) {
+		this.copyDuration = Objects.requireNonNull(copyDuration, "copyDuration");
+		this.databases = List.copyOf(Objects.requireNonNull(databases, "databases"));
+	}
+
+	public Duration getCopyDuration() {
+		return copyDuration;
+	}
+
+	public List<DatabaseStats> getDatabases() {
+		return Collections.unmodifiableList(databases);
+	}
+
+	public static final class DatabaseStats {
+
+		private final String name;
+		private final long entriesBefore;
+		private final long entriesCopied;
+		private final long pagesBefore;
+		private final long pagesAfter;
+
+		public DatabaseStats(String name, long entriesBefore, long entriesCopied, long pagesBefore,
+				long pagesAfter) {
+			this.name = Objects.requireNonNull(name, "name");
+			this.entriesBefore = entriesBefore;
+			this.entriesCopied = entriesCopied;
+			this.pagesBefore = pagesBefore;
+			this.pagesAfter = pagesAfter;
+		}
+
+		public String name() {
+			return name;
+		}
+
+		public long entriesBefore() {
+			return entriesBefore;
+		}
+
+		public long entriesCopied() {
+			return entriesCopied;
+		}
+
+		public long pagesBefore() {
+			return pagesBefore;
+		}
+
+		public long pagesAfter() {
+			return pagesAfter;
+		}
+	}
+}

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbCompactionOptions.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbCompactionOptions.java
@@ -1,0 +1,115 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.lmdb;
+
+import java.nio.file.Path;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+/**
+ * Options that control how an LMDB compaction run is executed.
+ */
+public final class LmdbCompactionOptions {
+
+	private final Path destinationDirectory;
+	private final Path temporaryDirectory;
+	private final boolean verifyAfterCopy;
+	private final boolean keepBackup;
+	private final Consumer<LmdbCompactionProgress> progressListener;
+	private final Consumer<LmdbCompactionMetrics> metricsConsumer;
+
+	private LmdbCompactionOptions(Builder builder) {
+		this.destinationDirectory = builder.destinationDirectory;
+		this.temporaryDirectory = builder.temporaryDirectory;
+		this.verifyAfterCopy = builder.verifyAfterCopy;
+		this.keepBackup = builder.keepBackup;
+		this.progressListener = builder.progressListener;
+		this.metricsConsumer = builder.metricsConsumer;
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public Optional<Path> destinationDirectory() {
+		return Optional.ofNullable(destinationDirectory);
+	}
+
+	public Optional<Path> temporaryDirectory() {
+		return Optional.ofNullable(temporaryDirectory);
+	}
+
+	public boolean verifyAfterCopy() {
+		return verifyAfterCopy;
+	}
+
+	public boolean keepBackup() {
+		return keepBackup;
+	}
+
+	public Consumer<LmdbCompactionProgress> progressListener() {
+		return progressListener;
+	}
+
+	public Consumer<LmdbCompactionMetrics> metricsConsumer() {
+		return metricsConsumer;
+	}
+
+	public static final class Builder {
+
+		private Path destinationDirectory;
+		private Path temporaryDirectory;
+		private boolean verifyAfterCopy;
+		private boolean keepBackup = true;
+		private Consumer<LmdbCompactionProgress> progressListener = progress -> {
+		};
+		private Consumer<LmdbCompactionMetrics> metricsConsumer = metrics -> {
+		};
+
+		private Builder() {
+		}
+
+		public Builder destinationDirectory(Path destinationDirectory) {
+			this.destinationDirectory = Objects.requireNonNull(destinationDirectory, "destinationDirectory");
+			return this;
+		}
+
+		public Builder temporaryDirectory(Path temporaryDirectory) {
+			this.temporaryDirectory = Objects.requireNonNull(temporaryDirectory, "temporaryDirectory");
+			return this;
+		}
+
+		public Builder verifyAfterCopy(boolean verifyAfterCopy) {
+			this.verifyAfterCopy = verifyAfterCopy;
+			return this;
+		}
+
+		public Builder keepBackup(boolean keepBackup) {
+			this.keepBackup = keepBackup;
+			return this;
+		}
+
+		public Builder progressListener(Consumer<LmdbCompactionProgress> progressListener) {
+			this.progressListener = Objects.requireNonNull(progressListener, "progressListener");
+			return this;
+		}
+
+		public Builder metricsConsumer(Consumer<LmdbCompactionMetrics> metricsConsumer) {
+			this.metricsConsumer = Objects.requireNonNull(metricsConsumer, "metricsConsumer");
+			return this;
+		}
+
+		public LmdbCompactionOptions build() {
+			return new LmdbCompactionOptions(this);
+		}
+	}
+}

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbCompactionProgress.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbCompactionProgress.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.lmdb;
+
+import java.util.Objects;
+
+/**
+ * Progress event produced while compaction work is running.
+ */
+public final class LmdbCompactionProgress {
+
+	public enum Stage {
+		PREPARE,
+		COPY_VALUES,
+		COPY_TRIPLES,
+		VERIFY,
+		SWAP,
+		COMPLETE
+	}
+
+	private final Stage stage;
+	private final String detail;
+	private final double fraction;
+
+	public LmdbCompactionProgress(Stage stage, String detail, double fraction) {
+		this.stage = Objects.requireNonNull(stage, "stage");
+		this.detail = detail == null ? "" : detail;
+		this.fraction = fraction;
+	}
+
+	public Stage stage() {
+		return stage;
+	}
+
+	public String detail() {
+		return detail;
+	}
+
+	public double fraction() {
+		return fraction;
+	}
+}

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbCompactionResult.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbCompactionResult.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.lmdb;
+
+import java.nio.file.Path;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Result of a compaction run.
+ */
+public final class LmdbCompactionResult {
+
+	private final long bytesBefore;
+	private final long bytesAfter;
+	private final Path compactedDirectory;
+	private final Path backupDirectory;
+	private final LmdbCompactionMetrics metrics;
+
+	LmdbCompactionResult(long bytesBefore, long bytesAfter, Path compactedDirectory, Path backupDirectory,
+			LmdbCompactionMetrics metrics) {
+		this.bytesBefore = bytesBefore;
+		this.bytesAfter = bytesAfter;
+		this.compactedDirectory = Objects.requireNonNull(compactedDirectory, "compactedDirectory");
+		this.backupDirectory = backupDirectory;
+		this.metrics = Objects.requireNonNull(metrics, "metrics");
+	}
+
+	public long getBytesBefore() {
+		return bytesBefore;
+	}
+
+	public long getBytesAfter() {
+		return bytesAfter;
+	}
+
+	public Path getCompactedDirectory() {
+		return compactedDirectory;
+	}
+
+	public Optional<Path> getBackupDirectory() {
+		return Optional.ofNullable(backupDirectory);
+	}
+
+	public LmdbCompactionMetrics getMetrics() {
+		return metrics;
+	}
+
+	public long getBytesFreed() {
+		return Math.max(0, bytesBefore - bytesAfter);
+	}
+}

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbCompactor.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbCompactor.java
@@ -1,0 +1,517 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.lmdb;
+
+import static org.eclipse.rdf4j.sail.lmdb.LmdbUtil.E;
+import static org.eclipse.rdf4j.sail.lmdb.LmdbUtil.readTransaction;
+import static org.lwjgl.system.MemoryStack.stackPush;
+import static org.lwjgl.util.lmdb.LMDB.MDB_CP_COMPACT;
+import static org.lwjgl.util.lmdb.LMDB.MDB_NOTFOUND;
+import static org.lwjgl.util.lmdb.LMDB.MDB_NOTLS;
+import static org.lwjgl.util.lmdb.LMDB.MDB_RDONLY;
+import static org.lwjgl.util.lmdb.LMDB.mdb_dbi_open;
+import static org.lwjgl.util.lmdb.LMDB.mdb_env_close;
+import static org.lwjgl.util.lmdb.LMDB.mdb_env_copy2;
+import static org.lwjgl.util.lmdb.LMDB.mdb_env_create;
+import static org.lwjgl.util.lmdb.LMDB.mdb_env_open;
+import static org.lwjgl.util.lmdb.LMDB.mdb_env_set_maxdbs;
+import static org.lwjgl.util.lmdb.LMDB.mdb_env_set_maxreaders;
+import static org.lwjgl.util.lmdb.LMDB.mdb_stat;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.IntBuffer;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import org.eclipse.rdf4j.sail.lmdb.LmdbCompactionProgress.Stage;
+import org.eclipse.rdf4j.sail.lmdb.config.LmdbStoreConfig;
+import org.lwjgl.PointerBuffer;
+import org.lwjgl.system.MemoryStack;
+import org.lwjgl.util.lmdb.MDBStat;
+
+final class LmdbCompactor {
+
+	private static final String VALUES_DIRECTORY = "values";
+	private static final String TRIPLES_DIRECTORY = "triples";
+	private static final String TRIPLE_PROPERTIES_FILE = "triples.prop";
+	private static final String INDEXES_KEY = "triple-indexes";
+	private static final DateTimeFormatter STAGING_FORMAT = DateTimeFormatter.ofPattern("yyyyMMddHHmmss")
+			.withLocale(Locale.ROOT)
+			.withZone(ZoneOffset.UTC);
+
+	private final Path dataDir;
+	private final LmdbStoreConfig config;
+	private final LmdbCompactionOptions options;
+	private final Consumer<LmdbCompactionProgress> progressListener;
+
+	LmdbCompactor(Path dataDir, LmdbStoreConfig config, LmdbCompactionOptions options) {
+		this.dataDir = Objects.requireNonNull(dataDir, "dataDir");
+		this.config = Objects.requireNonNull(config, "config");
+		this.options = Objects.requireNonNull(options, "options");
+		this.progressListener = options.progressListener();
+	}
+
+	LmdbCompactionResult run() throws IOException {
+		if (!Files.isDirectory(dataDir)) {
+			throw new IOException("LMDB data directory does not exist: " + dataDir);
+		}
+
+		progressListener.accept(new LmdbCompactionProgress(Stage.PREPARE, "preparing staging directory", 0));
+		Path stagingRoot = prepareStagingDirectory();
+		copyStaticFiles(stagingRoot);
+
+		long valuesSizeBefore = sizeOfDataFile(dataDir.resolve(VALUES_DIRECTORY));
+		long triplesSizeBefore = sizeOfDataFile(dataDir.resolve(TRIPLES_DIRECTORY));
+
+		Instant start = Instant.now();
+		List<LmdbCompactionMetrics.DatabaseStats> stats = new ArrayList<>();
+
+		progressListener.accept(new LmdbCompactionProgress(Stage.COPY_VALUES, VALUES_DIRECTORY, 0));
+		EnvironmentStats valuesStats = compactValues(stagingRoot);
+		stats.add(valuesStats.toDatabaseStats());
+
+		progressListener.accept(new LmdbCompactionProgress(Stage.COPY_TRIPLES, TRIPLES_DIRECTORY, 0.5));
+		EnvironmentStats triplesStats = compactTriples(stagingRoot);
+		stats.add(triplesStats.toDatabaseStats());
+
+		Duration duration = Duration.between(start, Instant.now());
+
+		long valuesSizeAfter = sizeOfDataFile(stagingRoot.resolve(VALUES_DIRECTORY));
+		long triplesSizeAfter = sizeOfDataFile(stagingRoot.resolve(TRIPLES_DIRECTORY));
+
+		LmdbCompactionMetrics metrics = new LmdbCompactionMetrics(duration, stats);
+		options.metricsConsumer().accept(metrics);
+
+		progressListener.accept(new LmdbCompactionProgress(Stage.SWAP, "swapping directories", 0.75));
+		Path backupDir = swapWithOriginal(stagingRoot);
+
+		long bytesBefore = safeAdd(valuesSizeBefore, triplesSizeBefore);
+		long bytesAfter = safeAdd(valuesSizeAfter, triplesSizeAfter);
+
+		progressListener.accept(new LmdbCompactionProgress(Stage.COMPLETE, "complete", 1));
+
+		return new LmdbCompactionResult(bytesBefore, bytesAfter, dataDir, backupDir, metrics);
+	}
+
+	private EnvironmentStats compactValues(Path stagingRoot) throws IOException {
+		Path source = dataDir.resolve(VALUES_DIRECTORY);
+		if (!Files.isDirectory(source)) {
+			return EnvironmentStats.empty(VALUES_DIRECTORY);
+		}
+		Path target = stagingRoot.resolve(VALUES_DIRECTORY);
+		Files.createDirectories(target);
+
+		List<String> dbNames = Arrays.asList(null, "unused_ids", "free_ids", "ref_counts");
+		EnvironmentStats stats = copyEnvironment(VALUES_DIRECTORY, source, target, 6, dbNames, null);
+		return stats;
+	}
+
+	private EnvironmentStats compactTriples(Path stagingRoot) throws IOException {
+		Path source = dataDir.resolve(TRIPLES_DIRECTORY);
+		if (!Files.isDirectory(source)) {
+			return EnvironmentStats.empty(TRIPLES_DIRECTORY);
+		}
+		Path target = stagingRoot.resolve(TRIPLES_DIRECTORY);
+		Files.createDirectories(target);
+
+		TripleLayout layout = loadTripleLayout();
+		EnvironmentStats stats = copyEnvironment(TRIPLES_DIRECTORY, source, target, layout.maxDatabases(),
+				layout.databaseNames(), layout.primaryDatabase());
+		return stats;
+	}
+
+	private EnvironmentStats copyEnvironment(String name, Path source, Path destination, int maxDbs,
+			List<String> dbNames, String primaryDb) throws IOException {
+		Map<String, StatValues> beforeStats = collectStats(source, maxDbs, dbNames);
+		performCopy(source, destination, maxDbs);
+		Map<String, StatValues> afterStats = collectStats(destination, maxDbs, dbNames);
+
+		if (options.verifyAfterCopy()) {
+			progressListener.accept(new LmdbCompactionProgress(Stage.VERIFY, name, 0.9));
+			verifyStats(name, beforeStats, afterStats);
+		}
+
+		String primaryKey = normalizeDbName(primaryDb);
+		StatValues before = beforeStats.getOrDefault(primaryKey, StatValues.EMPTY);
+		StatValues after = afterStats.getOrDefault(primaryKey, StatValues.EMPTY);
+		long pagesBefore = beforeStats.values()
+				.stream()
+				.mapToLong(StatValues::totalPages)
+				.sum();
+		long pagesAfter = afterStats.values()
+				.stream()
+				.mapToLong(StatValues::totalPages)
+				.sum();
+
+		return new EnvironmentStats(name, before.entries(), after.entries(), pagesBefore, pagesAfter);
+	}
+
+	private void verifyStats(String envName, Map<String, StatValues> before, Map<String, StatValues> after)
+			throws IOException {
+		for (Map.Entry<String, StatValues> entry : before.entrySet()) {
+			StatValues other = after.get(entry.getKey());
+			if (other == null) {
+				throw new IOException("Database '" + entry.getKey() + "' missing after compaction for " + envName);
+			}
+			if (entry.getValue().entries() != other.entries()) {
+				throw new IOException("Entry count mismatch for database '" + entry.getKey() + "' in environment "
+						+ envName);
+			}
+		}
+	}
+
+	private void performCopy(Path source, Path destination, int maxDbs) throws IOException {
+		try (MemoryStack stack = stackPush()) {
+			PointerBuffer ptr = stack.mallocPointer(1);
+			E(mdb_env_create(ptr));
+			long env = ptr.get(0);
+			try {
+				E(mdb_env_set_maxdbs(env, maxDbs));
+				E(mdb_env_set_maxreaders(env, 512));
+				int flags = MDB_RDONLY | MDB_NOTLS;
+				E(mdb_env_open(env, source.toString(), flags, 0664));
+				E(mdb_env_copy2(env, destination.toString(), MDB_CP_COMPACT));
+			} finally {
+				mdb_env_close(env);
+			}
+		}
+	}
+
+	private Map<String, StatValues> collectStats(Path envPath, int maxDbs, List<String> dbNames) throws IOException {
+		if (!Files.isDirectory(envPath)) {
+			return Collections.emptyMap();
+		}
+		Map<String, StatValues> result = new LinkedHashMap<>();
+		long env;
+		try (MemoryStack stack = stackPush()) {
+			PointerBuffer ptr = stack.mallocPointer(1);
+			E(mdb_env_create(ptr));
+			env = ptr.get(0);
+			try {
+				E(mdb_env_set_maxdbs(env, maxDbs));
+				E(mdb_env_set_maxreaders(env, 512));
+				int flags = MDB_RDONLY | MDB_NOTLS;
+				E(mdb_env_open(env, envPath.toString(), flags, 0664));
+			} catch (IOException e) {
+				mdb_env_close(env);
+				throw e;
+			}
+		}
+
+		try {
+			readTransaction(env, (stack, txn) -> {
+				for (String dbName : dbNames) {
+					IntBuffer ip = stack.mallocInt(1);
+					int rc = mdb_dbi_open(txn, dbName, 0, ip);
+					if (rc == MDB_NOTFOUND) {
+						continue;
+					}
+					E(rc);
+					MDBStat stat = MDBStat.malloc(stack);
+					mdb_stat(txn, ip.get(0), stat);
+					result.put(normalizeDbName(dbName), new StatValues(stat.ms_entries(),
+							stat.ms_branch_pages(), stat.ms_leaf_pages(), stat.ms_overflow_pages()));
+				}
+				return null;
+			});
+		} finally {
+			mdb_env_close(env);
+		}
+		return result;
+	}
+
+	private TripleLayout loadTripleLayout() throws IOException {
+		Path props = dataDir.resolve(TRIPLES_DIRECTORY).resolve(TRIPLE_PROPERTIES_FILE);
+		if (!Files.exists(props)) {
+			return TripleLayout.fromConfig(config);
+		}
+		Properties properties = new Properties();
+		try (InputStream in = Files.newInputStream(props)) {
+			properties.load(in);
+		}
+		String indexSpec = properties.getProperty(INDEXES_KEY);
+		if (indexSpec == null || indexSpec.isBlank()) {
+			return TripleLayout.fromConfig(config);
+		}
+		return TripleLayout.fromIndexString(indexSpec);
+	}
+
+	private Path prepareStagingDirectory() throws IOException {
+		Path staging = options.destinationDirectory().orElseGet(() -> {
+			Path base = options.temporaryDirectory().orElse(dataDir.getParent());
+			String candidateName = dataDir.getFileName() + "-compact-" + STAGING_FORMAT.format(Instant.now());
+			Path candidate = base.resolve(candidateName);
+			AtomicInteger counter = new AtomicInteger();
+			while (Files.exists(candidate)) {
+				candidate = base.resolve(candidateName + "-" + counter.incrementAndGet());
+			}
+			return candidate;
+		});
+
+		if (Files.exists(staging)) {
+			if (!Files.isDirectory(staging)) {
+				throw new IOException("Destination path is not a directory: " + staging);
+			}
+			try (var stream = Files.list(staging)) {
+				if (stream.findAny().isPresent()) {
+					throw new IOException("Destination directory must be empty: " + staging);
+				}
+			}
+		} else {
+			Files.createDirectories(staging);
+		}
+
+		if (staging.startsWith(dataDir)) {
+			throw new IOException("Destination directory may not be inside the LMDB data directory: " + staging);
+		}
+		return staging;
+	}
+
+	private void copyStaticFiles(Path stagingRoot) throws IOException {
+		Set<String> envDirectories = Set.of(VALUES_DIRECTORY, TRIPLES_DIRECTORY);
+		try (var stream = Files.list(dataDir)) {
+			for (Path entry : stream.collect(Collectors.toList())) {
+				String name = entry.getFileName().toString();
+				if (envDirectories.contains(name)) {
+					Files.createDirectories(stagingRoot.resolve(name));
+					continue;
+				}
+				Path target = stagingRoot.resolve(name);
+				if (Files.isDirectory(entry)) {
+					copyDirectory(entry, target);
+				} else {
+					Files.copy(entry, target, StandardCopyOption.COPY_ATTRIBUTES,
+							StandardCopyOption.REPLACE_EXISTING);
+				}
+			}
+		}
+	}
+
+	private void copyDirectory(Path source, Path target) throws IOException {
+		Files.walkFileTree(source, new SimpleFileVisitor<>() {
+			@Override
+			public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
+				Path relative = source.relativize(dir);
+				Files.createDirectories(target.resolve(relative));
+				return FileVisitResult.CONTINUE;
+			}
+
+			@Override
+			public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+				Path relative = source.relativize(file);
+				Files.copy(file, target.resolve(relative), StandardCopyOption.COPY_ATTRIBUTES,
+						StandardCopyOption.REPLACE_EXISTING);
+				return FileVisitResult.CONTINUE;
+			}
+		});
+	}
+
+	private Path swapWithOriginal(Path stagingRoot) throws IOException {
+		Path backup = null;
+		if (options.keepBackup()) {
+			backup = createBackupPath();
+			moveDirectory(dataDir, backup);
+		} else {
+			Path tempBackup = createBackupPath();
+			moveDirectory(dataDir, tempBackup);
+			deleteDirectory(tempBackup);
+		}
+		moveDirectory(stagingRoot, dataDir);
+		return backup;
+	}
+
+	private Path createBackupPath() throws IOException {
+		String baseName = dataDir.getFileName() + ".bak";
+		Path candidate = dataDir.resolveSibling(baseName);
+		int index = 1;
+		while (Files.exists(candidate)) {
+			candidate = dataDir.resolveSibling(baseName + "-" + index++);
+		}
+		return candidate;
+	}
+
+	private void moveDirectory(Path source, Path target) throws IOException {
+		try {
+			Files.move(source, target, StandardCopyOption.ATOMIC_MOVE);
+		} catch (AtomicMoveNotSupportedException e) {
+			Files.move(source, target, StandardCopyOption.REPLACE_EXISTING);
+		}
+	}
+
+	private void deleteDirectory(Path path) throws IOException {
+		if (!Files.exists(path)) {
+			return;
+		}
+		Files.walkFileTree(path, new SimpleFileVisitor<>() {
+			@Override
+			public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+				Files.delete(file);
+				return FileVisitResult.CONTINUE;
+			}
+
+			@Override
+			public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+				Files.delete(dir);
+				return FileVisitResult.CONTINUE;
+			}
+		});
+	}
+
+	private long sizeOfDataFile(Path envDir) throws IOException {
+		Path dataFile = envDir.resolve("data.mdb");
+		if (Files.exists(dataFile)) {
+			return Files.size(dataFile);
+		}
+		return 0L;
+	}
+
+	private static long safeAdd(long left, long right) {
+		long result = left + right;
+		if (((left ^ result) & (right ^ result)) < 0) {
+			return Long.MAX_VALUE;
+		}
+		return result;
+	}
+
+	private static String normalizeDbName(String name) {
+		return name == null ? "(main)" : name;
+	}
+
+	private static final class StatValues {
+
+		static final StatValues EMPTY = new StatValues(0, 0, 0, 0);
+
+		private final long entries;
+		private final long branchPages;
+		private final long leafPages;
+		private final long overflowPages;
+
+		StatValues(long entries, long branchPages, long leafPages, long overflowPages) {
+			this.entries = entries;
+			this.branchPages = branchPages;
+			this.leafPages = leafPages;
+			this.overflowPages = overflowPages;
+		}
+
+		long entries() {
+			return entries;
+		}
+
+		long totalPages() {
+			return branchPages + leafPages + overflowPages;
+		}
+	}
+
+	private static final class EnvironmentStats {
+		private final String name;
+		private final long entriesBefore;
+		private final long entriesAfter;
+		private final long pagesBefore;
+		private final long pagesAfter;
+
+		private EnvironmentStats(String name, long entriesBefore, long entriesAfter, long pagesBefore,
+				long pagesAfter) {
+			this.name = name;
+			this.entriesBefore = entriesBefore;
+			this.entriesAfter = entriesAfter;
+			this.pagesBefore = pagesBefore;
+			this.pagesAfter = pagesAfter;
+		}
+
+		static EnvironmentStats empty(String name) {
+			return new EnvironmentStats(name, 0, 0, 0, 0);
+		}
+
+		LmdbCompactionMetrics.DatabaseStats toDatabaseStats() {
+			return new LmdbCompactionMetrics.DatabaseStats(name, entriesBefore, entriesAfter, pagesBefore,
+					pagesAfter);
+		}
+	}
+
+	private static final class TripleLayout {
+
+		private final List<String> indexes;
+
+		private TripleLayout(List<String> indexes) {
+			this.indexes = List.copyOf(indexes);
+		}
+
+		static TripleLayout fromConfig(LmdbStoreConfig config) {
+			String indexSpec = config.getTripleIndexes();
+			if (indexSpec == null || indexSpec.isBlank()) {
+				return defaultLayout();
+			}
+			return fromIndexString(indexSpec);
+		}
+
+		static TripleLayout defaultLayout() {
+			return new TripleLayout(List.of("spoc", "posc", "ospc", "cspo", "cpso", "pocs"));
+		}
+
+		static TripleLayout fromIndexString(String indexString) {
+			String[] parts = indexString.split("[,\\s]+");
+			List<String> indexes = new ArrayList<>();
+			for (String part : parts) {
+				if (!part.isBlank()) {
+					indexes.add(part.trim().toLowerCase(Locale.ROOT));
+				}
+			}
+			if (indexes.isEmpty()) {
+				return defaultLayout();
+			}
+			return new TripleLayout(indexes);
+		}
+
+		int maxDatabases() {
+			// contexts + explicit/inferred per index + main
+			return 2 * indexes.size() + 2;
+		}
+
+		List<String> databaseNames() {
+			Set<String> names = new LinkedHashSet<>();
+			names.add(null);
+			names.add("contexts");
+			for (String index : indexes) {
+				names.add(index);
+				names.add(index + "-inf");
+			}
+			return new ArrayList<>(names);
+		}
+
+		String primaryDatabase() {
+			return indexes.isEmpty() ? null : indexes.get(0);
+		}
+	}
+}

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbStore.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbStore.java
@@ -16,6 +16,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
+import java.util.Objects;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
@@ -351,6 +352,21 @@ public class LmdbStore extends AbstractNotifyingSail implements FederatedService
 	@Override
 	public ValueFactory getValueFactory() {
 		return store.getValueFactory();
+	}
+
+	public LmdbCompactionResult compact(LmdbCompactionOptions options) throws IOException, SailException {
+		Objects.requireNonNull(options, "options");
+		if (isInitialized()) {
+			throw new SailException("Cannot compact an initialized store. Shut down the repository first.");
+		}
+
+		File dataDir = getDataDir();
+		if (dataDir == null) {
+			throw new SailException("Cannot compact store without a configured data directory");
+		}
+
+		LmdbCompactor compactor = new LmdbCompactor(dataDir.toPath(), config, options);
+		return compactor.run();
 	}
 
 	/**

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbCompactionIT.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbCompactionIT.java
@@ -1,0 +1,110 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.lmdb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.stream.IntStream;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.sail.lmdb.config.LmdbStoreConfig;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class LmdbCompactionIT {
+
+	@TempDir
+	Path tempDir;
+
+	private SailRepository repository;
+	private LmdbStore store;
+
+	@BeforeEach
+	void setUp() {
+		LmdbStoreConfig config = new LmdbStoreConfig("spoc,posc");
+		config.setAutoGrow(true);
+		store = new LmdbStore(tempDir.toFile(), config);
+		repository = new SailRepository(store);
+		repository.init();
+	}
+
+	@AfterEach
+	void tearDown() {
+		if (repository != null) {
+			repository.shutDown();
+		}
+	}
+
+	@Test
+	void compactShrinksValueStoreAndPreservesData() throws Exception {
+		try (RepositoryConnection connection = repository.getConnection()) {
+			connection.begin();
+			ValueFactory vf = connection.getValueFactory();
+			IntStream.range(0, 4_000).forEach(i -> {
+				IRI subject = vf.createIRI("http://example.com/s" + i);
+				connection.add(subject, RDF.TYPE, RDF.STATEMENT);
+			});
+			connection.commit();
+
+			connection.begin();
+			IntStream.range(0, 2_000).forEach(i -> {
+				IRI subject = vf.createIRI("http://example.com/s" + i);
+				connection.remove(subject, RDF.TYPE, RDF.STATEMENT);
+			});
+			connection.commit();
+		}
+
+		repository.shutDown();
+
+		Path valuesDataFile = tempDir.resolve("values").resolve("data.mdb");
+		long beforeSize = Files.size(valuesDataFile);
+
+		LmdbCompactionOptions options = LmdbCompactionOptions.builder()
+				.progressListener(progress -> {
+				})
+				.verifyAfterCopy(true)
+				.build();
+
+		LmdbCompactionResult result = store.compact(options);
+
+		assertThat(result.getBytesAfter()).isLessThan(beforeSize);
+		assertThat(result.getMetrics().getCopyDuration()).isGreaterThan(Duration.ZERO);
+		assertThat(result.getMetrics().getDatabases())
+				.extracting(LmdbCompactionMetrics.DatabaseStats::name,
+						LmdbCompactionMetrics.DatabaseStats::entriesCopied)
+				.contains(tuple("values", result.getMetrics()
+						.getDatabases()
+						.stream()
+						.filter(stats -> stats.name().equals("values"))
+						.findFirst()
+						.orElseThrow()
+						.entriesCopied()));
+
+		SailRepository reopened = new SailRepository(new LmdbStore(tempDir.toFile(), new LmdbStoreConfig("spoc,posc")));
+		reopened.init();
+		try (RepositoryConnection connection = reopened.getConnection()) {
+			long count = connection.size();
+			assertThat(count).isEqualTo(2_000);
+		} finally {
+			reopened.shutDown();
+		}
+	}
+}

--- a/docs/storage/LMDB_COMPACTION.md
+++ b/docs/storage/LMDB_COMPACTION.md
@@ -1,0 +1,52 @@
+# LMDB Compaction Overview
+
+## Purpose
+
+The LMDB compaction routine rewrites the `values` and `triples` environments into
+new LMDB databases, collapses fragmented pages, and atomically swaps the
+compacted copy into place. This reduces file sizes and improves cursor
+locality after sustained churn.
+
+## Dataflow
+
+```
+┌───────────────┐    copy+metrics     ┌────────────────┐
+│ live data dir │ ─────────────────▶ │ staging/env(*) │
+└───────────────┘                     └────────────────┘
+        │                                    │
+        │ swap                               │
+        ▼                                    ▼
+┌────────────────┐     optional backup     ┌───────────────┐
+│ compacted dir  │ ◀────────────────────── │ old dir .bak  │
+└────────────────┘                         └───────────────┘
+```
+
+1. The compactor creates an empty staging directory outside the active data
+   directory (either user supplied or a timestamped sibling directory).
+2. Non-LMDB artifacts (namespaces, configuration files) are copied as-is.
+3. Each LMDB environment (`values`, `triples`) is reopened read-only, copied via
+   `mdb_env_copy2(..., MDB_CP_COMPACT)`, and verified.
+4. Metrics (per-environment entry counts, page totals, copy duration) are
+   captured and fed to any configured consumer.
+5. Once both environments are copied successfully the compactor atomically moves
+   the original data directory aside (keeping or deleting the backup based on
+   options) and moves the staging directory into place.
+
+## API Surface
+
+* `LmdbCompactionOptions` – builder-style options for destination/temporary
+  directories, verification, backup retention, progress and metrics consumers.
+* `LmdbStore.compact(options)` – entry point invoked while the store is shut
+  down; throws if the store is still initialized or the data directory is
+  missing.
+* `LmdbCompactionResult` – exposes byte counts, backup location, and collected
+  metrics.
+
+## Operational Notes
+
+* Compaction must be run with the repository offline. `LmdbStore.compact()`
+  enforces this by rejecting calls when the store is still initialized.
+* A `.bak` directory is kept by default so operators can roll back manually.
+  Set `keepBackup(false)` in the options to automatically delete the old copy.
+* Verification compares per-database entry counts before and after the copy. If
+  any mismatch is detected the compactor aborts without swapping directories.


### PR DESCRIPTION
## Summary
- add a `LmdbStore.compact` API with options/result types to run offline LMDB compaction
- implement the compaction workflow, metrics collection, and documentation for operators
- add an integration test that exercises compaction end-to-end on a temporary store

## Testing
- mvn -pl core/sail/lmdb -Dtest=LmdbCompactionIT test

------
https://chatgpt.com/codex/tasks/task_e_6900d55f7d38832eb8eaed19ce5d58b4