### PR TITLE
GH-0000: Adjust LMDB cardinality penalties for non-optimal indexes

### DIFF
--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/TripleStore.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/TripleStore.java
@@ -85,6 +85,7 @@ import org.eclipse.rdf4j.sail.lmdb.TxnManager.Txn;
 import org.eclipse.rdf4j.sail.lmdb.TxnRecordCache.Record;
 import org.eclipse.rdf4j.sail.lmdb.TxnRecordCache.RecordCacheIterator;
 import org.eclipse.rdf4j.sail.lmdb.config.LmdbStoreConfig;
+import org.eclipse.rdf4j.sail.lmdb.model.LmdbValue;
 import org.eclipse.rdf4j.sail.lmdb.util.GroupMatcher;
 import org.eclipse.rdf4j.sail.lmdb.util.IndexKeyWriters;
 import org.lwjgl.PointerBuffer;
@@ -674,6 +675,10 @@ class TripleStore implements Closeable {
 	}
 
 	protected double cardinality(long subj, long pred, long obj, long context) throws IOException {
+		return cardinality(subj, pred, obj, context, true);
+	}
+
+	private double cardinality(long subj, long pred, long obj, long context, boolean applyPenalty) throws IOException {
 		TripleIndex index = getBestIndex(subj, pred, obj, context);
 
 		int relevantParts = index.getPatternScore(subj, pred, obj, context);
@@ -691,7 +696,7 @@ class TripleStore implements Closeable {
 			});
 		}
 
