### PR TITLE
GH-5553: Surface LMDB index recommendations in query plans

### DIFF
--- a/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/TripleSourceIterationWrapper.java
+++ b/core/sail/base/src/main/java/org/eclipse/rdf4j/sail/TripleSourceIterationWrapper.java
@@ -16,10 +16,11 @@ import java.util.Objects;
 
 import org.eclipse.rdf4j.common.annotation.InternalUseOnly;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
+import org.eclipse.rdf4j.common.iteration.IndexReportingIterator;
 import org.eclipse.rdf4j.query.QueryEvaluationException;
 
 @InternalUseOnly
-public class TripleSourceIterationWrapper<T> implements CloseableIteration<T> {
+public class TripleSourceIterationWrapper<T> implements CloseableIteration<T>, IndexReportingIterator {
 
 	private final CloseableIteration<? extends T> delegate;
 	private boolean closed = false;
@@ -107,5 +108,13 @@ public class TripleSourceIterationWrapper<T> implements CloseableIteration<T> {
 			closed = true;
 			delegate.close();
 		}
+	}
+
+	@Override
+	public String getIndexName() {
+		if (delegate instanceof IndexReportingIterator) {
+			return ((IndexReportingIterator) delegate).getIndexName();
+		}
+		return null;
 	}
 }

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbRecordIterator.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbRecordIterator.java
@@ -24,6 +24,8 @@ import static org.lwjgl.util.lmdb.LMDB.mdb_cursor_renew;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.List;
 
 import org.eclipse.rdf4j.common.concurrent.locks.StampedLongAdderLockManager;
 import org.eclipse.rdf4j.sail.SailException;
