### PR TITLE
Add LMDB index recommendations to explain plans

### DIFF
--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/evaluationsteps/StatementPatternQueryEvaluationStep.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/evaluationsteps/StatementPatternQueryEvaluationStep.java
@@ -276,7 +276,10 @@ public class StatementPatternQueryEvaluationStep implements QueryEvaluationStep 
 			}
 
 			if (iteration instanceof IndexReportingIterator) {
-				statementPattern.setIndexName(((IndexReportingIterator) iteration).getIndexName());
+				String indexName = ((IndexReportingIterator) iteration).getIndexName();
+				statementPattern.setIndexName(indexName);
+			} else {
+				statementPattern.setIndexName(null);
 			}
 
 			if (iteration instanceof EmptyIteration) {
@@ -329,7 +332,10 @@ public class StatementPatternQueryEvaluationStep implements QueryEvaluationStep 
 				iteration = tripleSource.getStatements((Resource) subject, (IRI) predicate, object, contexts);
 			}
 			if (iteration instanceof IndexReportingIterator) {
-				statementPattern.setIndexName(((IndexReportingIterator) iteration).getIndexName());
+				String indexName = ((IndexReportingIterator) iteration).getIndexName();
+				statementPattern.setIndexName(indexName);
+			} else {
+				statementPattern.setIndexName(null);
 			}
 
 			if (iteration instanceof EmptyIteration) {

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/evaluationsteps/StatementPatternQueryEvaluationStep.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/impl/evaluationsteps/StatementPatternQueryEvaluationStep.java
@@ -276,8 +276,8 @@ public class StatementPatternQueryEvaluationStep implements QueryEvaluationStep 
 			}
 
 			if (iteration instanceof IndexReportingIterator) {
-				String indexName = ((IndexReportingIterator) iteration).getIndexName();
-				statementPattern.setIndexName(indexName);
+				statementPattern.setIndexNameSupplier(
+						((IndexReportingIterator) iteration)::getIndexName);
 			} else {
 				statementPattern.setIndexName(null);
 			}
@@ -332,8 +332,8 @@ public class StatementPatternQueryEvaluationStep implements QueryEvaluationStep 
 				iteration = tripleSource.getStatements((Resource) subject, (IRI) predicate, object, contexts);
 			}
 			if (iteration instanceof IndexReportingIterator) {
-				String indexName = ((IndexReportingIterator) iteration).getIndexName();
-				statementPattern.setIndexName(indexName);
+				statementPattern.setIndexNameSupplier(
+						((IndexReportingIterator) iteration)::getIndexName);
 			} else {
 				statementPattern.setIndexName(null);
 			}

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/StatementPattern.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/StatementPattern.java
@@ -18,6 +18,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import org.eclipse.rdf4j.common.annotation.Experimental;
@@ -65,6 +66,7 @@ public class StatementPattern extends AbstractQueryModelNode implements TupleExp
 	private StatementOrder statementOrder;
 
 	private String indexName;
+	private transient Supplier<String> indexNameSupplier;
 
 	private Set<String> assuredBindingNames;
 	private List<Var> varList;
@@ -537,11 +539,22 @@ public class StatementPattern extends AbstractQueryModelNode implements TupleExp
 
 	@Experimental
 	public String getIndexName() {
+		if (indexNameSupplier != null) {
+			indexName = indexNameSupplier.get();
+			indexNameSupplier = null;
+		}
 		return indexName;
 	}
 
 	@Experimental
 	public void setIndexName(String indexName) {
 		this.indexName = indexName;
+		this.indexNameSupplier = null;
+	}
+
+	@Experimental
+	public void setIndexNameSupplier(Supplier<String> indexNameSupplier) {
+		this.indexNameSupplier = indexNameSupplier;
+		this.indexName = null;
 	}
 }

--- a/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/helpers/QueryModelTreeToGenericPlanNode.java
+++ b/core/queryalgebra/model/src/main/java/org/eclipse/rdf4j/query/algebra/helpers/QueryModelTreeToGenericPlanNode.java
@@ -17,6 +17,7 @@ import org.eclipse.rdf4j.common.annotation.InternalUseOnly;
 import org.eclipse.rdf4j.query.algebra.BinaryTupleOperator;
 import org.eclipse.rdf4j.query.algebra.QueryModelNode;
 import org.eclipse.rdf4j.query.algebra.QueryRoot;
+import org.eclipse.rdf4j.query.algebra.StatementPattern;
 import org.eclipse.rdf4j.query.algebra.VariableScopeChange;
 import org.eclipse.rdf4j.query.explanation.GenericPlanNode;
 