-		return txnManager.doWith((stack, txn) -> {
+		double estimate = txnManager.doWith((stack, txn) -> {
 			Pool pool = Pool.get();
 			final Statistics s = pool.getStatistics();
 			try {
@@ -707,7 +712,7 @@ class TripleStore implements Closeable {
 				ByteBuffer keyBuf = stack.malloc(TripleStore.MAX_KEY_LENGTH);
 				MDBVal valueData = MDBVal.mallocStack(stack);
 
-				double cardinality = 0;
+				double estimateValue = 0;
 				for (boolean explicit : new boolean[] { true, false }) {
 					Arrays.fill(s.avgRowsPerValue, 1.0);
 					Arrays.fill(s.avgRowsPerValueCounts, 0);
@@ -789,8 +794,8 @@ class TripleStore implements Closeable {
 												long diff = s.values[i] - s.lastValues[bucket][i];
 												s.avgRowsPerValueCounts[i]++;
 												s.avgRowsPerValue[i] = (s.avgRowsPerValue[i]
-														* (s.avgRowsPerValueCounts[i] - 1) +
-														(double) s.counts[i] / diff) / s.avgRowsPerValueCounts[i];
+														* (s.avgRowsPerValueCounts[i] - 1)
+														+ (double) s.counts[i] / diff) / s.avgRowsPerValueCounts[i];
 												s.counts[i] = 0;
 											}
 										}
@@ -805,7 +810,7 @@ class TripleStore implements Closeable {
 						}
 
 						// at least the seen samples must be counted
-						cardinality += allSamplesCount;
+						estimateValue += allSamplesCount;
 
 						// the actual number of buckets (bucket - 1 "real" buckets and one for the last element within
 						// the range)
@@ -823,7 +828,7 @@ class TripleStore implements Closeable {
 										.max(s.startValues[bucket][pos] - s.lastValues[bucket - 1][pos], 0);
 								// estimate number of elements between last element of previous bucket and first element
 								// of current bucket
-								cardinality += s.avgRowsPerValue[pos] * diffBetweenGroups;
+								estimateValue += s.avgRowsPerValue[pos] * diffBetweenGroups;
 							}
 						}
 					} finally {
@@ -832,10 +837,134 @@ class TripleStore implements Closeable {
 						}
 					}
 				}
-				return cardinality;
+				return estimateValue;
 			} finally {
 				pool.free(s);
 			}
+		});
+
+		if (applyPenalty && hasKnownComponentsBeyondPrefix(index, relevantParts, subj, pred, obj, context)) {
+			estimate = applyNonOptimalIndexPenalty(index, relevantParts, subj, pred, obj, context, estimate);
+		}
+
+		return estimate;
+	}
+
+	private boolean hasKnownComponentsBeyondPrefix(TripleIndex index, int relevantParts, long subj, long pred, long obj,
+			long context) {
+		for (int i = relevantParts; i < index.fieldSeq.length; i++) {
+			switch (index.fieldSeq[i]) {
+			case 's':
+				if (isKnown(subj)) {
+					return true;
+				}
+				break;
+			case 'p':
+				if (isKnown(pred)) {
+					return true;
+				}
+				break;
+			case 'o':
+				if (isKnown(obj)) {
+					return true;
+				}
+				break;
+			case 'c':
+				if (isKnown(context)) {
+					return true;
+				}
+				break;
+			default:
+				throw new IllegalStateException("Unexpected index field: " + index.fieldSeq[i]);
+			}
+		}
+		return false;
+	}
+
+	private boolean isKnown(long value) {
+		return value >= 0;
+	}
+
+	private double applyNonOptimalIndexPenalty(TripleIndex index, int relevantParts, long subj, long pred, long obj,
+			long context, double baseEstimate) throws IOException {
+		long penaltySubj = subj;
+		long penaltyPred = pred;
+		long penaltyObj = obj;
+		long penaltyContext = context;
+
+		for (int i = relevantParts; i < index.fieldSeq.length; i++) {
+			switch (index.fieldSeq[i]) {
+			case 's':
+				penaltySubj = LmdbValue.UNKNOWN_ID;
+				break;
+			case 'p':
+				penaltyPred = LmdbValue.UNKNOWN_ID;
+				break;
+			case 'o':
+				penaltyObj = LmdbValue.UNKNOWN_ID;
+				break;
+			case 'c':
+				penaltyContext = LmdbValue.UNKNOWN_ID;
+				break;
+			default:
+				throw new IllegalStateException("Unexpected index field: " + index.fieldSeq[i]);
+			}
+		}
+
+		double rangeCount = countEntriesForPrefix(index, penaltySubj, penaltyPred, penaltyObj, penaltyContext);
+		if (rangeCount > baseEstimate) {
+			return rangeCount;
+		}
+		return baseEstimate;
+	}
+
+	private double countEntriesForPrefix(TripleIndex index, long subj, long pred, long obj, long context)
+			throws IOException {
+		return txnManager.doWith((stack, txn) -> {
+			double count = 0;
+
+			ByteBuffer minKeyBuf = stack.malloc(TripleStore.MAX_KEY_LENGTH);
+			index.getMinKey(minKeyBuf, subj, pred, obj, context);
+			minKeyBuf.flip();
+
+			MDBVal maxKey = MDBVal.malloc(stack);
+			ByteBuffer maxKeyBuf = stack.malloc(TripleStore.MAX_KEY_LENGTH);
+			index.getMaxKey(maxKeyBuf, subj, pred, obj, context);
+			maxKeyBuf.flip();
+			maxKey.mv_data(maxKeyBuf);
+
+			MDBVal keyData = MDBVal.mallocStack(stack);
+			MDBVal valueData = MDBVal.mallocStack(stack);
+			PointerBuffer pp = stack.mallocPointer(1);
+
+			for (boolean explicit : new boolean[] { true, false }) {
+				int dbi = index.getDB(explicit);
+				long cursor = 0;
+
+				try {
+					E(mdb_cursor_open(txn, dbi, pp));
+					cursor = pp.get(0);
+
+					keyData.mv_data(minKeyBuf);
+					int rc = mdb_cursor_get(cursor, keyData, valueData, MDB_SET_RANGE);
+
+					while (rc == MDB_SUCCESS) {
+						if (mdb_cmp(txn, dbi, keyData, maxKey) > 0) {
+							break;
+						}
+
+						count++;
+
+						rc = mdb_cursor_get(cursor, keyData, valueData, MDB_NEXT);
+					}
+				} finally {
+					if (cursor != 0) {
+						mdb_cursor_close(cursor);
+					}
+				}
+			}
+
+			return count;
 		});
 	}
 

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbStatisticsPenaltyTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbStatisticsPenaltyTest.java
@@ -1,0 +1,88 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ ******************************************************************************/
+package org.eclipse.rdf4j.sail.lmdb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.assertj.core.data.Offset;
+import org.eclipse.rdf4j.sail.lmdb.config.LmdbStoreConfig;
+import org.eclipse.rdf4j.sail.lmdb.model.LmdbValue;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class LmdbStatisticsPenaltyTest {
+
+	private static final long TYPE = 2L;
+	private static final long PERSON = 100L;
+	private static final long CONTEXT = 1L;
+
+	private static final int MATCH_COUNT = 5;
+	private static final int TOTAL_STATEMENTS = 405;
+
+	@TempDir
+	File tempDir;
+
+	@Test
+	void nonOptimalIndexHasHigherCardinalityEstimate() throws Exception {
+		double optimal = computeCardinality("spoc,posc");
+		double nonOptimal = computeCardinality("psoc");
+
+		assertThat(optimal).isCloseTo(MATCH_COUNT, withinTolerance());
+		assertThat(nonOptimal).isGreaterThan(optimal);
+		assertThat(nonOptimal).isGreaterThanOrEqualTo(TOTAL_STATEMENTS);
+	}
+
+	private double computeCardinality(String indexSpec) throws Exception {
+		File dataDir = new File(tempDir, indexSpec.replace(',', '_'));
+		dataDir.mkdir();
+
+		List<long[]> statements = createStatements();
+
+		TripleStore store = new TripleStore(dataDir, new LmdbStoreConfig(indexSpec), null);
+		try {
+			store.startTransaction();
+			for (long[] st : statements) {
+				store.storeTriple(st[0], st[1], st[2], st[3], true);
+			}
+			store.commit();
+
+			return store.cardinality(LmdbValue.UNKNOWN_ID, TYPE, PERSON, LmdbValue.UNKNOWN_ID);
+		} finally {
+			store.close();
+		}
+	}
+
+	private List<long[]> createStatements() {
+		List<long[]> statements = new ArrayList<>();
+
+		for (int i = 0; i < MATCH_COUNT; i++) {
+			statements.add(new long[] { i + 1, TYPE, PERSON, CONTEXT });
+		}
+
+		for (int i = 0; i < 400; i++) {
+			statements.add(new long[] { i + 100, TYPE, 1_000 + i, CONTEXT });
+		}
+
+		for (int i = 0; i < 200; i++) {
+			statements.add(new long[] { i + 500, TYPE + 100 + (i % 3), PERSON, CONTEXT });
+		}
+
+		return statements;
+	}
+
+	private Offset<Double> withinTolerance() {
+		return Offset.offset(1.0d);
+	}
+}


### PR DESCRIPTION
## Summary
- add a regression test that verifies LMDB statistics penalize non-optimal index lookups
- count the full prefix range when known components appear after the matching index prefix so the penalty matches scan cost

## Testing
- `mvn -pl core/sail/lmdb test -Dtest=LmdbStatisticsPenaltyTest`


------
https://chatgpt.com/codex/tasks/task_e_690abe1e18e4832e80457f6e73206df0