### PR TITLE
Add LMDB compaction API and tooling

### DIFF
--- a/bin/rdf4j-lmdb-maintenance.sh
+++ b/bin/rdf4j-lmdb-maintenance.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+PROJECT_ROOT=$(cd "${SCRIPT_DIR}/.." && pwd)
+LMDB_MODULE="${PROJECT_ROOT}/core/sail/lmdb"
+JAR=$(ls "${LMDB_MODULE}"/target/rdf4j-sail-lmdb-*.jar 2>/dev/null | head -n 1)
+DEPS_DIR="${LMDB_MODULE}/target/dependency"
+
+if [[ -z "${JAR}" ]]; then
+  echo "Error: LMDB module artifacts not found." >&2
+  echo "Build them with 'mvn -pl core/sail/lmdb -DskipTests package dependency:copy-dependencies'" >&2
+  exit 1
+fi
+
+CLASSPATH="${JAR}"
+if [[ -d "${DEPS_DIR}" ]]; then
+  CLASSPATH="${CLASSPATH}:${DEPS_DIR}/*"
+fi
+
+exec java -cp "${CLASSPATH}" org.eclipse.rdf4j.sail.lmdb.LmdbMaintenanceCli "$@"

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbCompactionMetrics.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbCompactionMetrics.java
@@ -1,0 +1,207 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.lmdb;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Immutable metrics collected during an LMDB compaction run.
+ */
+public final class LmdbCompactionMetrics {
+
+	private final long fileSizeBeforeBytes;
+	private final long fileSizeAfterBytes;
+	private final Duration copyDuration;
+	private final Instant startedAt;
+	private final Instant completedAt;
+	private final List<EnvironmentMetrics> environmentsBefore;
+	private final List<EnvironmentMetrics> environmentsAfter;
+
+	private LmdbCompactionMetrics(Builder builder) {
+		this.fileSizeBeforeBytes = builder.fileSizeBeforeBytes;
+		this.fileSizeAfterBytes = builder.fileSizeAfterBytes;
+		this.copyDuration = builder.copyDuration;
+		this.startedAt = builder.startedAt;
+		this.completedAt = builder.completedAt;
+		this.environmentsBefore = Collections.unmodifiableList(new ArrayList<>(builder.environmentsBefore));
+		this.environmentsAfter = Collections.unmodifiableList(new ArrayList<>(builder.environmentsAfter));
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public long getFileSizeBeforeBytes() {
+		return fileSizeBeforeBytes;
+	}
+
+	public long getFileSizeAfterBytes() {
+		return fileSizeAfterBytes;
+	}
+
+	public Duration getCopyDuration() {
+		return copyDuration;
+	}
+
+	public Instant getStartedAt() {
+		return startedAt;
+	}
+
+	public Instant getCompletedAt() {
+		return completedAt;
+	}
+
+	public List<EnvironmentMetrics> getEnvironmentsBefore() {
+		return environmentsBefore;
+	}
+
+	public List<EnvironmentMetrics> getEnvironmentsAfter() {
+		return environmentsAfter;
+	}
+
+	public double getTotalFreePageRatioBefore() {
+		return environmentsBefore.stream().mapToDouble(EnvironmentMetrics::getFreePageRatio).average().orElse(0.0);
+	}
+
+	public double getTotalFreePageRatioAfter() {
+		return environmentsAfter.stream().mapToDouble(EnvironmentMetrics::getFreePageRatio).average().orElse(0.0);
+	}
+
+	/**
+	 * Builder for {@link LmdbCompactionMetrics}.
+	 */
+	public static final class Builder {
+		private long fileSizeBeforeBytes;
+		private long fileSizeAfterBytes;
+		private Duration copyDuration = Duration.ZERO;
+		private Instant startedAt = Instant.now();
+		private Instant completedAt = Instant.now();
+		private final List<EnvironmentMetrics> environmentsBefore = new ArrayList<>();
+		private final List<EnvironmentMetrics> environmentsAfter = new ArrayList<>();
+
+		private Builder() {
+		}
+
+		public Builder fileSizeBeforeBytes(long fileSizeBeforeBytes) {
+			this.fileSizeBeforeBytes = fileSizeBeforeBytes;
+			return this;
+		}
+
+		public Builder fileSizeAfterBytes(long fileSizeAfterBytes) {
+			this.fileSizeAfterBytes = fileSizeAfterBytes;
+			return this;
+		}
+
+		public Builder copyDuration(Duration copyDuration) {
+			this.copyDuration = Objects.requireNonNull(copyDuration, "copyDuration");
+			return this;
+		}
+
+		public Builder startedAt(Instant startedAt) {
+			this.startedAt = Objects.requireNonNull(startedAt, "startedAt");
+			return this;
+		}
+
+		public Builder completedAt(Instant completedAt) {
+			this.completedAt = Objects.requireNonNull(completedAt, "completedAt");
+			return this;
+		}
+
+		public Builder addEnvironmentBefore(EnvironmentMetrics metrics) {
+			this.environmentsBefore.add(Objects.requireNonNull(metrics, "metrics"));
+			return this;
+		}
+
+		public Builder addEnvironmentAfter(EnvironmentMetrics metrics) {
+			this.environmentsAfter.add(Objects.requireNonNull(metrics, "metrics"));
+			return this;
+		}
+
+		public LmdbCompactionMetrics build() {
+			return new LmdbCompactionMetrics(this);
+		}
+	}
+
+	/**
+	 * Snapshot of a single LMDB environment before or after compaction.
+	 */
+	public static final class EnvironmentMetrics {
+		private final String name;
+		private final long mapSize;
+		private final long pageSize;
+		private final long lastPageNumber;
+		private final long totalPages;
+		private final long branchPages;
+		private final long leafPages;
+		private final long overflowPages;
+
+		public EnvironmentMetrics(String name, long mapSize, long pageSize, long lastPageNumber, long totalPages,
+				long branchPages, long leafPages, long overflowPages) {
+			this.name = name;
+			this.mapSize = mapSize;
+			this.pageSize = pageSize;
+			this.lastPageNumber = lastPageNumber;
+			this.totalPages = totalPages;
+			this.branchPages = branchPages;
+			this.leafPages = leafPages;
+			this.overflowPages = overflowPages;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public long getMapSize() {
+			return mapSize;
+		}
+
+		public long getPageSize() {
+			return pageSize;
+		}
+
+		public long getLastPageNumber() {
+			return lastPageNumber;
+		}
+
+		public long getTotalPages() {
+			return totalPages;
+		}
+
+		public long getBranchPages() {
+			return branchPages;
+		}
+
+		public long getLeafPages() {
+			return leafPages;
+		}
+
+		public long getOverflowPages() {
+			return overflowPages;
+		}
+
+		public long getFreePages() {
+			long used = Math.max(lastPageNumber, branchPages + leafPages + overflowPages);
+			return Math.max(0, totalPages - used);
+		}
+
+		public double getFreePageRatio() {
+			if (totalPages == 0) {
+				return 0.0;
+			}
+			return (double) getFreePages() / (double) totalPages;
+		}
+	}
+}

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbCompactionOptions.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbCompactionOptions.java
@@ -1,0 +1,154 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.lmdb;
+
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Consumer;
+
+/**
+ * Fluent options used to drive a single LMDB compaction run.
+ */
+public final class LmdbCompactionOptions {
+
+	private final Path destinationDirectory;
+	private final Path temporaryDirectory;
+	private final boolean verifyAfterCopy;
+	private final boolean keepBackup;
+	private final LmdbCompactionProgressListener progressListener;
+	private final Consumer<LmdbCompactionMetrics> metricsConsumer;
+	private final Duration verificationTimeout;
+	private final String jobId;
+
+	private LmdbCompactionOptions(Builder builder) {
+		this.destinationDirectory = Objects.requireNonNull(builder.destinationDirectory, "destinationDirectory");
+		this.temporaryDirectory = Objects.requireNonNull(builder.temporaryDirectory, "temporaryDirectory");
+		this.verifyAfterCopy = builder.verifyAfterCopy;
+		this.keepBackup = builder.keepBackup;
+		this.progressListener = builder.progressListener;
+		this.metricsConsumer = builder.metricsConsumer;
+		this.verificationTimeout = builder.verificationTimeout;
+		this.jobId = builder.jobId != null ? builder.jobId : UUID.randomUUID().toString();
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public Path getDestinationDirectory() {
+		return destinationDirectory;
+	}
+
+	public Path getTemporaryDirectory() {
+		return temporaryDirectory;
+	}
+
+	public boolean isVerifyAfterCopy() {
+		return verifyAfterCopy;
+	}
+
+	public boolean isKeepBackup() {
+		return keepBackup;
+	}
+
+	public LmdbCompactionProgressListener getProgressListener() {
+		return progressListener;
+	}
+
+	public Consumer<LmdbCompactionMetrics> getMetricsConsumer() {
+		return metricsConsumer;
+	}
+
+	public Duration getVerificationTimeout() {
+		return verificationTimeout;
+	}
+
+	public String getJobId() {
+		return jobId;
+	}
+
+	/** Builder for {@link LmdbCompactionOptions}. */
+	public static final class Builder {
+		private Path destinationDirectory;
+		private Path temporaryDirectory;
+		private boolean verifyAfterCopy;
+		private boolean keepBackup = true;
+		private LmdbCompactionProgressListener progressListener = progress -> {
+		};
+		private Consumer<LmdbCompactionMetrics> metricsConsumer = metrics -> {
+		};
+		private Duration verificationTimeout = Duration.ofMinutes(10);
+		private String jobId;
+
+		private Builder() {
+		}
+
+		public Builder destinationDirectory(Path destinationDirectory) {
+			this.destinationDirectory = destinationDirectory;
+			if (this.temporaryDirectory == null && destinationDirectory != null) {
+				this.temporaryDirectory = destinationDirectory.getParent();
+			}
+			return this;
+		}
+
+		public Builder temporaryDirectory(Path temporaryDirectory) {
+			this.temporaryDirectory = temporaryDirectory;
+			return this;
+		}
+
+		public Builder verifyAfterCopy(boolean verifyAfterCopy) {
+			this.verifyAfterCopy = verifyAfterCopy;
+			return this;
+		}
+
+		public Builder keepBackup(boolean keepBackup) {
+			this.keepBackup = keepBackup;
+			return this;
+		}
+
+		public Builder progressListener(LmdbCompactionProgressListener progressListener) {
+			this.progressListener = Objects.requireNonNull(progressListener, "progressListener");
+			return this;
+		}
+
+		public Builder metricsConsumer(Consumer<LmdbCompactionMetrics> metricsConsumer) {
+			this.metricsConsumer = Objects.requireNonNull(metricsConsumer, "metricsConsumer");
+			return this;
+		}
+
+		public Builder verificationTimeout(Duration verificationTimeout) {
+			this.verificationTimeout = Objects.requireNonNull(verificationTimeout, "verificationTimeout");
+			return this;
+		}
+
+		public Builder jobId(String jobId) {
+			this.jobId = jobId;
+			return this;
+		}
+
+		public LmdbCompactionOptions build() {
+			if (destinationDirectory == null) {
+				throw new IllegalStateException("Destination directory must be provided");
+			}
+			if (temporaryDirectory == null) {
+				throw new IllegalStateException("Temporary directory must be provided");
+			}
+			return new LmdbCompactionOptions(this);
+		}
+	}
+
+	public Optional<String> getJobIdOptional() {
+		return Optional.of(jobId);
+	}
+}

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbCompactionProgress.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbCompactionProgress.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.lmdb;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Immutable progress payload emitted during LMDB compaction.
+ */
+public final class LmdbCompactionProgress {
+
+	public enum Phase {
+		/** The compaction request has been accepted and validation is in progress. */
+		VALIDATING,
+		/** All LMDB environments are currently being copied to the staging location. */
+		COPYING_ENVIRONMENTS,
+		/** Verification of the staged environment is running. */
+		VERIFYING,
+		/** The compacted environment is being swapped into place. */
+		SWAPPING,
+		/** Final clean-up after a successful compaction. */
+		FINISHED
+	}
+
+	private final Phase phase;
+	private final String message;
+	private final long completed;
+	private final long total;
+	private final Instant timestamp;
+
+	private LmdbCompactionProgress(Phase phase, String message, long completed, long total, Instant timestamp) {
+		this.phase = Objects.requireNonNull(phase, "phase");
+		this.message = message;
+		this.completed = completed;
+		this.total = total;
+		this.timestamp = Objects.requireNonNull(timestamp, "timestamp");
+	}
+
+	public static LmdbCompactionProgress of(Phase phase, String message) {
+		return new LmdbCompactionProgress(phase, message, -1, -1, Instant.now());
+	}
+
+	public static LmdbCompactionProgress of(Phase phase, long completed, long total, String message) {
+		return new LmdbCompactionProgress(phase, message, completed, total, Instant.now());
+	}
+
+	public Phase getPhase() {
+		return phase;
+	}
+
+	public Optional<String> getMessage() {
+		return Optional.ofNullable(message);
+	}
+
+	public Optional<Long> getCompleted() {
+		return completed >= 0 ? Optional.of(completed) : Optional.empty();
+	}
+
+	public Optional<Long> getTotal() {
+		return total >= 0 ? Optional.of(total) : Optional.empty();
+	}
+
+	public Instant getTimestamp() {
+		return timestamp;
+	}
+}

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbCompactionProgressListener.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbCompactionProgressListener.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.lmdb;
+
+/**
+ * Listener that receives progress callbacks during LMDB environment compaction.
+ */
+@FunctionalInterface
+public interface LmdbCompactionProgressListener {
+
+	/**
+	 * Invoked whenever a compaction phase makes progress.
+	 *
+	 * @param progress details about the current state of the compaction run.
+	 */
+	void onProgress(LmdbCompactionProgress progress);
+}

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbCompactionReport.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbCompactionReport.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.lmdb;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Result payload for a completed compaction run.
+ */
+public final class LmdbCompactionReport {
+
+	private final LmdbCompactionMetrics metrics;
+	private final Path backupDirectory;
+	private final Path compactedDirectory;
+	private final boolean verificationAttempted;
+	private final boolean verificationSucceeded;
+	private final List<String> warnings;
+
+	public LmdbCompactionReport(LmdbCompactionMetrics metrics, Path backupDirectory, Path compactedDirectory,
+			boolean verificationAttempted, boolean verificationSucceeded, List<String> warnings) {
+		this.metrics = Objects.requireNonNull(metrics, "metrics");
+		this.backupDirectory = backupDirectory;
+		this.compactedDirectory = compactedDirectory;
+		this.verificationAttempted = verificationAttempted;
+		this.verificationSucceeded = verificationSucceeded;
+		this.warnings = Collections.unmodifiableList(new ArrayList<>(warnings));
+	}
+
+	public LmdbCompactionMetrics getMetrics() {
+		return metrics;
+	}
+
+	public Optional<Path> getBackupDirectory() {
+		return Optional.ofNullable(backupDirectory);
+	}
+
+	public Optional<Path> getCompactedDirectory() {
+		return Optional.ofNullable(compactedDirectory);
+	}
+
+	public boolean isVerificationAttempted() {
+		return verificationAttempted;
+	}
+
+	public boolean isVerificationSucceeded() {
+		return verificationSucceeded;
+	}
+
+	public List<String> getWarnings() {
+		return warnings;
+	}
+}

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbCompactionTask.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbCompactionTask.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.lmdb;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+/**
+ * Convenience wrapper that executes LMDB compaction asynchronously.
+ */
+public final class LmdbCompactionTask implements Callable<LmdbCompactionReport> {
+
+	private final LmdbStore store;
+	private final LmdbCompactionOptions options;
+
+	public LmdbCompactionTask(LmdbStore store, LmdbCompactionOptions options) {
+		this.store = Objects.requireNonNull(store, "store");
+		this.options = Objects.requireNonNull(options, "options");
+	}
+
+	@Override
+	public LmdbCompactionReport call() throws IOException {
+		return store.compact(options);
+	}
+
+	public CompletableFuture<LmdbCompactionReport> submit(Executor executor) {
+		CompletableFuture<LmdbCompactionReport> future = new CompletableFuture<>();
+		executor.execute(() -> {
+			try {
+				future.complete(call());
+			} catch (Throwable t) {
+				future.completeExceptionally(t);
+			}
+		});
+		return future;
+	}
+}

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbMaintenance.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbMaintenance.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.lmdb;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.eclipse.rdf4j.sail.lmdb.config.LmdbStoreConfig;
+
+/**
+ * Convenience entry point for maintenance activities on LMDB data directories.
+ */
+public final class LmdbMaintenance {
+
+	private final LmdbStore store;
+
+	public LmdbMaintenance(LmdbStore store) {
+		this.store = Objects.requireNonNull(store, "store");
+	}
+
+	public Optional<LmdbCompactionReport> compactIfNeeded(LmdbCompactionOptions options) throws IOException {
+		Objects.requireNonNull(options, "options");
+		LmdbStoreConfig config = store.getStoreConfig();
+		if (!config.isCompactionAutoEnabled()) {
+			return Optional.empty();
+		}
+		return store.compactIfNeeded(options, config.getCompactionFragmentationThreshold());
+	}
+}

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbMaintenanceCli.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbMaintenanceCli.java
@@ -1,0 +1,187 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.lmdb;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import org.eclipse.rdf4j.sail.lmdb.config.LmdbStoreConfig;
+
+/**
+ * Command line entry point for LMDB maintenance operations.
+ */
+public final class LmdbMaintenanceCli {
+
+	private LmdbMaintenanceCli() {
+	}
+
+	public static void main(String[] args) {
+		try {
+			new Runner(args).run();
+		} catch (Exception e) {
+			System.err.println("LMDB maintenance failed: " + e.getMessage());
+			e.printStackTrace(System.err);
+			System.exit(1);
+		}
+	}
+
+	private static final class Runner {
+		private final List<String> args;
+
+		private Runner(String[] args) {
+			this.args = List.of(args);
+		}
+
+		void run() throws IOException {
+			if (args.contains("--help") || args.isEmpty()) {
+				printUsage();
+				return;
+			}
+
+			boolean compactRequested = false;
+			boolean verify = false;
+			boolean keepBackup = true;
+			Double threshold = null;
+			Path dataDir = null;
+			Path destination = null;
+			Path temporary = null;
+
+			for (int i = 0; i < args.size(); i++) {
+				String arg = args.get(i);
+				switch (arg) {
+				case "--compact":
+					compactRequested = true;
+					break;
+				case "--dataDir":
+					dataDir = Paths.get(requireValue(i++));
+					break;
+				case "--target":
+					destination = Paths.get(requireValue(i++));
+					break;
+				case "--temporary":
+					temporary = Paths.get(requireValue(i++));
+					break;
+				case "--threshold":
+					String thresholdValue = requireValue(i++);
+					threshold = Double.parseDouble(thresholdValue);
+					break;
+				case "--verify":
+					verify = true;
+					break;
+				case "--no-backup":
+					keepBackup = false;
+					break;
+				case "--keep-backup":
+					keepBackup = true;
+					break;
+				default:
+					if (arg.startsWith("--")) {
+						throw new IllegalArgumentException("Unknown option " + arg);
+					}
+				}
+			}
+
+			if (!compactRequested) {
+				printUsage();
+				return;
+			}
+			if (dataDir == null) {
+				throw new IllegalArgumentException("--dataDir must be provided");
+			}
+			if (!Files.isDirectory(dataDir)) {
+				throw new IllegalArgumentException("Data directory " + dataDir + " does not exist");
+			}
+
+			if (destination == null) {
+				destination = dataDir.resolveSibling(dataDir.getFileName() + "-compacted");
+			}
+			if (temporary == null) {
+				Path parent = destination.getParent();
+				temporary = parent != null ? parent : destination;
+			}
+
+			LmdbStoreConfig config = new LmdbStoreConfig();
+			LmdbStore store = new LmdbStore(dataDir.toFile(), config);
+			double fragmentation = store.estimateFragmentationRatio();
+			System.out.printf(Locale.ROOT, "Detected fragmentation ratio: %.4f%n", fragmentation);
+
+			if (threshold != null && fragmentation < threshold) {
+				System.out.printf(Locale.ROOT,
+						"Fragmentation %.4f below threshold %.4f; skipping compaction.%n",
+						fragmentation, threshold);
+				return;
+			}
+
+			LmdbCompactionOptions options = LmdbCompactionOptions.builder()
+					.destinationDirectory(destination)
+					.temporaryDirectory(temporary)
+					.verifyAfterCopy(verify)
+					.keepBackup(keepBackup)
+					.build();
+
+			LmdbCompactionReport report = store.compact(options);
+			printReport(report);
+		}
+
+		private void printReport(LmdbCompactionReport report) {
+			LmdbCompactionMetrics metrics = report.getMetrics();
+			System.out.println("Compaction completed successfully.");
+			System.out.printf(Locale.ROOT, "  Started:   %s%n", metrics.getStartedAt());
+			System.out.printf(Locale.ROOT, "  Completed: %s%n", metrics.getCompletedAt());
+			System.out.printf(Locale.ROOT, "  Duration:  %s%n", metrics.getCopyDuration());
+			System.out.printf(Locale.ROOT, "  Size:      %s -> %s%n",
+					formatSize(metrics.getFileSizeBeforeBytes()),
+					formatSize(metrics.getFileSizeAfterBytes()));
+			System.out.printf(Locale.ROOT, "  Free page ratio: %.4f -> %.4f%n",
+					metrics.getTotalFreePageRatioBefore(), metrics.getTotalFreePageRatioAfter());
+			report.getBackupDirectory().ifPresent(path -> System.out.println("  Backup:    " + path));
+		}
+
+		private String formatSize(long bytes) {
+			final String[] units = { "B", "KiB", "MiB", "GiB", "TiB" };
+			double size = bytes;
+			int unit = 0;
+			while (size >= 1024 && unit < units.length - 1) {
+				size /= 1024;
+				unit++;
+			}
+			return String.format(Locale.ROOT, "%.2f %s", size, units[unit]);
+		}
+
+		private String requireValue(int index) {
+			if (index + 1 >= args.size()) {
+				throw new IllegalArgumentException("Missing value for " + args.get(index));
+			}
+			return args.get(index + 1);
+		}
+
+		private void printUsage() {
+			List<String> lines = new ArrayList<>();
+			lines.add("Usage: rdf4j-lmdb-maintenance.sh --compact --dataDir <path> [options]");
+			lines.add("Options:");
+			lines.add("  --dataDir <path>          LMDB data directory");
+			lines.add("  --compact                 Run compaction");
+			lines.add("  --target <path>           Destination directory for staged copy");
+			lines.add("  --temporary <path>        Temporary directory used during swap");
+			lines.add("  --threshold <ratio>       Minimum fragmentation ratio required to compact");
+			lines.add("  --verify                  Verify staged copy before swap");
+			lines.add("  --no-backup               Remove backup once compaction succeeds");
+			lines.add("  --keep-backup             Retain backup (default)");
+			lines.add("  --help                    Show this help message");
+			lines.forEach(System.out::println);
+		}
+	}
+}

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbStore.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbStore.java
@@ -10,12 +10,40 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.lmdb;
 
+import static org.eclipse.rdf4j.sail.lmdb.LmdbUtil.E;
+import static org.lwjgl.system.MemoryStack.stackPush;
+import static org.lwjgl.util.lmdb.LMDB.MDB_CP_COMPACT;
+import static org.lwjgl.util.lmdb.LMDB.MDB_INVALID;
+import static org.lwjgl.util.lmdb.LMDB.MDB_NOTLS;
+import static org.lwjgl.util.lmdb.LMDB.MDB_RDONLY;
+import static org.lwjgl.util.lmdb.LMDB.mdb_env_close;
+import static org.lwjgl.util.lmdb.LMDB.mdb_env_copy2;
+import static org.lwjgl.util.lmdb.LMDB.mdb_env_create;
+import static org.lwjgl.util.lmdb.LMDB.mdb_env_info;
+import static org.lwjgl.util.lmdb.LMDB.mdb_env_open;
+import static org.lwjgl.util.lmdb.LMDB.mdb_env_set_mapsize;
+import static org.lwjgl.util.lmdb.LMDB.mdb_env_set_maxdbs;
+import static org.lwjgl.util.lmdb.LMDB.mdb_env_stat;
+
 import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
@@ -45,6 +73,10 @@ import org.eclipse.rdf4j.sail.base.SnapshotSailStore;
 import org.eclipse.rdf4j.sail.helpers.AbstractNotifyingSail;
 import org.eclipse.rdf4j.sail.helpers.DirectoryLockManager;
 import org.eclipse.rdf4j.sail.lmdb.config.LmdbStoreConfig;
+import org.lwjgl.PointerBuffer;
+import org.lwjgl.system.MemoryStack;
+import org.lwjgl.util.lmdb.MDBEnvInfo;
+import org.lwjgl.util.lmdb.MDBStat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -411,6 +443,344 @@ public class LmdbStore extends AbstractNotifyingSail implements FederatedService
 	@Override
 	public Supplier<CollectionFactory> getCollectionFactory() {
 		return () -> new MapDb3CollectionFactory(getIterationCacheSyncThreshold());
+	}
+
+	public LmdbStoreConfig getStoreConfig() {
+		return config;
+	}
+
+	/**
+	 * Performs an offline LMDB compaction by copying all environments to a staging directory and atomically swapping
+	 * the compacted copy into place.
+	 *
+	 * @param options compaction options
+	 * @return a report describing the outcome of the compaction run
+	 * @throws IOException if the compaction fails
+	 */
+	public LmdbCompactionReport compact(LmdbCompactionOptions options) throws IOException {
+		Objects.requireNonNull(options, "options");
+		File dataDir = getDataDir();
+		if (dataDir == null) {
+			throw new IllegalStateException("Data directory is not configured");
+		}
+		if (store != null) {
+			throw new IllegalStateException("LmdbStore must be shut down before running compaction");
+		}
+		Path sourceDir = dataDir.toPath();
+		if (!Files.isDirectory(sourceDir)) {
+			throw new IOException("LMDB data directory does not exist: " + sourceDir);
+		}
+		LmdbCompactionProgressListener progressListener = options.getProgressListener();
+		progressListener.onProgress(LmdbCompactionProgress
+				.of(LmdbCompactionProgress.Phase.VALIDATING, "Validating LMDB compaction prerequisites"));
+		Path stagingDir = options.getDestinationDirectory();
+		if (sourceDir.equals(stagingDir)) {
+			throw new IllegalArgumentException("Destination directory must differ from the source data directory");
+		}
+		ensureDestinationIsEmpty(stagingDir);
+		Path temporaryRoot = options.getTemporaryDirectory();
+		Files.createDirectories(temporaryRoot);
+		Path backupDir = uniqueChild(temporaryRoot, "lmdb-backup-" + options.getJobId());
+		Instant started = Instant.now();
+		long sizeBefore = directorySize(sourceDir);
+		LmdbCompactionMetrics.Builder metricsBuilder = LmdbCompactionMetrics.builder()
+				.fileSizeBeforeBytes(sizeBefore)
+				.startedAt(started);
+		DirectoryLockManager lockManager = new DirectoryLockManager(dataDir);
+		Lock lock = null;
+		boolean swapped = false;
+		boolean verificationAttempted = false;
+		boolean verificationSucceeded = false;
+		List<String> warnings = new ArrayList<>();
+		try {
+			lock = lockManager.lockOrFail();
+			copyStore(sourceDir, stagingDir, progressListener, metricsBuilder);
+			if (options.isVerifyAfterCopy()) {
+				verificationAttempted = true;
+				progressListener.onProgress(LmdbCompactionProgress
+						.of(LmdbCompactionProgress.Phase.VERIFYING, "Verifying staged LMDB environment"));
+				try {
+					verifyCompactedStore(stagingDir);
+					verificationSucceeded = true;
+				} catch (SailException e) {
+					throw new IOException("Verification of staged LMDB environment failed", e);
+				}
+			} else {
+				progressListener.onProgress(LmdbCompactionProgress
+						.of(LmdbCompactionProgress.Phase.VERIFYING, "Verification skipped by configuration"));
+				verificationSucceeded = true;
+			}
+			progressListener.onProgress(LmdbCompactionProgress
+					.of(LmdbCompactionProgress.Phase.SWAPPING, "Swapping compacted environment into place"));
+			swapDirectories(sourceDir, stagingDir, backupDir);
+			swapped = true;
+		} finally {
+			if (lock != null) {
+				lock.release();
+			}
+			if (!swapped) {
+				safeDeleteQuietly(stagingDir);
+				safeDeleteQuietly(backupDir);
+			}
+		}
+		Instant completed = Instant.now();
+		long sizeAfter = directorySize(sourceDir);
+		metricsBuilder.fileSizeAfterBytes(sizeAfter)
+				.copyDuration(Duration.between(started, completed))
+				.completedAt(completed);
+		LmdbCompactionMetrics metrics = metricsBuilder.build();
+		options.getMetricsConsumer().accept(metrics);
+		progressListener.onProgress(
+				LmdbCompactionProgress.of(LmdbCompactionProgress.Phase.FINISHED, "LMDB compaction finished"));
+		Path reportBackup = backupDir;
+		if (!options.isKeepBackup()) {
+			safeDeleteQuietly(backupDir);
+			reportBackup = null;
+		}
+		return new LmdbCompactionReport(metrics, reportBackup, sourceDir, verificationAttempted, verificationSucceeded,
+				warnings);
+	}
+
+	public Optional<LmdbCompactionReport> compactIfNeeded(LmdbCompactionOptions options, double fragmentationThreshold)
+			throws IOException {
+		Objects.requireNonNull(options, "options");
+		double fragmentation = estimateFragmentationRatio();
+		if (fragmentation >= fragmentationThreshold) {
+			return Optional.of(compact(options));
+		}
+		return Optional.empty();
+	}
+
+	public double estimateFragmentationRatio() throws IOException {
+		File dataDir = getDataDir();
+		if (dataDir == null) {
+			throw new IllegalStateException("Data directory is not configured");
+		}
+		Path sourceDir = dataDir.toPath();
+		if (!Files.isDirectory(sourceDir)) {
+			return 0.0;
+		}
+		List<Path> environments = collectEnvironmentDirectories(sourceDir);
+		if (environments.isEmpty()) {
+			return 0.0;
+		}
+		double total = 0.0;
+		for (Path env : environments) {
+			String label = sourceDir.relativize(env).toString();
+			LmdbCompactionMetrics.EnvironmentMetrics metrics = readEnvironmentMetrics(env, label);
+			total += metrics.getFreePageRatio();
+		}
+		return total / environments.size();
+	}
+
+	private void copyStore(Path sourceDir, Path stagingDir, LmdbCompactionProgressListener progressListener,
+			LmdbCompactionMetrics.Builder metricsBuilder) throws IOException {
+		progressListener.onProgress(LmdbCompactionProgress
+				.of(LmdbCompactionProgress.Phase.COPYING_ENVIRONMENTS, "Copying LMDB environments"));
+		List<Path> environments = collectEnvironmentDirectories(sourceDir);
+		Set<Path> envSet = new HashSet<>(environments);
+		Files.createDirectories(stagingDir);
+		final int total = environments.size();
+		final int[] counter = new int[] { 0 };
+		Files.walkFileTree(sourceDir, new SimpleFileVisitor<>() {
+			@Override
+			public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
+				if (dir.equals(sourceDir)) {
+					return FileVisitResult.CONTINUE;
+				}
+				Path relative = sourceDir.relativize(dir);
+				Path target = stagingDir.resolve(relative);
+				if (envSet.contains(dir)) {
+					int current = ++counter[0];
+					String label = relative.toString();
+					progressListener.onProgress(LmdbCompactionProgress.of(
+							LmdbCompactionProgress.Phase.COPYING_ENVIRONMENTS, current, Math.max(total, 1),
+							"Copying " + label));
+					metricsBuilder.addEnvironmentBefore(readEnvironmentMetrics(dir, label));
+					copyEnvironment(dir, target);
+					metricsBuilder.addEnvironmentAfter(readEnvironmentMetrics(target, label));
+					return FileVisitResult.SKIP_SUBTREE;
+				}
+				Files.createDirectories(target);
+				return FileVisitResult.CONTINUE;
+			}
+
+			@Override
+			public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+				Path target = stagingDir.resolve(sourceDir.relativize(file));
+				Files.createDirectories(target.getParent());
+				Files.copy(file, target, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.COPY_ATTRIBUTES);
+				return FileVisitResult.CONTINUE;
+			}
+		});
+	}
+
+	private List<Path> collectEnvironmentDirectories(Path sourceDir) throws IOException {
+		List<Path> result = new ArrayList<>();
+		try (Stream<Path> stream = Files.walk(sourceDir)) {
+			stream.filter(Files::isDirectory).forEach(dir -> {
+				Path parent = dir.getParent();
+				if (Files.exists(dir.resolve("data.mdb")) && !dir.equals(sourceDir)
+						&& (parent == null || !Files.exists(parent.resolve("data.mdb")))) {
+					result.add(dir);
+				}
+			});
+		}
+		result.sort(Comparator.naturalOrder());
+		return result;
+	}
+
+	private void copyEnvironment(Path sourceEnv, Path targetEnv) throws IOException {
+		safeDeleteQuietly(targetEnv);
+		Files.createDirectories(targetEnv);
+		try (MemoryStack stack = stackPush()) {
+			PointerBuffer pp = stack.mallocPointer(1);
+			E(mdb_env_create(pp));
+			long env = pp.get(0);
+			try {
+				E(mdb_env_set_maxdbs(env, 64));
+				int flags = MDB_NOTLS | MDB_RDONLY;
+				E(mdb_env_open(env, sourceEnv.toAbsolutePath().toString(), flags, 0664));
+				int rc = mdb_env_copy2(env, targetEnv.toAbsolutePath().toString(), MDB_CP_COMPACT);
+				if (rc == MDB_INVALID) {
+					E(mdb_env_copy2(env, targetEnv.toAbsolutePath().toString(), 0));
+					shrinkEnvironment(targetEnv);
+				} else {
+					E(rc);
+				}
+			} finally {
+				mdb_env_close(env);
+			}
+		}
+	}
+
+	private void shrinkEnvironment(Path envDir) throws IOException {
+		try (MemoryStack stack = stackPush()) {
+			PointerBuffer pp = stack.mallocPointer(1);
+			E(mdb_env_create(pp));
+			long env = pp.get(0);
+			try {
+				E(mdb_env_set_maxdbs(env, 64));
+				E(mdb_env_open(env, envDir.toAbsolutePath().toString(), MDB_NOTLS, 0664));
+				MDBStat stat = MDBStat.malloc(stack);
+				E(mdb_env_stat(env, stat));
+				MDBEnvInfo info = MDBEnvInfo.malloc(stack);
+				mdb_env_info(env, info);
+				long pageSize = stat.ms_psize();
+				long usedPages = info.me_last_pgno() + 1;
+				long targetSize = usedPages * pageSize;
+				if (targetSize < info.me_mapsize()) {
+					E(mdb_env_set_mapsize(env, targetSize));
+				}
+			} finally {
+				mdb_env_close(env);
+			}
+		}
+	}
+
+	private LmdbCompactionMetrics.EnvironmentMetrics readEnvironmentMetrics(Path envDir, String label)
+			throws IOException {
+		try (MemoryStack stack = stackPush()) {
+			PointerBuffer pp = stack.mallocPointer(1);
+			E(mdb_env_create(pp));
+			long env = pp.get(0);
+			try {
+				E(mdb_env_set_maxdbs(env, 64));
+				E(mdb_env_open(env, envDir.toAbsolutePath().toString(), MDB_RDONLY | MDB_NOTLS, 0664));
+				MDBStat stat = MDBStat.malloc(stack);
+				E(mdb_env_stat(env, stat));
+				MDBEnvInfo info = MDBEnvInfo.malloc(stack);
+				mdb_env_info(env, info);
+				long pageSize = stat.ms_psize();
+				long totalPages = pageSize == 0 ? 0 : info.me_mapsize() / pageSize;
+				return new LmdbCompactionMetrics.EnvironmentMetrics(label, info.me_mapsize(), pageSize,
+						info.me_last_pgno(), totalPages, stat.ms_branch_pages(), stat.ms_leaf_pages(),
+						stat.ms_overflow_pages());
+			} finally {
+				mdb_env_close(env);
+			}
+		}
+	}
+
+	private void verifyCompactedStore(Path stagingDir) throws SailException {
+		LmdbStore verificationStore = new LmdbStore(stagingDir.toFile(), config);
+		verificationStore.init();
+		verificationStore.shutDown();
+	}
+
+	private void swapDirectories(Path sourceDir, Path stagingDir, Path backupDir) throws IOException {
+		safeDeleteQuietly(backupDir);
+		Files.createDirectories(backupDir.getParent());
+		moveDirectory(sourceDir, backupDir);
+		try {
+			moveDirectory(stagingDir, sourceDir);
+		} catch (IOException e) {
+			moveDirectory(backupDir, sourceDir);
+			throw e;
+		}
+	}
+
+	private void moveDirectory(Path source, Path target) throws IOException {
+		try {
+			Files.move(source, target, StandardCopyOption.ATOMIC_MOVE);
+		} catch (IOException e) {
+			Files.move(source, target, StandardCopyOption.REPLACE_EXISTING);
+		}
+	}
+
+	private void ensureDestinationIsEmpty(Path destination) throws IOException {
+		if (Files.exists(destination)) {
+			try (Stream<Path> stream = Files.list(destination)) {
+				if (stream.findAny().isPresent()) {
+					throw new IOException("Destination directory must be empty: " + destination);
+				}
+			}
+		} else {
+			Files.createDirectories(destination);
+		}
+	}
+
+	private Path uniqueChild(Path parent, String prefix) throws IOException {
+		Files.createDirectories(parent);
+		Path candidate = parent.resolve(prefix);
+		int counter = 0;
+		while (Files.exists(candidate)) {
+			counter++;
+			candidate = parent.resolve(prefix + "-" + counter);
+		}
+		return candidate;
+	}
+
+	private void safeDeleteQuietly(Path path) {
+		if (path == null) {
+			return;
+		}
+		try {
+			if (Files.notExists(path)) {
+				return;
+			}
+			if (Files.isDirectory(path)) {
+				FileUtils.deleteDirectory(path.toFile());
+			} else {
+				Files.deleteIfExists(path);
+			}
+		} catch (IOException e) {
+			logger.warn("Failed to delete temporary directory {}", path, e);
+		}
+	}
+
+	private long directorySize(Path root) throws IOException {
+		try (Stream<Path> stream = Files.walk(root)) {
+			return stream.filter(Files::isRegularFile).mapToLong(path -> {
+				try {
+					return Files.size(path);
+				} catch (IOException e) {
+					throw new UncheckedIOException(e);
+				}
+			}).sum();
+		} catch (UncheckedIOException e) {
+			throw e.getCause();
+		}
 	}
 
 }

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/config/LmdbStoreConfig.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/config/LmdbStoreConfig.java
@@ -55,6 +55,10 @@ public class LmdbStoreConfig extends BaseSailConfig {
 	 */
 	public static final int NAMESPACE_ID_CACHE_SIZE = 32;
 
+	public static final double DEFAULT_COMPACTION_FRAGMENTATION_THRESHOLD = 0.35;
+
+	public static final long DEFAULT_COMPACTION_MIN_INTERVAL = Duration.ofDays(7).toMillis();
+
 	private String tripleIndexes;
 
 	private long tripleDBSize = -1;
@@ -74,6 +78,12 @@ public class LmdbStoreConfig extends BaseSailConfig {
 	private boolean autoGrow = true;
 
 	private long valueEvictionInterval = Duration.ofSeconds(60).toMillis();
+
+	private boolean compactionAutoEnabled = false;
+
+	private double compactionFragmentationThreshold = DEFAULT_COMPACTION_FRAGMENTATION_THRESHOLD;
+
+	private long compactionMinimumInterval = DEFAULT_COMPACTION_MIN_INTERVAL;
 
 	/*--------------*
 	 * Constructors *
@@ -190,6 +200,39 @@ public class LmdbStoreConfig extends BaseSailConfig {
 		return this;
 	}
 
+	public boolean isCompactionAutoEnabled() {
+		return compactionAutoEnabled;
+	}
+
+	public LmdbStoreConfig setCompactionAutoEnabled(boolean compactionAutoEnabled) {
+		this.compactionAutoEnabled = compactionAutoEnabled;
+		return this;
+	}
+
+	public double getCompactionFragmentationThreshold() {
+		return compactionFragmentationThreshold;
+	}
+
+	public LmdbStoreConfig setCompactionFragmentationThreshold(double compactionFragmentationThreshold) {
+		if (compactionFragmentationThreshold < 0.0 || compactionFragmentationThreshold > 1.0) {
+			throw new IllegalArgumentException("Compaction fragmentation threshold must be between 0.0 and 1.0");
+		}
+		this.compactionFragmentationThreshold = compactionFragmentationThreshold;
+		return this;
+	}
+
+	public long getCompactionMinimumInterval() {
+		return compactionMinimumInterval;
+	}
+
+	public LmdbStoreConfig setCompactionMinimumInterval(long compactionMinimumInterval) {
+		if (compactionMinimumInterval < 0) {
+			throw new IllegalArgumentException("Compaction minimum interval must be >= 0");
+		}
+		this.compactionMinimumInterval = compactionMinimumInterval;
+		return this;
+	}
+
 	@Override
 	public Resource export(Model m) {
 		Resource implNode = super.export(m);
@@ -225,6 +268,16 @@ public class LmdbStoreConfig extends BaseSailConfig {
 		}
 		if (valueEvictionInterval != Duration.ofSeconds(60).toMillis()) {
 			m.add(implNode, LmdbStoreSchema.VALUE_EVICTION_INTERVAL, vf.createLiteral(valueEvictionInterval));
+		}
+		if (compactionAutoEnabled) {
+			m.add(implNode, LmdbStoreSchema.COMPACTION_AUTO_ENABLED, vf.createLiteral(true));
+		}
+		if (Double.compare(compactionFragmentationThreshold, DEFAULT_COMPACTION_FRAGMENTATION_THRESHOLD) != 0) {
+			m.add(implNode, LmdbStoreSchema.COMPACTION_FRAGMENTATION_THRESHOLD,
+					vf.createLiteral(compactionFragmentationThreshold));
+		}
+		if (compactionMinimumInterval != DEFAULT_COMPACTION_MIN_INTERVAL) {
+			m.add(implNode, LmdbStoreSchema.COMPACTION_MIN_INTERVAL, vf.createLiteral(compactionMinimumInterval));
 		}
 		return implNode;
 	}
@@ -327,6 +380,39 @@ public class LmdbStoreConfig extends BaseSailConfig {
 						} catch (NumberFormatException e) {
 							throw new SailConfigException(
 									"Long value required for " + LmdbStoreSchema.VALUE_EVICTION_INTERVAL
+											+ " property, found " + lit);
+						}
+					});
+
+			Models.objectLiteral(m.getStatements(implNode, LmdbStoreSchema.COMPACTION_AUTO_ENABLED, null))
+					.ifPresent(lit -> {
+						try {
+							setCompactionAutoEnabled(lit.booleanValue());
+						} catch (IllegalArgumentException e) {
+							throw new SailConfigException(
+									"Boolean value required for " + LmdbStoreSchema.COMPACTION_AUTO_ENABLED
+											+ " property, found " + lit);
+						}
+					});
+
+			Models.objectLiteral(m.getStatements(implNode, LmdbStoreSchema.COMPACTION_FRAGMENTATION_THRESHOLD, null))
+					.ifPresent(lit -> {
+						try {
+							setCompactionFragmentationThreshold(lit.doubleValue());
+						} catch (NumberFormatException e) {
+							throw new SailConfigException(
+									"Double value required for " + LmdbStoreSchema.COMPACTION_FRAGMENTATION_THRESHOLD
+											+ " property, found " + lit);
+						}
+					});
+
+			Models.objectLiteral(m.getStatements(implNode, LmdbStoreSchema.COMPACTION_MIN_INTERVAL, null))
+					.ifPresent(lit -> {
+						try {
+							setCompactionMinimumInterval(lit.longValue());
+						} catch (NumberFormatException e) {
+							throw new SailConfigException(
+									"Long value required for " + LmdbStoreSchema.COMPACTION_MIN_INTERVAL
 											+ " property, found " + lit);
 						}
 					});

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/config/LmdbStoreSchema.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/config/LmdbStoreSchema.java
@@ -76,6 +76,21 @@ public class LmdbStoreSchema {
 	 */
 	public final static IRI VALUE_EVICTION_INTERVAL;
 
+	/**
+	 * <tt>http://rdf4j.org/config/sail/lmdb#compactAutoEnabled</tt>
+	 */
+	public final static IRI COMPACTION_AUTO_ENABLED;
+
+	/**
+	 * <tt>http://rdf4j.org/config/sail/lmdb#compactThreshold</tt>
+	 */
+	public final static IRI COMPACTION_FRAGMENTATION_THRESHOLD;
+
+	/**
+	 * <tt>http://rdf4j.org/config/sail/lmdb#compactMinInterval</tt>
+	 */
+	public final static IRI COMPACTION_MIN_INTERVAL;
+
 	static {
 		ValueFactory factory = SimpleValueFactory.getInstance();
 		TRIPLE_INDEXES = factory.createIRI(NAMESPACE, "tripleIndexes");
@@ -88,5 +103,8 @@ public class LmdbStoreSchema {
 		NAMESPACE_ID_CACHE_SIZE = factory.createIRI(NAMESPACE, "namespaceIDCacheSize");
 		AUTO_GROW = factory.createIRI(NAMESPACE, "autoGrow");
 		VALUE_EVICTION_INTERVAL = factory.createIRI(NAMESPACE, "valueEvictionInterval");
+		COMPACTION_AUTO_ENABLED = factory.createIRI(NAMESPACE, "compactAutoEnabled");
+		COMPACTION_FRAGMENTATION_THRESHOLD = factory.createIRI(NAMESPACE, "compactThreshold");
+		COMPACTION_MIN_INTERVAL = factory.createIRI(NAMESPACE, "compactMinInterval");
 	}
 }

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbCompactionIT.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbCompactionIT.java
@@ -1,0 +1,224 @@
+package org.eclipse.rdf4j.sail.lmdb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.sail.lmdb.config.LmdbStoreConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Integration test for LMDB compaction.
+ */
+public class LmdbCompactionIT {
+
+	@TempDir
+	File tempDir;
+
+	private File dataDir;
+	private LmdbStoreConfig config;
+
+	@BeforeEach
+	void setUp() {
+		dataDir = new File(tempDir, "store");
+		config = new LmdbStoreConfig("spoc,posc");
+	}
+
+	@Test
+	void compactShrinksStoreAndPreservesData() throws Exception {
+		List<Statement> retainedStatements = new ArrayList<>();
+		createFragmentedStore(retainedStatements);
+
+		long sizeBefore = directorySize(dataDir.toPath());
+		Path destinationDir = tempDir.toPath().resolve("compacted");
+		Files.createDirectories(destinationDir);
+		Path temporaryDir = tempDir.toPath().resolve("temp-swap");
+		Files.createDirectories(temporaryDir);
+
+		Class<?> optionsClass;
+		try {
+			optionsClass = Class.forName("org.eclipse.rdf4j.sail.lmdb.LmdbCompactionOptions");
+		} catch (ClassNotFoundException e) {
+			fail("LMDB compaction options should be available", e);
+			return;
+		}
+
+		Object optionsBuilder = invokeStatic(optionsClass, "builder");
+
+		optionsBuilder = invoke(optionsBuilder, "destinationDirectory", destinationDir);
+		optionsBuilder = invoke(optionsBuilder, "temporaryDirectory", temporaryDir);
+		optionsBuilder = invoke(optionsBuilder, "verifyAfterCopy", true);
+
+		Class<?> progressListenerClass = Class
+				.forName("org.eclipse.rdf4j.sail.lmdb.LmdbCompactionProgressListener");
+		CopyOnWriteArrayList<Object> progressEvents = new CopyOnWriteArrayList<>();
+		Object progressListenerProxy = Proxy.newProxyInstance(progressListenerClass.getClassLoader(),
+				new Class[] { progressListenerClass }, new ProgressInvocationHandler(progressEvents));
+		optionsBuilder = invoke(optionsBuilder, "progressListener", progressListenerProxy);
+
+		AtomicReference<Object> metricsFromCallback = new AtomicReference<>();
+		optionsBuilder = invoke(optionsBuilder, "metricsConsumer", (Consumer<Object>) metricsFromCallback::set);
+
+		Object options = invoke(optionsBuilder, "build");
+
+		LmdbStore store = new LmdbStore(dataDir, config);
+		Method compactMethod = LmdbStore.class.getMethod("compact", optionsClass);
+		Object report = compactMethod.invoke(store, options);
+
+		Class<?> reportClass = Class.forName("org.eclipse.rdf4j.sail.lmdb.LmdbCompactionReport");
+		assertThat(reportClass.isInstance(report)).isTrue();
+
+		Method metricsGetter = reportClass.getMethod("getMetrics");
+		Object metrics = metricsGetter.invoke(report);
+		assertThat(metrics).isNotNull();
+
+		Class<?> metricsClass = Class.forName("org.eclipse.rdf4j.sail.lmdb.LmdbCompactionMetrics");
+		assertThat(metricsClass.isInstance(metrics)).isTrue();
+
+		long sizeAfter = directorySize(dataDir.toPath());
+		Method beforeGetter = metricsClass.getMethod("getFileSizeBeforeBytes");
+		Method afterGetter = metricsClass.getMethod("getFileSizeAfterBytes");
+		long reportedBefore = ((Number) beforeGetter.invoke(metrics)).longValue();
+		long reportedAfter = ((Number) afterGetter.invoke(metrics)).longValue();
+
+		assertThat(reportedBefore).isEqualTo(sizeBefore);
+		assertThat(reportedAfter).isEqualTo(sizeAfter);
+		assertThat(sizeAfter).isLessThan(sizeBefore);
+
+		assertThat(metricsFromCallback.get()).isSameAs(metrics);
+		assertThat(progressEvents).isNotEmpty();
+
+		verifyDataPreserved(retainedStatements);
+	}
+
+	private void createFragmentedStore(List<Statement> retainedStatements) throws IOException {
+		SailRepository repo = new SailRepository(new LmdbStore(dataDir, config));
+		repo.init();
+
+		ValueFactory vf = repo.getValueFactory();
+		List<Statement> inserted = new ArrayList<>();
+		try (RepositoryConnection conn = repo.getConnection()) {
+			conn.begin();
+			for (int i = 0; i < 2000; i++) {
+				IRI subject = vf.createIRI("urn:s:" + (i % 200));
+				IRI predicate = vf.createIRI("urn:p:" + (i % 10));
+				Statement st = vf.createStatement(subject, predicate, vf.createLiteral("value-" + i));
+				conn.add(st);
+				inserted.add(st);
+			}
+			conn.commit();
+
+			conn.begin();
+			for (int i = 0; i < inserted.size(); i++) {
+				Statement st = inserted.get(i);
+				if (i % 3 == 0) {
+					conn.remove(st);
+				} else {
+					retainedStatements.add(st);
+				}
+			}
+			conn.commit();
+		}
+
+		repo.shutDown();
+	}
+
+	private void verifyDataPreserved(List<Statement> retainedStatements) {
+		SailRepository repo = new SailRepository(new LmdbStore(dataDir, config));
+		repo.init();
+		try (RepositoryConnection conn = repo.getConnection()) {
+			Set<Statement> statements = conn.getStatements(null, null, null, false)
+					.stream()
+					.collect(Collectors.toSet());
+			assertThat(statements).containsExactlyInAnyOrderElementsOf(retainedStatements);
+		}
+		repo.shutDown();
+	}
+
+	private static long directorySize(Path root) throws IOException {
+		try (var stream = Files.walk(root)) {
+			return stream.filter(Files::isRegularFile).mapToLong(path -> {
+				try {
+					return Files.size(path);
+				} catch (IOException e) {
+					throw new RuntimeException(e);
+				}
+			}).sum();
+		}
+	}
+
+	private static Object invokeStatic(Class<?> type, String method) {
+		try {
+			return type.getMethod(method).invoke(null);
+		} catch (ReflectiveOperationException e) {
+			throw new AssertionError("Failed to invoke static method " + method + " on " + type, e);
+		}
+	}
+
+	private static Object invoke(Object target, String method, Object... args) {
+		try {
+			Class<?>[] parameterTypes = new Class<?>[args.length];
+			for (int i = 0; i < args.length; i++) {
+				Object arg = args[i];
+				parameterTypes[i] = arg == null ? Object.class : arg.getClass();
+			}
+			Method m = findMethod(target.getClass(), method, parameterTypes);
+			if (m == null) {
+				throw new AssertionError("Method " + method + " not found on " + target.getClass());
+			}
+			return m.invoke(target, args);
+		} catch (ReflectiveOperationException e) {
+			throw new AssertionError("Failed to invoke method " + method + " on " + target.getClass(), e);
+		}
+	}
+
+	private static Method findMethod(Class<?> clazz, String name, Class<?>[] parameterTypes) {
+		for (Method method : clazz.getMethods()) {
+			if (!method.getName().equals(name)) {
+				continue;
+			}
+			if (method.getParameterCount() != parameterTypes.length) {
+				continue;
+			}
+			return method;
+		}
+		return null;
+	}
+
+	private static final class ProgressInvocationHandler implements InvocationHandler {
+		private final CopyOnWriteArrayList<Object> events;
+
+		ProgressInvocationHandler(CopyOnWriteArrayList<Object> events) {
+			this.events = events;
+		}
+
+		@Override
+		public Object invoke(Object proxy, Method method, Object[] args) {
+			if (args != null && args.length == 1) {
+				events.add(args[0]);
+			}
+			return null;
+		}
+	}
+}

--- a/docs/storage/LMDB_COMPACTION.md
+++ b/docs/storage/LMDB_COMPACTION.md
@@ -1,0 +1,111 @@
+# LMDB Compaction Architecture
+
+LMDB environments accumulate free pages and fragmentation over time. RDF4J now ships with an
+on-demand compaction workflow that rewrites the store into a fresh directory, verifies the copy,
+and atomically swaps it into place. The process is designed to be offline and safe: the original
+data directory is preserved as a backup until the swap completes successfully.
+
+## High-level dataflow
+
+```mermaid
+flowchart TD
+    A[Maintenance trigger] --> B{Collect fragmentation metrics}
+    B -->|below threshold| C[Exit]
+    B -->|above threshold| D[Stage destination directory]
+    D --> E[Copy LMDB environments
+    (MDB_CP_COMPACT)]
+    E --> F[Optional verification
+    via LmdbStore.init()]
+    F --> G[Atomic swap & backup]
+    G --> H[Emit metrics/report]
+```
+
+## Workflow summary
+
+1. **Validation** – Ensure the store is shut down, compute baseline metrics, and prepare staging and
+   temporary directories.
+2. **Copy** – Each LMDB environment (`values`, `triples`, persistent set caches, …) is copied with
+   `mdb_env_copy2(..., MDB_CP_COMPACT)`. If the host does not support the compact flag the
+   destination map size is shrunk to the minimum required number of pages.
+3. **Verification (optional)** – A temporary `LmdbStore` instance opens the staged directory; if the
+   initialization succeeds the snapshot is considered valid.
+4. **Swap** – The live data directory is renamed into a timestamped backup and the staged copy is
+   atomically moved into place.
+5. **Reporting** – A `LmdbCompactionReport` captures timings, file sizes, free-page ratios, and backup
+   details. Callers may subscribe to progress events and metric callbacks.
+
+## Configuration properties
+
+Add the following entries to an LMDB store configuration to enable automatic maintenance:
+
+| Key | Default | Description |
+| --- | --- | --- |
+| `lmdb:compactAutoEnabled` | `false` | Enables the automatic compaction check executed by maintenance tools. |
+| `lmdb:compactThreshold` | `0.35` | Fragmentation ratio (free pages / total pages) that triggers compaction. |
+| `lmdb:compactMinInterval` | `7 days` | Minimum interval between automatic compaction runs (informational hint for schedulers). |
+
+See [`LmdbStoreConfig`](../../core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/config/LmdbStoreConfig.java)
+for programmatic access to these properties.
+
+## Programmatic API
+
+```java
+LmdbStore store = new LmdbStore(dataDir, config);
+LmdbCompactionOptions options = LmdbCompactionOptions.builder()
+        .destinationDirectory(staging)
+        .temporaryDirectory(temporary)
+        .verifyAfterCopy(true)
+        .progressListener(progress -> LOG.info("{}", progress.getMessage().orElse("")))
+        .metricsConsumer(metrics -> LOG.info("Shrank to {} bytes", metrics.getFileSizeAfterBytes()))
+        .build();
+
+// run always
+LmdbCompactionReport report = store.compact(options);
+
+// or only when fragmentation is high enough
+store.compactIfNeeded(options, config.getCompactionFragmentationThreshold());
+```
+
+The `LmdbCompactionMetrics` object carried by the report exposes file-size deltas, copy duration,
+per-environment statistics, and free-page ratios before/after the copy.
+
+## Maintenance helper
+
+`LmdbMaintenance` provides a small façade around `LmdbStore.compactIfNeeded`, respecting the
+configuration flags for automatic maintenance. It is suitable for background schedulers that already
+operate on RDF4J configuration objects.
+
+## CLI usage
+
+A helper script is available under `bin/rdf4j-lmdb-maintenance.sh`. Build the LMDB module first:
+
+```bash
+mvn -pl core/sail/lmdb -DskipTests package dependency:copy-dependencies
+```
+
+Then invoke the script:
+
+```bash
+bin/rdf4j-lmdb-maintenance.sh \
+  --compact \
+  --dataDir /var/lib/rdf4j/repositories/foo/data \
+  --target /var/lib/rdf4j/repositories/foo/compacted \
+  --threshold 0.30 \
+  --verify
+```
+
+The command prints the current fragmentation ratio, performs compaction only when the supplied
+threshold is met, and outputs a summary of the resulting metrics. Use `--no-backup` to discard the
+backup directory after a successful swap.
+
+## Metrics
+
+Compaction records the following metrics, surfaced via `LmdbCompactionMetrics` and the CLI output:
+
+- Size before/after (bytes)
+- Duration of the copy stage
+- Average free page ratio before/after
+- Per-environment page statistics
+- Backup location (if retained)
+
+These metrics can be persisted or reported to external monitoring systems as needed.

--- a/etc/lmdb.properties
+++ b/etc/lmdb.properties
@@ -1,0 +1,12 @@
+# Sample LMDB maintenance configuration
+# Build artifacts before running the maintenance CLI:
+# mvn -pl core/sail/lmdb -DskipTests package dependency:copy-dependencies
+
+lmdb:dataDir=/var/lib/rdf4j/repositories/example/data
+lmdb:compactAutoEnabled=true
+lmdb:compactThreshold=0.35
+lmdb:compactMinInterval=604800000   # 7 days in milliseconds
+# CLI parameters
+lmdb:cli.target=/var/lib/rdf4j/repositories/example/compacted
+lmdb:cli.temporary=/var/lib/rdf4j/repositories/example/tmp
+lmdb:cli.verify=true


### PR DESCRIPTION
## Summary
- add LMDB compaction API, metrics, and maintenance helpers
- implement CLI and shell wrapper for offline LMDB compaction
- document compaction workflow and provide sample configuration

## Testing
- mvn -pl core/sail/lmdb test -Dtest=LmdbCompactionIT

------
https://chatgpt.com/codex/tasks/task_e_690809cb25a0832e987fc066930fad4b