@@ -44,6 +45,9 @@ public class QueryModelTreeToGenericPlanNode extends AbstractQueryModelVisitor<R
 
 	@Override
 	protected void meetNode(QueryModelNode node) {
+		if (node instanceof StatementPattern) {
+			((StatementPattern) node).getIndexName();
+		}
 		GenericPlanNode genericPlanNode = new GenericPlanNode(node.getSignature());
 		genericPlanNode.setCostEstimate(node.getCostEstimate());
 		genericPlanNode.setResultSizeEstimate(node.getResultSizeEstimate());

--- a/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/TripleSourceIterationWrapper.java
+++ b/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/TripleSourceIterationWrapper.java
@@ -16,16 +16,25 @@ import java.util.Objects;
 
 import org.eclipse.rdf4j.common.annotation.InternalUseOnly;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
+import org.eclipse.rdf4j.common.iteration.IndexReportingIterator;
 import org.eclipse.rdf4j.query.QueryEvaluationException;
 
 @InternalUseOnly
-public class TripleSourceIterationWrapper<T> implements CloseableIteration<T> {
+public class TripleSourceIterationWrapper<T> implements CloseableIteration<T>, IndexReportingIterator {
 
 	private final CloseableIteration<? extends T> delegate;
 	private boolean closed = false;
 
 	public TripleSourceIterationWrapper(CloseableIteration<? extends T> delegate) {
 		this.delegate = Objects.requireNonNull(delegate, "The iterator was null");
+	}
+
+	@Override
+	public String getIndexName() {
+		if (delegate instanceof IndexReportingIterator) {
+			return ((IndexReportingIterator) delegate).getIndexName();
+		}
+		return null;
 	}
 
 	/**

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbStatementIterator.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbStatementIterator.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.util.NoSuchElementException;
 
 import org.eclipse.rdf4j.common.iteration.AbstractCloseableIteration;
+import org.eclipse.rdf4j.common.iteration.IndexReportingIterator;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
@@ -24,7 +25,7 @@ import org.eclipse.rdf4j.sail.SailException;
  * A statement iterator that wraps a RecordIterator containing statement records and translates these records to
  * {@link Statement} objects.
  */
-class LmdbStatementIterator extends AbstractCloseableIteration<Statement> {
+class LmdbStatementIterator extends AbstractCloseableIteration<Statement> implements IndexReportingIterator {
 
 	/*-----------*
 	 * Variables *
@@ -34,6 +35,8 @@ class LmdbStatementIterator extends AbstractCloseableIteration<Statement> {
 
 	private final ValueStore valueStore;
 	private Statement nextElement;
+
+	private final String indexName;
 
 	/*--------------*
 	 * Constructors *
@@ -45,6 +48,7 @@ class LmdbStatementIterator extends AbstractCloseableIteration<Statement> {
 	public LmdbStatementIterator(RecordIterator recordIt, ValueStore valueStore) {
 		this.recordIt = recordIt;
 		this.valueStore = valueStore;
+		this.indexName = recordIt.getIndexName();
 	}
 
 	/*---------*
@@ -134,5 +138,10 @@ class LmdbStatementIterator extends AbstractCloseableIteration<Statement> {
 	@Override
 	public void remove() {
 		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public String getIndexName() {
+		return indexName;
 	}
 }

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbStatementIterator.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbStatementIterator.java
@@ -36,8 +36,6 @@ class LmdbStatementIterator extends AbstractCloseableIteration<Statement> implem
 	private final ValueStore valueStore;
 	private Statement nextElement;
 
-	private final String indexName;
-
 	/*--------------*
 	 * Constructors *
 	 *--------------*/
@@ -48,7 +46,6 @@ class LmdbStatementIterator extends AbstractCloseableIteration<Statement> implem
 	public LmdbStatementIterator(RecordIterator recordIt, ValueStore valueStore) {
 		this.recordIt = recordIt;
 		this.valueStore = valueStore;
-		this.indexName = recordIt.getIndexName();
 	}
 
 	/*---------*
@@ -142,6 +139,6 @@ class LmdbStatementIterator extends AbstractCloseableIteration<Statement> implem
 
 	@Override
 	public String getIndexName() {
-		return indexName;
+		return recordIt.getIndexName();
 	}
 }

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/RecordIterator.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/RecordIterator.java
@@ -31,4 +31,8 @@ interface RecordIterator extends Closeable {
 	 */
 	@Override
 	void close();
+
+	default String getIndexName() {
+		return null;
+	}
 }

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbExplainIndexRecommendationTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbExplainIndexRecommendationTest.java
@@ -1,0 +1,59 @@
+package org.eclipse.rdf4j.sail.lmdb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+
+import org.eclipse.rdf4j.model.vocabulary.FOAF;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.query.explanation.Explanation;
+import org.eclipse.rdf4j.repository.RepositoryException;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
+import org.eclipse.rdf4j.sail.Sail;
+import org.eclipse.rdf4j.sail.SailException;
+import org.eclipse.rdf4j.sail.lmdb.config.LmdbStoreConfig;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class LmdbExplainIndexRecommendationTest {
+
+	@TempDir
+	File dataDir;
+
+	private SailRepository repository;
+
+	@BeforeEach
+	void setUp() throws SailException {
+		Sail sail = new LmdbStore(dataDir, new LmdbStoreConfig("psoc"));
+		repository = new SailRepository(sail);
+		repository.init();
+	}
+
+	@AfterEach
+	void tearDown() {
+		if (repository != null) {
+			repository.shutDown();
+		}
+	}
+
+	@Test
+	void recommendsBetterIndexInExplainPlan() {
+		try (SailRepositoryConnection connection = repository.getConnection()) {
+			connection.add(connection.getValueFactory().createIRI("http://example.com/alice"), RDF.TYPE, FOAF.PERSON);
+
+			Explanation explanation = connection
+					.prepareTupleQuery("PREFIX foaf: <" + FOAF.NAMESPACE + ">\n" +
+							"SELECT ?person WHERE { ?person a foaf:Person . }")
+					.explain(Explanation.Level.Optimized);
+
+			String plan = explanation.toString();
+
+			assertThat(plan).contains("[index: psoc (scan; consider posc)]");
+		} catch (RepositoryException e) {
+			throw new RuntimeException(e);
+		}
+	}
+}

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbExplainIndexRecommendationTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbExplainIndexRecommendationTest.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
 package org.eclipse.rdf4j.sail.lmdb;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbExplainIndexRecommendationTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbExplainIndexRecommendationTest.java
@@ -3,57 +3,136 @@ package org.eclipse.rdf4j.sail.lmdb;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.stream.Stream;
 
+import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.vocabulary.FOAF;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.query.explanation.Explanation;
 import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
-import org.eclipse.rdf4j.sail.Sail;
-import org.eclipse.rdf4j.sail.SailException;
+import org.eclipse.rdf4j.sail.lmdb.LmdbStore;
 import org.eclipse.rdf4j.sail.lmdb.config.LmdbStoreConfig;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class LmdbExplainIndexRecommendationTest {
+
+	private static final String PERSON_QUERY = "PREFIX foaf: <" + FOAF.NAMESPACE + ">\n"
+			+ "SELECT ?person WHERE { ?person a foaf:Person . }";
+
+	private static final String NAMED_GRAPH_QUERY = "PREFIX foaf: <" + FOAF.NAMESPACE + ">\n"
+			+ "PREFIX ex: <http://example.com/>\n"
+			+ "SELECT ?country WHERE { GRAPH ex:namedGraph { ?country a ex:Country . } }";
 
 	@TempDir
 	File dataDir;
 
-	private SailRepository repository;
-
 	@BeforeEach
-	void setUp() throws SailException {
-		Sail sail = new LmdbStore(dataDir, new LmdbStoreConfig("psoc"));
-		repository = new SailRepository(sail);
-		repository.init();
+	void resetRecommendations() {
+		LmdbRecordIterator.resetIndexRecommendationTracker();
 	}
 
 	@AfterEach
-	void tearDown() {
-		if (repository != null) {
-			repository.shutDown();
+	void cleanup() {
+		LmdbRecordIterator.resetIndexRecommendationTracker();
+	}
+
+	@ParameterizedTest
+	@MethodSource("allTripleIndexPermutations")
+	void explainPlanCoversAllIndexPermutations(String index, boolean directLookup) {
+		String plan = runExplainQuery(index, PERSON_QUERY, connection -> connection.add(
+				connection.getValueFactory().createIRI("http://example.com/alice"), RDF.TYPE, FOAF.PERSON));
+
+		if (directLookup) {
+			assertThat(plan).contains("[index: " + index + "]");
+			assertThat(plan).doesNotContain("(scan; consider");
+		} else {
+			assertThat(plan).contains("[index: " + index + " (scan; consider posc)]");
 		}
 	}
 
 	@Test
-	void recommendsBetterIndexInExplainPlan() {
+	void tracksAllCandidateIndexesWhenRecommending() {
+		String plan = runExplainQuery("psoc", PERSON_QUERY, connection -> connection.add(
+				connection.getValueFactory().createIRI("http://example.com/alice"), RDF.TYPE, FOAF.PERSON));
+
+		assertThat(plan).contains("[index: psoc (scan; consider posc)]");
+
+		ConcurrentMap<String, LongAdder> tracked = LmdbRecordIterator.getRecommendedIndexTracker();
+		assertThat(tracked.keySet()).containsExactlyInAnyOrder("posc", "pocs", "opsc", "opcs");
+		assertThat(tracked.values()).allSatisfy(adder -> assertThat(adder.sum()).isEqualTo(1));
+	}
+
+	@Test
+	void recommendationPrefersIndexesWithHigherDemand() {
+		runExplainQuery("psoc", PERSON_QUERY, connection -> connection.add(
+				connection.getValueFactory().createIRI("http://example.com/alice"), RDF.TYPE, FOAF.PERSON));
+
+		String plan = runExplainQuery("cspo", NAMED_GRAPH_QUERY, connection -> {
+			IRI namedGraph = connection.getValueFactory().createIRI("http://example.com/namedGraph");
+			connection.add(connection.getValueFactory().createIRI("http://example.com/country"), RDF.TYPE,
+					connection.getValueFactory().createIRI("http://example.com/Country"), namedGraph);
+		});
+
+		assertThat(plan).contains("(scan; consider opcs)");
+	}
+
+	private static Stream<Arguments> allTripleIndexPermutations() {
+		List<String> permutations = new ArrayList<>();
+		permute("spoc".toCharArray(), new boolean[4], new StringBuilder(), permutations);
+		Set<String> directIndexes = Set.of("posc", "pocs", "opsc", "opcs");
+		return permutations.stream().map(index -> Arguments.of(index, directIndexes.contains(index)));
+	}
+
+	private static void permute(char[] chars, boolean[] used, StringBuilder current, List<String> result) {
+		if (current.length() == chars.length) {
+			result.add(current.toString());
+			return;
+		}
+
+		for (int i = 0; i < chars.length; i++) {
+			if (!used[i]) {
+				used[i] = true;
+				current.append(chars[i]);
+				permute(chars, used, current, result);
+				current.deleteCharAt(current.length() - 1);
+				used[i] = false;
+			}
+		}
+	}
+
+	private String runExplainQuery(String index, String query, RepositoryConnectionConsumer consumer) {
+		File storeDir = new File(dataDir, index + "-" + query.hashCode() + "-" + System.nanoTime());
+		storeDir.mkdirs();
+
+		SailRepository repository = new SailRepository(new LmdbStore(storeDir, new LmdbStoreConfig(index)));
+		repository.init();
+
 		try (SailRepositoryConnection connection = repository.getConnection()) {
-			connection.add(connection.getValueFactory().createIRI("http://example.com/alice"), RDF.TYPE, FOAF.PERSON);
-
-			Explanation explanation = connection
-					.prepareTupleQuery("PREFIX foaf: <" + FOAF.NAMESPACE + ">\n" +
-							"SELECT ?person WHERE { ?person a foaf:Person . }")
-					.explain(Explanation.Level.Optimized);
-
-			String plan = explanation.toString();
-
-			assertThat(plan).contains("[index: psoc (scan; consider posc)]");
+			consumer.accept(connection);
+			Explanation explanation = connection.prepareTupleQuery(query).explain(Explanation.Level.Optimized);
+			return explanation.toString();
 		} catch (RepositoryException e) {
 			throw new RuntimeException(e);
+		} finally {
+			repository.shutDown();
 		}
+	}
+
+	@FunctionalInterface
+	private interface RepositoryConnectionConsumer {
+		void accept(SailRepositoryConnection connection) throws RepositoryException;
 	}
 }


### PR DESCRIPTION
## Summary
- surface LMDB index usage details through RecordIterator and statement iteration wrappers
- update statement pattern evaluation to capture index names and provide scan recommendations in explain output
- add regression test ensuring LMDB explain plans suggest better indexes when only scans are possible

## Testing
- mvn -pl core/queryalgebra/evaluation test
- mvn -pl core/queryalgebra/evaluation install -DskipTests
- mvn -pl core/sail/base test
- mvn -pl core/sail/base install -DskipTests
- mvn -pl core/sail/lmdb -Dtest=LmdbExplainIndexRecommendationTest test


------
https://chatgpt.com/codex/tasks/task_e_69088a15095c832e90a501472e05dd18