@@ -44,6 +46,10 @@ class LmdbRecordIterator implements RecordIterator {
 	private final Pool pool;
 
 	private final TripleIndex index;
+
+	private final String indexName;
+
+	private final List<String> recommendedIndexes;
 
 	private final long subj;
 	private final long pred;
@@ -87,7 +93,7 @@ class LmdbRecordIterator implements RecordIterator {
 	private final Thread ownerThread = Thread.currentThread();
 
 	LmdbRecordIterator(TripleIndex index, boolean rangeSearch, long subj, long pred, long obj,
-			long context, boolean explicit, Txn txnRef) throws IOException {
+			long context, boolean explicit, Txn txnRef, List<String> recommendedIndexes) throws IOException {
 		this.subj = subj;
 		this.pred = pred;
 		this.obj = obj;
@@ -98,6 +104,9 @@ class LmdbRecordIterator implements RecordIterator {
 		this.keyData = pool.getVal();
 		this.valueData = pool.getVal();
 		this.index = index;
+		this.indexName = new String(index.getFieldSeq());
+		this.recommendedIndexes = recommendedIndexes == null ? Collections.emptyList()
+				: List.copyOf(recommendedIndexes);
 		if (rangeSearch) {
 			minKeyBuf = pool.getKeyBuffer();
 			index.getMinKey(minKeyBuf, subj, pred, obj, context);
@@ -125,6 +134,7 @@ class LmdbRecordIterator implements RecordIterator {
 		} catch (InterruptedException e) {
 			throw new SailException(e);
 		}
+
 		try {
 			this.txnRefVersion = txnRef.version();
 			this.txn = txnRef.get();
@@ -137,6 +147,16 @@ class LmdbRecordIterator implements RecordIterator {
 		} finally {
 			txnLockManager.unlockRead(readStamp);
 		}
+	}
+
+	@Override
+	public String getIndexName() {
+		return indexName;
+	}
+
+	@Override
+	public List<String> getRecommendedIndexes() {
+		return recommendedIndexes;
 	}
 
 	@Override

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbRecordIterator.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbRecordIterator.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Supplier;
 
 import org.eclipse.rdf4j.common.concurrent.locks.StampedLongAdderLockManager;
 import org.eclipse.rdf4j.sail.SailException;
@@ -49,7 +50,8 @@ class LmdbRecordIterator implements RecordIterator {
 
 	private final String indexName;
 
-	private final List<String> recommendedIndexes;
+	private final Supplier<List<String>> recommendedIndexesSupplier;
+	private volatile List<String> recommendedIndexes;
 
 	private final long subj;
 	private final long pred;
@@ -93,7 +95,8 @@ class LmdbRecordIterator implements RecordIterator {
 	private final Thread ownerThread = Thread.currentThread();
 
 	LmdbRecordIterator(TripleIndex index, boolean rangeSearch, long subj, long pred, long obj,
-			long context, boolean explicit, Txn txnRef, List<String> recommendedIndexes) throws IOException {
+			long context, boolean explicit, Txn txnRef, Supplier<List<String>> recommendedIndexesSupplier)
+			throws IOException {
 		this.subj = subj;
 		this.pred = pred;
 		this.obj = obj;
@@ -105,8 +108,7 @@ class LmdbRecordIterator implements RecordIterator {
 		this.valueData = pool.getVal();
 		this.index = index;
 		this.indexName = new String(index.getFieldSeq());
-		this.recommendedIndexes = recommendedIndexes == null ? Collections.emptyList()
-				: List.copyOf(recommendedIndexes);
+		this.recommendedIndexesSupplier = recommendedIndexesSupplier;
 		if (rangeSearch) {
 			minKeyBuf = pool.getKeyBuffer();
 			index.getMinKey(minKeyBuf, subj, pred, obj, context);
@@ -156,7 +158,25 @@ class LmdbRecordIterator implements RecordIterator {
 
 	@Override
 	public List<String> getRecommendedIndexes() {
-		return recommendedIndexes;
+		List<String> current = recommendedIndexes;
+		if (current != null) {
+			return current;
+		}
+
+		List<String> computed;
+		if (recommendedIndexesSupplier == null) {
+			computed = Collections.emptyList();
+		} else {
+			computed = recommendedIndexesSupplier.get();
+			if (computed == null || computed.isEmpty()) {
+				computed = Collections.emptyList();
+			} else {
+				computed = List.copyOf(computed);
+			}
+		}
+
+		recommendedIndexes = computed;
+		return computed;
 	}
 
 	@Override

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbStatementIterator.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbStatementIterator.java
@@ -11,9 +11,13 @@
 package org.eclipse.rdf4j.sail.lmdb;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.Locale;
 import java.util.NoSuchElementException;
+import java.util.stream.Collectors;
 
 import org.eclipse.rdf4j.common.iteration.AbstractCloseableIteration;
+import org.eclipse.rdf4j.common.iteration.IndexReportingIterator;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
@@ -24,7 +28,7 @@ import org.eclipse.rdf4j.sail.SailException;
  * A statement iterator that wraps a RecordIterator containing statement records and translates these records to
  * {@link Statement} objects.
  */
-class LmdbStatementIterator extends AbstractCloseableIteration<Statement> {
+class LmdbStatementIterator extends AbstractCloseableIteration<Statement> implements IndexReportingIterator {
 
 	/*-----------*
 	 * Variables *
@@ -34,6 +38,10 @@ class LmdbStatementIterator extends AbstractCloseableIteration<Statement> {
 
 	private final ValueStore valueStore;
 	private Statement nextElement;
+
+	private final String indexName;
+
+	private final String recommendedIndexes;
 
 	/*--------------*
 	 * Constructors *
@@ -45,6 +53,16 @@ class LmdbStatementIterator extends AbstractCloseableIteration<Statement> {
 	public LmdbStatementIterator(RecordIterator recordIt, ValueStore valueStore) {
 		this.recordIt = recordIt;
 		this.valueStore = valueStore;
+		String iteratorIndexName = recordIt.getIndexName();
+		this.indexName = iteratorIndexName;
+		List<String> recommendations = recordIt.getRecommendedIndexes();
+		if (recommendations != null && !recommendations.isEmpty()) {
+			this.recommendedIndexes = recommendations.stream()
+					.map(s -> s.toLowerCase(Locale.ROOT))
+					.collect(Collectors.joining(", "));
+		} else {
+			this.recommendedIndexes = null;
+		}
 	}
 
 	/*---------*
@@ -134,5 +152,16 @@ class LmdbStatementIterator extends AbstractCloseableIteration<Statement> {
 	@Override
 	public void remove() {
 		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public String getIndexName() {
+		if (indexName == null || indexName.isEmpty()) {
+			return indexName;
+		}
+		if (recommendedIndexes == null || recommendedIndexes.isEmpty()) {
+			return indexName;
+		}
+		return indexName + "] [recommended indexes: " + recommendedIndexes;
 	}
 }

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbStatementIterator.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbStatementIterator.java
@@ -39,9 +39,7 @@ class LmdbStatementIterator extends AbstractCloseableIteration<Statement> implem
 	private final ValueStore valueStore;
 	private Statement nextElement;
 
-	private final String indexName;
-
-	private final String recommendedIndexes;
+	private volatile String cachedIndexName;
 
 	/*--------------*
 	 * Constructors *
@@ -53,16 +51,6 @@ class LmdbStatementIterator extends AbstractCloseableIteration<Statement> implem
 	public LmdbStatementIterator(RecordIterator recordIt, ValueStore valueStore) {
 		this.recordIt = recordIt;
 		this.valueStore = valueStore;
-		String iteratorIndexName = recordIt.getIndexName();
-		this.indexName = iteratorIndexName;
-		List<String> recommendations = recordIt.getRecommendedIndexes();
-		if (recommendations != null && !recommendations.isEmpty()) {
-			this.recommendedIndexes = recommendations.stream()
-					.map(s -> s.toLowerCase(Locale.ROOT))
-					.collect(Collectors.joining(", "));
-		} else {
-			this.recommendedIndexes = null;
-		}
 	}
 
 	/*---------*
@@ -156,12 +144,28 @@ class LmdbStatementIterator extends AbstractCloseableIteration<Statement> implem
 
 	@Override
 	public String getIndexName() {
-		if (indexName == null || indexName.isEmpty()) {
-			return indexName;
+		String cached = cachedIndexName;
+		if (cached != null) {
+			return cached;
 		}
-		if (recommendedIndexes == null || recommendedIndexes.isEmpty()) {
-			return indexName;
+
+		String iteratorIndexName = recordIt.getIndexName();
+		if (iteratorIndexName == null || iteratorIndexName.isEmpty()) {
+			cachedIndexName = iteratorIndexName;
+			return iteratorIndexName;
 		}
-		return indexName + "] [recommended indexes: " + recommendedIndexes;
+
+		List<String> recommendations = recordIt.getRecommendedIndexes();
+		if (recommendations == null || recommendations.isEmpty()) {
+			cachedIndexName = iteratorIndexName;
+			return iteratorIndexName;
+		}
+
+		String formattedRecommendations = recommendations.stream()
+				.map(s -> s.toLowerCase(Locale.ROOT))
+				.collect(Collectors.joining(", "));
+		String formatted = iteratorIndexName + "] [recommended indexes: " + formattedRecommendations;
+		cachedIndexName = formatted;
+		return formatted;
 	}
 }

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/RecordIterator.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/RecordIterator.java
@@ -11,6 +11,8 @@
 package org.eclipse.rdf4j.sail.lmdb;
 
 import java.io.Closeable;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * An iterator that iterates over records, for example those in a key-value database.
@@ -23,6 +25,14 @@ interface RecordIterator extends Closeable {
 	 * @return A record that or <tt>null</tt> if all records have been returned.
 	 */
 	long[] next();
+
+	default String getIndexName() {
+		return null;
+	}
+
+	default List<String> getRecommendedIndexes() {
+		return Collections.emptyList();
+	}
 
 	/**
 	 * Closes the iterator, freeing any resources that it uses. Once closed, the iterator will not return any more

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/TripleStore.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/TripleStore.java
@@ -79,6 +79,7 @@ import java.util.StringTokenizer;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import org.eclipse.rdf4j.common.concurrent.locks.StampedLongAdderLockManager;
@@ -404,7 +405,7 @@ class TripleStore implements Closeable {
 						RecordIterator[] sourceIter = { null };
 						try {
 							sourceIter[0] = new LmdbRecordIterator(sourceIndex, false, -1, -1, -1, -1,
-									explicit, txnManager.createTxn(txn), Collections.emptyList());
+									explicit, txnManager.createTxn(txn), null);
 
 							RecordIterator it = sourceIter[0];
 							long[] quad;
@@ -507,8 +508,7 @@ class TripleStore implements Closeable {
 		for (TripleIndex index : indexes) {
 			if (index.getFieldSeq()[0] == 'c') {
 				// found a context-first index
-				return getTriplesUsingIndex(txn, -1, -1, -1, -1, true, index, false,
-						Collections.emptyList());
+				return getTriplesUsingIndex(txn, -1, -1, -1, -1, true, index, false, null);
 			}
 		}
 		return null;
@@ -520,7 +520,8 @@ class TripleStore implements Closeable {
 		// System.out.println("get triples: " + Arrays.asList(subj, pred, obj,context));
 		int bestScore = index.getPatternScore(subj, pred, obj, context);
 		boolean doRangeSearch = bestScore > 0;
-		List<String> recommendedIndexes = computeRecommendedIndexes(subj, pred, obj, context, index, bestScore);
+		Supplier<List<String>> recommendedIndexes = () -> computeRecommendedIndexes(subj, pred, obj, context,
+				index, bestScore);
 		return getTriplesUsingIndex(txn, subj, pred, obj, context, explicit, index, doRangeSearch,
 				recommendedIndexes);
 	}
@@ -535,8 +536,8 @@ class TripleStore implements Closeable {
 	}
 
 	private RecordIterator getTriplesUsingIndex(Txn txn, long subj, long pred, long obj, long context,
-			boolean explicit, TripleIndex index, boolean rangeSearch, List<String> recommendedIndexes)
-			throws IOException {
+			boolean explicit, TripleIndex index, boolean rangeSearch,
+			Supplier<List<String>> recommendedIndexes) throws IOException {
 		return new LmdbRecordIterator(index, rangeSearch, subj, pred, obj, context, explicit, txn,
 				recommendedIndexes);
 	}

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/TripleStore.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/TripleStore.java
@@ -65,11 +65,13 @@ import java.nio.IntBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
@@ -77,6 +79,7 @@ import java.util.StringTokenizer;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 import org.eclipse.rdf4j.common.concurrent.locks.StampedLongAdderLockManager;
 import org.eclipse.rdf4j.sail.SailException;
@@ -108,6 +111,8 @@ class TripleStore implements Closeable {
 	static long hit = 0;
 	static long fullHit = 0;
 	static long miss = 0;
+
+	private static final ConcurrentHashMap<String, LongAdder> RECOMMENDED_INDEX_COUNTS = new ConcurrentHashMap<>();
 
 	/*-----------*
 	 * Constants *
@@ -399,7 +404,7 @@ class TripleStore implements Closeable {
 						RecordIterator[] sourceIter = { null };
 						try {
 							sourceIter[0] = new LmdbRecordIterator(sourceIndex, false, -1, -1, -1, -1,
-									explicit, txnManager.createTxn(txn));
+									explicit, txnManager.createTxn(txn), Collections.emptyList());
 
 							RecordIterator it = sourceIter[0];
 							long[] quad;
@@ -502,7 +507,8 @@ class TripleStore implements Closeable {
 		for (TripleIndex index : indexes) {
 			if (index.getFieldSeq()[0] == 'c') {
 				// found a context-first index
-				return getTriplesUsingIndex(txn, -1, -1, -1, -1, true, index, false);
+				return getTriplesUsingIndex(txn, -1, -1, -1, -1, true, index, false,
+						Collections.emptyList());
 			}
 		}
 		return null;
@@ -512,8 +518,11 @@ class TripleStore implements Closeable {
 			throws IOException {
 		TripleIndex index = getBestIndex(subj, pred, obj, context);
 		// System.out.println("get triples: " + Arrays.asList(subj, pred, obj,context));
-		boolean doRangeSearch = index.getPatternScore(subj, pred, obj, context) > 0;
-		return getTriplesUsingIndex(txn, subj, pred, obj, context, explicit, index, doRangeSearch);
+		int bestScore = index.getPatternScore(subj, pred, obj, context);
+		boolean doRangeSearch = bestScore > 0;
+		List<String> recommendedIndexes = computeRecommendedIndexes(subj, pred, obj, context, index, bestScore);
+		return getTriplesUsingIndex(txn, subj, pred, obj, context, explicit, index, doRangeSearch,
+				recommendedIndexes);
 	}
 
 	boolean hasTriples(boolean explicit) throws IOException {
@@ -526,8 +535,10 @@ class TripleStore implements Closeable {
 	}
 
 	private RecordIterator getTriplesUsingIndex(Txn txn, long subj, long pred, long obj, long context,
-			boolean explicit, TripleIndex index, boolean rangeSearch) throws IOException {
-		return new LmdbRecordIterator(index, rangeSearch, subj, pred, obj, context, explicit, txn);
+			boolean explicit, TripleIndex index, boolean rangeSearch, List<String> recommendedIndexes)
+			throws IOException {
+		return new LmdbRecordIterator(index, rangeSearch, subj, pred, obj, context, explicit, txn,
+				recommendedIndexes);
 	}
 
 	/**
@@ -852,6 +863,123 @@ class TripleStore implements Closeable {
 		}
 
 		return bestIndex;
+	}
+
+	private List<String> computeRecommendedIndexes(long subj, long pred, long obj, long context,
+			TripleIndex selectedIndex, int bestScore) {
+		int boundCount = 0;
+		if (subj >= 0) {
+			boundCount++;
+		}
+		if (pred >= 0) {
+			boundCount++;
+		}
+		if (obj >= 0) {
+			boundCount++;
+		}
+		if (context >= 0) {
+			boundCount++;
+		}
+
+		if (boundCount == 0 || bestScore >= boundCount) {
+			return List.of();
+		}
+
+		List<Character> bound = new ArrayList<>(4);
+		List<Character> unbound = new ArrayList<>(4);
+		if (subj >= 0) {
+			bound.add('s');
+		} else {
+			unbound.add('s');
+		}
+		if (pred >= 0) {
+			bound.add('p');
+		} else {
+			unbound.add('p');
+		}
+		if (obj >= 0) {
+			bound.add('o');
+		} else {
+			unbound.add('o');
+		}
+		if (context >= 0) {
+			bound.add('c');
+		} else {
+			unbound.add('c');
+		}
+
+		List<String> boundPermutations = permutationsOf(bound);
+		List<String> unboundPermutations = permutationsOf(unbound);
+		if (unboundPermutations.isEmpty()) {
+			unboundPermutations = List.of("");
+		}
+
+		Set<String> existing = indexes.stream()
+				.map(idx -> new String(idx.getFieldSeq()).toUpperCase(Locale.ROOT))
+				.collect(Collectors.toSet());
+
+		String currentIndex = new String(selectedIndex.getFieldSeq()).toUpperCase(Locale.ROOT);
+
+		List<String> candidates = new ArrayList<>();
+		for (String prefix : boundPermutations) {
+			for (String suffix : unboundPermutations) {
+				String candidate = prefix + suffix;
+				if (candidate.equals(currentIndex) || existing.contains(candidate)) {
+					continue;
+				}
+				candidates.add(candidate);
+			}
+		}
+
+		if (candidates.isEmpty()) {
+			return List.of();
+		}
+
+		for (String candidate : candidates) {
+			RECOMMENDED_INDEX_COUNTS.computeIfAbsent(candidate, k -> new LongAdder()).increment();
+		}
+
+		candidates.sort((left, right) -> {
+			long leftCount = getRecommendationCount(left);
+			long rightCount = getRecommendationCount(right);
+			if (leftCount != rightCount) {
+				return Long.compare(rightCount, leftCount);
+			}
+			return left.compareTo(right);
+		});
+
+		return candidates;
+	}
+
+	private static long getRecommendationCount(String indexName) {
+		LongAdder counter = RECOMMENDED_INDEX_COUNTS.get(indexName);
+		return counter != null ? counter.sum() : 0;
+	}
+
+	private List<String> permutationsOf(List<Character> elements) {
+		if (elements.isEmpty()) {
+			return List.of("");
+		}
+		List<String> results = new ArrayList<>();
+		permute(elements, new boolean[elements.size()], new StringBuilder(elements.size()), results);
+		return results;
+	}
+
+	private void permute(List<Character> elements, boolean[] used, StringBuilder builder, List<String> results) {
+		if (builder.length() == elements.size()) {
+			results.add(builder.toString());
+			return;
+		}
+		for (int i = 0; i < elements.size(); i++) {
+			if (used[i]) {
+				continue;
+			}
+			used[i] = true;
+			builder.append(Character.toUpperCase(elements.get(i)));
+			permute(elements, used, builder, results);
+			builder.setLength(builder.length() - 1);
+			used[i] = false;
+		}
 	}
 
 	private boolean requiresResize() {

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbQueryExplanationTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbQueryExplanationTest.java
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ ******************************************************************************/
+package org.eclipse.rdf4j.sail.lmdb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.util.Values;
+import org.eclipse.rdf4j.query.QueryLanguage;
+import org.eclipse.rdf4j.query.TupleQuery;
+import org.eclipse.rdf4j.query.explanation.Explanation;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.sail.Sail;
+import org.eclipse.rdf4j.sail.SailException;
+import org.eclipse.rdf4j.sail.lmdb.config.LmdbStoreConfig;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class LmdbQueryExplanationTest {
+
+	@TempDir
+	File dataDir;
+
+	private SailRepository repository;
+
+	@BeforeEach
+	void setUp() throws SailException {
+		Sail sail = new LmdbStore(dataDir, new LmdbStoreConfig("spoc,posc"));
+		sail.init();
+		repository = new SailRepository(sail);
+		repository.init();
+
+		try (RepositoryConnection connection = repository.getConnection()) {
+			IRI alice = Values.iri("http://example.com/alice");
+			IRI knows = Values.iri("http://example.com/knows");
+			IRI bob = Values.iri("http://example.com/bob");
+			IRI carol = Values.iri("http://example.com/carol");
+
+			connection.add(alice, knows, bob);
+			connection.add(bob, knows, carol);
+			connection.add(carol, knows, alice);
+		}
+	}
+
+	@AfterEach
+	void tearDown() {
+		if (repository != null) {
+			repository.shutDown();
+		}
+	}
+
+	@Test
+	void executedExplanationIncludesIndexName() {
+		try (RepositoryConnection connection = repository.getConnection()) {
+			TupleQuery query = connection.prepareTupleQuery(QueryLanguage.SPARQL,
+					"SELECT ?o WHERE { <http://example.com/alice> <http://example.com/knows> ?o }");
+			Explanation explanation = query.explain(Explanation.Level.Executed);
+			String plan = explanation.toString();
+
+			assertThat(plan).contains("[index: spoc]");
+			assertThat(plan).doesNotContain("recommended indexes");
+		}
+	}
+
+	@Test
+	void executedExplanationSuggestsIndexesWhenSequentialScan() {
+		try (RepositoryConnection connection = repository.getConnection()) {
+			TupleQuery query = connection.prepareTupleQuery(QueryLanguage.SPARQL,
+					"SELECT ?s WHERE { ?s ?p <http://example.com/bob> } LIMIT 1");
+			Explanation explanation = query.explain(Explanation.Level.Executed);
+			String plan = explanation.toString();
+
+			assertThat(plan).contains("recommended indexes: o");
+		}
+	}
+}

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/TripleStoreIndexRecommendationTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/TripleStoreIndexRecommendationTest.java
@@ -75,7 +75,7 @@ class TripleStoreIndexRecommendationTest {
 		BoundPattern ocBound = new BoundPattern(LmdbValue.UNKNOWN_ID, LmdbValue.UNKNOWN_ID, 1L, 1L);
 		Path storeDir = Files.createTempDirectory(tempDir, "freq-");
 
-		try (TripleStore tripleStore = createTripleStore(storeDir, List.of("SPOC", "PSOC", "OPSC"));
+		try (TripleStore tripleStore = createTripleStore(storeDir, List.of("SPOC", "PSOC", "CSPO"));
 				Txn txn = tripleStore.getTxnManager().createReadTxn();
 				RecordIterator iterator = tripleStore.getTriples(txn, ocBound.subj(), ocBound.pred(),
 						ocBound.obj(), ocBound.context(), true)) {
@@ -83,6 +83,22 @@ class TripleStoreIndexRecommendationTest {
 			assertThat(recommendations)
 					.containsExactly("OCPS", "COPS", "COSP", "OCSP");
 		}
+	}
+
+	@Test
+	void recommendationsNotComputedDuringIterationUnlessRequested() throws Exception {
+		BoundPattern objBound = new BoundPattern(LmdbValue.UNKNOWN_ID, LmdbValue.UNKNOWN_ID, 1L,
+				LmdbValue.UNKNOWN_ID);
+		Path storeDir = Files.createTempDirectory(tempDir, "lazy-");
+
+		try (TripleStore tripleStore = createTripleStore(storeDir, List.of("SPOC", "PSOC", "CSPO"));
+				Txn txn = tripleStore.getTxnManager().createReadTxn();
+				RecordIterator iterator = tripleStore.getTriples(txn, objBound.subj(), objBound.pred(),
+						objBound.obj(), objBound.context(), true)) {
+			iterator.next();
+		}
+
+		assertThat(recommendationCounters).isEmpty();
 	}
 
 	private boolean matchesAnyPrefix(String index, List<String> prefixes) {

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/TripleStoreIndexRecommendationTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/TripleStoreIndexRecommendationTest.java
@@ -1,0 +1,196 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ ******************************************************************************/
+package org.eclipse.rdf4j.sail.lmdb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.eclipse.rdf4j.sail.SailException;
+import org.eclipse.rdf4j.sail.lmdb.TxnManager.Txn;
+import org.eclipse.rdf4j.sail.lmdb.config.LmdbStoreConfig;
+import org.eclipse.rdf4j.sail.lmdb.model.LmdbValue;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class TripleStoreIndexRecommendationTest {
+
+	@TempDir
+	Path tempDir;
+
+	private ConcurrentHashMap<String, LongAdder> recommendationCounters;
+
+	@BeforeEach
+	void resetRecommendationCounters() throws Exception {
+		recommendationCounters = extractRecommendationCounters();
+		recommendationCounters.clear();
+	}
+
+	@ParameterizedTest(name = "{0}: {1}")
+	@MethodSource("recommendationCases")
+	void recommendedIndexesMatchExpectations(String id, String description, BoundPattern pattern,
+			List<String> existingIndexes, List<String> expectedPrefixes, List<String> expectedRecommendations)
+			throws Exception {
+		Path storeDir = Files.createTempDirectory(tempDir, id + "-");
+
+		try (TripleStore tripleStore = createTripleStore(storeDir, existingIndexes);
+				Txn txn = tripleStore.getTxnManager().createReadTxn();
+				RecordIterator iterator = tripleStore.getTriples(txn, pattern.subj(), pattern.pred(),
+						pattern.obj(), pattern.context(), true)) {
+			List<String> recommendations = iterator.getRecommendedIndexes();
+
+			assertThat(recommendations).containsExactlyElementsOf(expectedRecommendations);
+			assertThat(recommendations).doesNotContainAnyElementsOf(existingIndexes);
+			assertThat(recommendations).allSatisfy(index -> assertThat(matchesAnyPrefix(index, expectedPrefixes))
+					.as("Index %s should start with one of %s", index, expectedPrefixes)
+					.isTrue());
+		}
+	}
+
+	@Test
+	void recommendationsPreferFrequentlySuggestedIndexes() throws Exception {
+		recommendationCounters.computeIfAbsent("OCPS", key -> new LongAdder()).add(5);
+
+		BoundPattern ocBound = new BoundPattern(LmdbValue.UNKNOWN_ID, LmdbValue.UNKNOWN_ID, 1L, 1L);
+		Path storeDir = Files.createTempDirectory(tempDir, "freq-");
+
+		try (TripleStore tripleStore = createTripleStore(storeDir, List.of("SPOC", "PSOC", "OPSC"));
+				Txn txn = tripleStore.getTxnManager().createReadTxn();
+				RecordIterator iterator = tripleStore.getTriples(txn, ocBound.subj(), ocBound.pred(),
+						ocBound.obj(), ocBound.context(), true)) {
+			List<String> recommendations = iterator.getRecommendedIndexes();
+			assertThat(recommendations)
+					.containsExactly("OCPS", "COPS", "COSP", "OCSP");
+		}
+	}
+
+	private boolean matchesAnyPrefix(String index, List<String> prefixes) {
+		return prefixes.stream().anyMatch(index::startsWith);
+	}
+
+	private TripleStore createTripleStore(Path storeDir, List<String> existingIndexes)
+			throws IOException, SailException {
+		String indexSpec = existingIndexes.stream()
+				.map(s -> s.toLowerCase(Locale.ROOT))
+				.collect(Collectors.joining(","));
+		return new TripleStore(storeDir.toFile(), new LmdbStoreConfig(indexSpec), null);
+	}
+
+	private ConcurrentHashMap<String, LongAdder> extractRecommendationCounters() throws Exception {
+		Field field = TripleStore.class.getDeclaredField("RECOMMENDED_INDEX_COUNTS");
+		field.setAccessible(true);
+		@SuppressWarnings("unchecked")
+		ConcurrentHashMap<String, LongAdder> counters = (ConcurrentHashMap<String, LongAdder>) field.get(null);
+		return counters;
+	}
+
+	private static Stream<Arguments> recommendationCases() {
+		return Stream.of(
+				Arguments.of("N01", "S bound only", pattern(true, false, false, false),
+						List.of("POSC", "OPSC", "CPOS", "COPS"), List.of("S"),
+						List.of("SCOP", "SCPO", "SOCP", "SOPC", "SPCO", "SPOC")),
+				Arguments.of("N02", "P bound only", pattern(false, true, false, false),
+						List.of("SPOC", "OSPC", "CSPO", "OCSP"), List.of("P"),
+						List.of("PCOS", "PCSO", "POCS", "POSC", "PSCO", "PSOC")),
+				Arguments.of("N03", "O bound only", pattern(false, false, true, false),
+						List.of("SPOC", "PSOC", "CSPO", "COPS"), List.of("O"),
+						List.of("OCPS", "OCSP", "OPCS", "OPSC", "OSCP", "OSPC")),
+				Arguments.of("N04", "C bound only (graph fixed)", pattern(false, false, false, true),
+						List.of("SPOC", "PSOC", "OSPC", "OPSC"), List.of("C"),
+						List.of("COPS", "COSP", "CPOS", "CPSO", "CSOP", "CSPO")),
+				Arguments.of("N05", "S and P bound", pattern(true, true, false, false),
+						List.of("COPS", "OPSC", "OCSP"), List.of("SP", "PS"),
+						List.of("PSCO", "PSOC", "SPCO", "SPOC")),
+				Arguments.of("N06", "S and O bound", pattern(true, false, true, false),
+						List.of("SPOC", "SPCO", "COPS"), List.of("SO", "OS"),
+						List.of("OSCP", "OSPC", "SOCP", "SOPC")),
+				Arguments.of("N07", "S and C bound", pattern(true, false, false, true),
+						List.of("SPOC", "OPSC", "POCS"), List.of("SC", "CS"),
+						List.of("CSOP", "CSPO", "SCOP", "SCPO")),
+				Arguments.of("N08", "P and O bound", pattern(false, true, true, false),
+						List.of("SPOC", "SCOP", "CPSO"), List.of("PO", "OP"),
+						List.of("OPCS", "OPSC", "POCS", "POSC")),
+				Arguments.of("N09", "P and C bound", pattern(false, true, false, true),
+						List.of("SPOC", "OSPC", "SCOP"), List.of("PC", "CP"),
+						List.of("CPOS", "CPSO", "PCOS", "PCSO")),
+				Arguments.of("N10", "O and C bound", pattern(false, false, true, true),
+						List.of("SPOC", "PSOC", "SPCO"), List.of("OC", "CO"),
+						List.of("COPS", "COSP", "OCPS", "OCSP")),
+				Arguments.of("N11", "S,P,O bound; C unbound", pattern(true, true, true, false),
+						List.of("SCPO", "PCSO", "COPS"),
+						List.of("SPO", "SOP", "PSO", "POS", "OSP", "OPS"),
+						List.of("OPSC", "OSPC", "POSC", "PSOC", "SOPC", "SPOC")),
+				Arguments.of("N12", "C,S,P bound; O unbound", pattern(true, true, false, true),
+						List.of("SPOC", "OCSP", "OPCS"),
+						List.of("CSP", "CPS", "SCP", "SPC", "PCS", "PSC"),
+						List.of("CPSO", "CSPO", "PCSO", "PSCO", "SCPO", "SPCO")),
+				Arguments.of("N13", "C,S,O bound; P unbound", pattern(true, false, true, true),
+						List.of("SPOC", "PCSO", "COPS"),
+						List.of("CSO", "COS", "SCO", "SOC", "OCS", "OSC"),
+						List.of("COSP", "CSOP", "OCSP", "OSCP", "SCOP", "SOCP")),
+				Arguments.of("N14", "C,P,O bound; S unbound", pattern(false, true, true, true),
+						List.of("SPOC", "SPCO", "CSPO"),
+						List.of("CPO", "COP", "PCO", "POC", "OCP", "OPC"),
+						List.of("COPS", "CPOS", "OCPS", "OPCS", "PCOS", "POCS"))
+		);
+	}
+
+	private static BoundPattern pattern(boolean subjBound, boolean predBound, boolean objBound, boolean contextBound) {
+		long subj = subjBound ? 1L : LmdbValue.UNKNOWN_ID;
+		long pred = predBound ? 1L : LmdbValue.UNKNOWN_ID;
+		long obj = objBound ? 1L : LmdbValue.UNKNOWN_ID;
+		long context = contextBound ? 1L : LmdbValue.UNKNOWN_ID;
+		return new BoundPattern(subj, pred, obj, context);
+	}
+
+	private static final class BoundPattern {
+		private final long subj;
+		private final long pred;
+		private final long obj;
+		private final long context;
+
+		private BoundPattern(long subj, long pred, long obj, long context) {
+			this.subj = subj;
+			this.pred = pred;
+			this.obj = obj;
+			this.context = context;
+		}
+
+		long subj() {
+			return subj;
+		}
+
+		long pred() {
+			return pred;
+		}
+
+		long obj() {
+			return obj;
+		}
+
+		long context() {
+			return context;
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- propagate LMDB iterator index names and recommendations up through TripleSourceIterationWrapper
- capture recommended triple indexes when sequential scans are used and expose them via query explanations
- add focused integration and unit coverage for LMDB query plans and recommendation heuristics

## Testing
- mvn -pl core/sail/lmdb -Dtest=TripleStoreIndexRecommendationTest test
- mvn -pl core/sail/lmdb -Dtest=LmdbQueryExplanationTest,TripleStoreIndexRecommendationTest test

------
https://chatgpt.com/codex/tasks/task_e_690af67b9a94832e8d4c88e0e85129ff