### PR TITLE
Migrate NativeStore helpers to FileChannel

### DIFF
--- a/ExecPlan-NativeStore-FileChannel.md
+++ b/ExecPlan-NativeStore-FileChannel.md
@@ -1,0 +1,82 @@
+# Migrate NativeStore locking and hashing helpers to FileChannel
+
+This ExecPlan is a living document. The sections `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work proceeds.
+
+See `PLANS.md` at the repository root for required structure and maintenance rules.
+
+## Purpose / Big Picture
+
+NativeStore currently relies on `RandomAccessFile` in its hashing data structure and directory locking helper. We want the store to exclusively use NIO `FileChannel`-based access so it benefits from the same interrupt-safe reopen logic provided elsewhere and avoids legacy I/O APIs. After these changes a developer can point to both the hash file rehash path and the directory lock manager using `FileChannel` primitives, with tests that guard against regressing back to `RandomAccessFile`.
+
+## Progress
+
+- [x] (2024-03-05 00:00Z) Draft plan and identify affected classes.
+- [x] (2025-11-10 17:50Z) Add regression tests that currently fail because `RandomAccessFile` is still in use.
+- [x] (2025-11-10 17:52Z) Update implementation to satisfy tests and ensure all resources use `FileChannel`.
+- [x] (2025-11-10 17:53Z) Run targeted Maven test suites and formatting checks.
+- [x] (2025-11-10 17:54Z) Document outcomes, clean up plan, and finalize.
+
+## Surprises & Discoveries
+
+- Maven module isolation: running a single module's tests (`core/sail/nativerdf`) without pre-installing sibling modules fails
+  because the build expects snapshot artifacts for other RDF4J modules in the local repository. Evidence: dependency resolution
+  errors when executing `mvn -pl core/sail/nativerdf -Dtest=HashFileFileChannelMigrationTest test`.
+
+## Decision Log
+
+- Decision (superseded): Attempt a root-level `mvn install -DskipTests` to populate local snapshot artifacts before targeted
+  module tests. Rationale was to avoid the forbidden `-am` flag when running tests. This proved too time-consuming (multi-hour
+  reactor), so the approach was abandoned partway through. Date/Author: 2025-11-10 / ChatGPT.
+- Decision: Use `mvn -pl core/sail/nativerdf -am -DskipTests install` followed by `mvn -pl core/sail/api -am -DskipTests install`
+  to pre-install only the relevant module subtrees. Rationale: `-am` is disallowed only for test runs per AGENTS.md, so using it
+  for skipped-test installs is compliant and far faster than a full reactor build. Date/Author: 2025-11-10 / ChatGPT.
+
+## Outcomes & Retrospective
+
+- HashFile and DirectoryLockManager both rely exclusively on `FileChannel` primitives and close them deterministically, keeping
+  the previous durability semantics intact.
+- Guard-rail tests in `core/sail/nativerdf` and `core/sail/api` fail against the legacy code and pass after the migration,
+  proving the refactor.
+
+## Context and Orientation
+
+NativeStore lives under `core/sail/nativerdf`. Hash indexing lives in `core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/datastore/HashFile.java`. Directory locking is provided by `core/sail/api/src/main/java/org/eclipse/rdf4j/sail/helpers/DirectoryLockManager.java`, which NativeStore uses during initialization. Both classes still allocate `RandomAccessFile`. We already have an interrupt-safe wrapper `org.eclipse.rdf4j.common.io.NioFile` that wraps `FileChannel` and exposes reopen logic. The goal is to align these components with the rest of the NativeStore stack and prevent regressions with tests.
+
+## Plan of Work
+
+1. Create a new unit test in `core/sail/nativerdf` that introspects `HashFile`'s private `createEmptyFile` helper via reflection and asserts it returns a `FileChannel`. The legacy code returns `RandomAccessFile`, so this test will fail before the migration.
+2. Add a complementary test in `core/sail/api` exercising `DirectoryLockManager.tryLock()` and verifying the anonymous `Lock` implementation no longer closes over a `RandomAccessFile` field but instead keeps a `FileChannel`. Reflection on the lock's declared fields provides the guardrail.
+3. Modify `HashFile` to replace the `RandomAccessFile` usage with `FileChannel.open(...)` and adjust related logic (`createEmptyFile`, rehash temp file handling) to work with the new channel. Ensure all paths close channels and preserve truncation behavior.
+4. Refactor `DirectoryLockManager` to open `FileChannel` instances using NIO options (read, write, create), adjust lock acquisition/release to work directly with channels, and update cleanup code accordingly.
+5. Run targeted Maven tests for the affected modules, followed by any required formatting checks.
+6. Update this plan's living sections with progress, discoveries, and outcomes.
+
+## Concrete Steps
+
+1. `cd /workspace/rdf4j`
+2. Implement and run `mvn -pl core/sail/nativerdf -Dtest=HashFileFileChannelMigrationTest test` to capture the pre-change failure.
+3. Implement and run `mvn -pl core/sail/api -Dtest=DirectoryLockManagerFileChannelTest test` to capture its pre-change failure.
+4. Apply production code changes described above.
+5. Re-run the same Maven commands to confirm passing tests.
+6. Run any additional formatting or verification commands required by the repository.
+
+## Validation and Acceptance
+
+- The new HashFile reflection test fails before the migration and passes afterwards, showing that rehash temp files now use `FileChannel`.
+- The new DirectoryLockManager reflection test fails before the migration and passes afterwards, demonstrating lock management no longer depends on `RandomAccessFile`.
+- Targeted Maven test runs complete successfully post-change.
+
+## Idempotence and Recovery
+
+- Tests and Maven commands are safe to re-run; they only operate on temporary directories under `java.nio.file.Files.createTempDirectory`.
+- The code edits are reversible via Git if needed.
+
+## Artifacts and Notes
+
+- Capture Maven failure snippets for both new tests before applying fixes.
+- Record passing output after the migration to evidence success.
+
+## Interfaces and Dependencies
+
+- Use `java.nio.channels.FileChannel` with `StandardOpenOption.CREATE`, `WRITE`, `READ`, and `TRUNCATE_EXISTING` where applicable.
+- Continue to rely on `org.eclipse.rdf4j.common.io.NioFile` for safe channel operations in `HashFile`.

--- a/ExecPlan-NativeStore-FileChannel.md
+++ b/ExecPlan-NativeStore-FileChannel.md
@@ -15,6 +15,8 @@ NativeStore currently relies on `RandomAccessFile` in its hashing data structure
 - [x] (2025-11-10 17:52Z) Update implementation to satisfy tests and ensure all resources use `FileChannel`.
 - [x] (2025-11-10 17:53Z) Run targeted Maven test suites and formatting checks.
 - [x] (2025-11-10 17:54Z) Document outcomes, clean up plan, and finalize.
+- [x] (2025-11-10 18:05Z) Introduce FileChannel guard rails for DataFile/IDFile and port their channel helpers away from NioFile.
+- [x] (2025-11-10 18:19Z) Run the full `core/sail/nativerdf` module tests to ensure the broader NativeStore suite remains stable.
 
 ## Surprises & Discoveries
 
@@ -37,6 +39,8 @@ NativeStore currently relies on `RandomAccessFile` in its hashing data structure
   the previous durability semantics intact.
 - Guard-rail tests in `core/sail/nativerdf` and `core/sail/api` fail against the legacy code and pass after the migration,
   proving the refactor.
+- DataFile and IDFile reopen their channels via `FileChannel`, maintain cached sizes, and expose regression tests that exercise
+  recovery paths when channels are closed mid-operation.
 
 ## Context and Orientation
 
@@ -49,7 +53,11 @@ NativeStore lives under `core/sail/nativerdf`. Hash indexing lives in `core/sail
 3. Modify `HashFile` to replace the `RandomAccessFile` usage with `FileChannel.open(...)` and adjust related logic (`createEmptyFile`, rehash temp file handling) to work with the new channel. Ensure all paths close channels and preserve truncation behavior.
 4. Refactor `DirectoryLockManager` to open `FileChannel` instances using NIO options (read, write, create), adjust lock acquisition/release to work directly with channels, and update cleanup code accordingly.
 5. Run targeted Maven tests for the affected modules, followed by any required formatting checks.
-6. Update this plan's living sections with progress, discoveries, and outcomes.
+6. Extend the regression harness with DataFile/IDFile guard rails that verify FileChannel usage, reopen semantics, and recovery
+   helpers.
+7. Port DataFile/IDFile off `NioFile`, ensuring buffer flushes, cached sizes, and reopen loops use direct `FileChannel` calls.
+8. Re-run module-level Maven tests (`mvn -pl core/sail/nativerdf test`) and update this plan's living sections with the latest
+   evidence.
 
 ## Concrete Steps
 
@@ -64,6 +72,7 @@ NativeStore lives under `core/sail/nativerdf`. Hash indexing lives in `core/sail
 
 - The new HashFile reflection test fails before the migration and passes afterwards, showing that rehash temp files now use `FileChannel`.
 - The new DirectoryLockManager reflection test fails before the migration and passes afterwards, demonstrating lock management no longer depends on `RandomAccessFile`.
+- DataFile/IDFile guard tests confirm FileChannel usage, reopen recovery, and header validation across the migration.
 - Targeted Maven test runs complete successfully post-change.
 
 ## Idempotence and Recovery

--- a/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/helpers/DirectoryLockManager.java
+++ b/core/sail/api/src/main/java/org/eclipse/rdf4j/sail/helpers/DirectoryLockManager.java
@@ -15,10 +15,11 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.io.RandomAccessFile;
 import java.lang.management.ManagementFactory;
+import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
 import java.nio.channels.OverlappingFileLockException;
+import java.nio.file.StandardOpenOption;
 import java.security.AccessControlException;
 
 import org.eclipse.rdf4j.common.concurrent.locks.Lock;
@@ -91,17 +92,22 @@ public class DirectoryLockManager implements LockManager {
 			File infoFile = new File(lockDir, INFO_FILE_NAME);
 			File lockedFile = new File(lockDir, LOCK_FILE_NAME);
 
-			RandomAccessFile raf = new RandomAccessFile(lockedFile, "rw");
+			FileChannel channel = null;
 			try {
-				FileLock fileLock = raf.getChannel().lock();
-				lock = createLock(raf, fileLock);
+				channel = FileChannel.open(lockedFile.toPath(), StandardOpenOption.CREATE,
+						StandardOpenOption.READ, StandardOpenOption.WRITE);
+				FileLock fileLock = channel.lock();
+				lock = createLock(channel, fileLock);
 				sign(infoFile);
 			} catch (IOException e) {
 				if (lock != null) {
-					// Also closes raf
 					lock.release();
-				} else {
-					raf.close();
+				} else if (channel != null && channel.isOpen()) {
+					try {
+						channel.close();
+					} catch (IOException closeException) {
+						e.addSuppressed(closeException);
+					}
 				}
 				throw e;
 			}
@@ -161,8 +167,9 @@ public class DirectoryLockManager implements LockManager {
 			boolean revokeLock = false;
 
 			File lockedFile = new File(lockDir, LOCK_FILE_NAME);
-			try (RandomAccessFile raf = new RandomAccessFile(lockedFile, "rw")) {
-				FileLock fileLock = raf.getChannel().tryLock();
+			try (FileChannel channel = FileChannel.open(lockedFile.toPath(), StandardOpenOption.CREATE,
+					StandardOpenOption.READ, StandardOpenOption.WRITE)) {
+				FileLock fileLock = channel.tryLock();
 
 				if (fileLock != null) {
 					logger.warn("Removing invalid lock {}", getLockedBy());
@@ -194,7 +201,7 @@ public class DirectoryLockManager implements LockManager {
 		}
 	}
 
-	private Lock createLock(final RandomAccessFile raf, final FileLock fileLock) {
+	private Lock createLock(final FileChannel channel, final FileLock fileLock) {
 		return new Lock() {
 
 			private Thread hook;
@@ -231,12 +238,19 @@ public class DirectoryLockManager implements LockManager {
 
 			synchronized void delete() {
 				try {
-					if (raf.getChannel().isOpen()) {
+					if (fileLock.isValid()) {
 						fileLock.release();
-						raf.close();
 					}
 				} catch (IOException e) {
 					logger.warn(e.toString(), e);
+				} finally {
+					try {
+						if (channel.isOpen()) {
+							channel.close();
+						}
+					} catch (IOException e) {
+						logger.warn(e.toString(), e);
+					}
 				}
 
 				revokeLock();

--- a/core/sail/api/src/test/java/org/eclipse/rdf4j/sail/helpers/DirectoryLockManagerFileChannelTest.java
+++ b/core/sail/api/src/test/java/org/eclipse/rdf4j/sail/helpers/DirectoryLockManagerFileChannelTest.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.helpers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.nio.channels.FileChannel;
+import java.util.Arrays;
+
+import org.eclipse.rdf4j.common.concurrent.locks.Lock;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Ensures the lock returned by {@link DirectoryLockManager#tryLock()} retains only {@link FileChannel}-based state,
+ * guaranteeing that the manager no longer depends on {@link java.io.RandomAccessFile}.
+ */
+public class DirectoryLockManagerFileChannelTest {
+
+	@TempDir
+	File tempDir;
+
+	@Test
+	public void lockCapturesFileChannelNotRandomAccessFile() {
+		DirectoryLockManager manager = new DirectoryLockManager(tempDir);
+		Lock lock = manager.tryLock();
+
+		assertThat(lock).as("DirectoryLockManager should acquire a lock").isNotNull();
+
+		Field[] fields = lock.getClass().getDeclaredFields();
+
+		boolean hasRandomAccessFileField = Arrays.stream(fields)
+				.anyMatch(field -> field.getType().getName().equals("java.io.RandomAccessFile"));
+		boolean hasFileChannelField = Arrays.stream(fields)
+				.anyMatch(field -> FileChannel.class.isAssignableFrom(field.getType()));
+
+		try {
+			assertThat(hasRandomAccessFileField)
+					.as("Lock implementation should avoid capturing RandomAccessFile")
+					.isFalse();
+			assertThat(hasFileChannelField)
+					.as("Lock implementation should capture FileChannel state for cleanup")
+					.isTrue();
+		} finally {
+			if (lock != null) {
+				lock.release();
+			}
+		}
+	}
+}

--- a/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/datastore/DataFile.java
+++ b/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/datastore/DataFile.java
@@ -16,12 +16,18 @@ import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.channels.ClosedByInterruptException;
+import java.nio.channels.ClosedChannelException;
+import java.nio.channels.FileChannel;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.NoSuchElementException;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.rdf4j.common.annotation.InternalUseOnly;
-import org.eclipse.rdf4j.common.io.NioFile;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,12 +68,19 @@ public class DataFile implements Closeable {
 	 * Variables *
 	 *-----------*/
 
-	private final NioFile nioFile;
+	private static final Set<StandardOpenOption> FILE_OPEN_OPTIONS = EnumSet
+			.of(StandardOpenOption.CREATE, StandardOpenOption.READ, StandardOpenOption.WRITE);
+
+	private final Path path;
+	private final Set<StandardOpenOption> openOptions;
+	private final Object channelLock = new Object();
+	private volatile FileChannel fileChannel;
+	private volatile boolean explicitlyClosed;
 
 	private final boolean forceSync;
 
 	// cached file size, also reflects buffer usage
-	private volatile long nioFileSize;
+	private volatile long fileSize;
 
 	// 4KB write buffer that is flushed on sync, close and any read operations
 	private final ByteBuffer buffer = ByteBuffer.allocate(4 * 1024);
@@ -81,39 +94,42 @@ public class DataFile implements Closeable {
 	}
 
 	public DataFile(File file, boolean forceSync) throws IOException {
-		this.nioFile = new NioFile(file);
+		this.path = file.toPath();
+		this.openOptions = EnumSet.copyOf(FILE_OPEN_OPTIONS);
 		this.forceSync = forceSync;
+		this.explicitlyClosed = false;
 
 		try {
-			// Open a read/write channel to the file
+			synchronized (channelLock) {
+				this.fileChannel = FileChannel.open(path, openOptions);
+			}
 
-			if (nioFile.size() == 0) {
-				// Empty file, write header
-				nioFile.writeBytes(MAGIC_NUMBER, 0);
-				nioFile.writeByte(FILE_FORMAT_VERSION, MAGIC_NUMBER.length);
-
+			long initialSize = size();
+			if (initialSize == 0L) {
+				writeBytes(MAGIC_NUMBER, 0L);
+				writeByte(FILE_FORMAT_VERSION, MAGIC_NUMBER.length);
 				sync();
-			} else if (nioFile.size() < HEADER_LENGTH) {
+			} else if (initialSize < HEADER_LENGTH) {
 				throw new IOException("File too small to be a compatible data file");
 			} else {
-				// Verify file header
-				if (!Arrays.equals(MAGIC_NUMBER, nioFile.readBytes(0, MAGIC_NUMBER.length))) {
+				byte[] magic = readBytes(0L, MAGIC_NUMBER.length);
+				if (!Arrays.equals(MAGIC_NUMBER, magic)) {
 					throw new IOException("File doesn't contain compatible data records");
 				}
 
-				byte version = nioFile.readByte(MAGIC_NUMBER.length);
+				byte version = readByte(MAGIC_NUMBER.length);
 				if (version > FILE_FORMAT_VERSION) {
 					throw new IOException("Unable to read data file; it uses a newer file format");
 				} else if (version != FILE_FORMAT_VERSION) {
 					throw new IOException("Unable to read data file; invalid file format version: " + version);
 				}
 			}
+
+			this.fileSize = size();
 		} catch (IOException e) {
-			this.nioFile.close();
+			closeQuietly();
 			throw e;
 		}
-
-		this.nioFileSize = nioFile.size();
 
 	}
 
@@ -122,7 +138,7 @@ public class DataFile implements Closeable {
 	 *---------*/
 
 	public File getFile() {
-		return nioFile.getFile();
+		return path.toFile();
 	}
 
 	/**
@@ -130,7 +146,7 @@ public class DataFile implements Closeable {
 	 */
 	public long getFileSize() throws IOException {
 		flush();
-		return nioFileSize;
+		return fileSize;
 	}
 
 	/**
@@ -146,7 +162,7 @@ public class DataFile implements Closeable {
 		long available = endOffset - (startOffset + 4);
 		int cap = 32 * 1024 * 1024; // 32MB cap for recovery
 		int toRead = (int) Math.min(Math.max(available, 0), cap);
-		return nioFile.readBytes(startOffset + 4L, toRead);
+		return readBytes(startOffset + 4L, toRead);
 	}
 
 	/**
@@ -158,7 +174,7 @@ public class DataFile implements Closeable {
 	synchronized public long storeData(byte[] data) throws IOException {
 		assert data != null : "data must not be null";
 
-		long offset = nioFileSize;
+		long offset = fileSize;
 
 		if (data.length + 4 > buffer.capacity()) {
 			// direct write because we are writing more data than the buffer can hold
@@ -169,11 +185,12 @@ public class DataFile implements Closeable {
 			ByteBuffer buf = ByteBuffer.allocate(data.length + 4);
 			buf.putInt(data.length);
 			buf.put(data);
-			buf.rewind();
+			buf.flip();
+			int total = buf.remaining();
 
-			nioFile.write(buf, offset);
+			writeFully(buf, offset);
 
-			nioFileSize += buf.array().length;
+			fileSize += total;
 
 		} else {
 			if (data.length + 4 > remainingBufferCapacity()) {
@@ -182,7 +199,7 @@ public class DataFile implements Closeable {
 
 			buffer.putInt(data.length);
 			buffer.put(data);
-			nioFileSize += data.length + 4;
+			fileSize += data.length + 4;
 		}
 
 		return offset;
@@ -194,14 +211,9 @@ public class DataFile implements Closeable {
 		if (position == 0) {
 			return;
 		}
-		buffer.position(0);
-
-		byte[] byteToWrite = new byte[position];
-		buffer.get(byteToWrite, 0, position);
-
-		nioFile.write(ByteBuffer.wrap(byteToWrite), nioFileSize - byteToWrite.length);
-
-		buffer.position(0);
+		buffer.flip();
+		writeFully(buffer, fileSize - position);
+		buffer.clear();
 
 	}
 
@@ -228,7 +240,7 @@ public class DataFile implements Closeable {
 		// operation even if that larger operation is unnecessarily large (within sensible limits).
 		byte[] data = new byte[(dataLengthApproximateAverage * 2) + 4];
 		ByteBuffer buf = ByteBuffer.wrap(data);
-		nioFile.read(buf, offset);
+		readFully(buf, offset);
 
 		int dataLength = (data[0] << 24) & 0xff000000 |
 				(data[1] << 16) & 0x00ff0000 |
@@ -268,7 +280,7 @@ public class DataFile implements Closeable {
 				// we didn't read enough data so we need to execute a new read
 				data = new byte[dataLength];
 				buf = ByteBuffer.wrap(data);
-				nioFile.read(buf, offset + 4L);
+				readFully(buf, offset + 4L);
 
 				return data;
 			}
@@ -379,14 +391,180 @@ public class DataFile implements Closeable {
 		return Math.toIntExact(Math.min(threshold, Integer.MAX_VALUE));
 	}
 
+	private FileChannel ensureChannel() throws IOException {
+		FileChannel channel = fileChannel;
+		if (channel != null && channel.isOpen()) {
+			return channel;
+		}
+
+		synchronized (channelLock) {
+			if (explicitlyClosed) {
+				throw new ClosedChannelException();
+			}
+			channel = fileChannel;
+			if (channel == null || !channel.isOpen()) {
+				fileChannel = FileChannel.open(path, openOptions);
+				channel = fileChannel;
+			}
+			return channel;
+		}
+	}
+
+	private void reopen(ClosedChannelException e) throws IOException {
+		if (explicitlyClosed) {
+			throw e;
+		}
+
+		synchronized (channelLock) {
+			FileChannel channel = fileChannel;
+			if (channel != null && channel.isOpen()) {
+				return;
+			}
+			fileChannel = FileChannel.open(path, openOptions);
+		}
+	}
+
+	private long size() throws IOException {
+		while (true) {
+			try {
+				return ensureChannel().size();
+			} catch (ClosedByInterruptException e) {
+				throw e;
+			} catch (ClosedChannelException e) {
+				reopen(e);
+			}
+		}
+	}
+
+	private void truncate(long newSize) throws IOException {
+		while (true) {
+			try {
+				ensureChannel().truncate(newSize);
+				return;
+			} catch (ClosedByInterruptException e) {
+				throw e;
+			} catch (ClosedChannelException e) {
+				reopen(e);
+			}
+		}
+	}
+
+	private void force(boolean metaData) throws IOException {
+		while (true) {
+			try {
+				ensureChannel().force(metaData);
+				return;
+			} catch (ClosedByInterruptException e) {
+				throw e;
+			} catch (ClosedChannelException e) {
+				reopen(e);
+			}
+		}
+	}
+
+	private int writeFully(ByteBuffer buffer, long offset) throws IOException {
+		final int startPosition = buffer.position();
+		while (buffer.hasRemaining()) {
+			try {
+				FileChannel channel = ensureChannel();
+				long position = offset + (buffer.position() - startPosition);
+				int written = channel.write(buffer, position);
+				if (written == 0) {
+					continue;
+				}
+			} catch (ClosedByInterruptException e) {
+				throw e;
+			} catch (ClosedChannelException e) {
+				reopen(e);
+			}
+		}
+		return buffer.position() - startPosition;
+	}
+
+	private int readFully(ByteBuffer buffer, long offset) throws IOException {
+		final int startPosition = buffer.position();
+		while (buffer.hasRemaining()) {
+			try {
+				FileChannel channel = ensureChannel();
+				long position = offset + (buffer.position() - startPosition);
+				int read = channel.read(buffer, position);
+				if (read < 0) {
+					if (buffer.position() == startPosition) {
+						return -1;
+					}
+					break;
+				}
+				if (read == 0) {
+					continue;
+				}
+			} catch (ClosedByInterruptException e) {
+				throw e;
+			} catch (ClosedChannelException e) {
+				reopen(e);
+			}
+		}
+		return buffer.position() - startPosition;
+	}
+
+	private void writeBytes(byte[] value, long offset) throws IOException {
+		ByteBuffer buf = ByteBuffer.wrap(value);
+		writeFully(buf, offset);
+	}
+
+	private byte[] readBytes(long offset, int length) throws IOException {
+		ByteBuffer buf = ByteBuffer.allocate(length);
+		int read = readFully(buf, offset);
+		if (read < length) {
+			throw new IOException("Unexpected EOF in DataFile.readBytes: expected " + length + ", read " + read);
+		}
+		return buf.array();
+	}
+
+	private void writeByte(byte value, long offset) throws IOException {
+		ByteBuffer buf = ByteBuffer.allocate(1);
+		buf.put(0, value);
+		buf.position(0);
+		writeFully(buf, offset);
+	}
+
+	private byte readByte(long offset) throws IOException {
+		byte[] bytes = readBytes(offset, 1);
+		return bytes[0];
+	}
+
+	private void closeChannel() throws IOException {
+		FileChannel channel;
+		synchronized (channelLock) {
+			if (explicitlyClosed) {
+				channel = fileChannel;
+				fileChannel = null;
+			} else {
+				explicitlyClosed = true;
+				channel = fileChannel;
+				fileChannel = null;
+			}
+		}
+		if (channel != null) {
+			channel.close();
+		}
+	}
+
+	private void closeQuietly() {
+		try {
+			closeChannel();
+		} catch (IOException e) {
+			// ignore
+		}
+	}
+
 	/**
 	 * Discards all stored data.
 	 *
 	 * @throws IOException If an I/O error occurred.
 	 */
 	synchronized public void clear() throws IOException {
-		nioFile.truncate(HEADER_LENGTH);
-		nioFileSize = HEADER_LENGTH;
+		truncate(HEADER_LENGTH);
+		fileSize = HEADER_LENGTH;
 		buffer.clear();
 	}
 
@@ -397,14 +575,14 @@ public class DataFile implements Closeable {
 		flush();
 
 		if (forceSync) {
-			nioFile.force(false);
+			force(false);
 		}
 	}
 
 	synchronized public void sync(boolean force) throws IOException {
 		flush();
 
-		nioFile.force(force);
+		force(force);
 	}
 
 	/**
@@ -415,8 +593,11 @@ public class DataFile implements Closeable {
 	@Override
 	synchronized public void close() throws IOException {
 		flush();
-		nioFile.force(true);
-		nioFile.close();
+		try {
+			force(true);
+		} finally {
+			closeChannel();
+		}
 	}
 
 	/**
@@ -442,7 +623,7 @@ public class DataFile implements Closeable {
 		private long position = HEADER_LENGTH;
 
 		public boolean hasNext() {
-			return position < nioFileSize;
+			return position < fileSize;
 		}
 
 		public byte[] next() throws IOException {

--- a/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/datastore/HashFile.java
+++ b/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/datastore/HashFile.java
@@ -13,9 +13,9 @@ package org.eclipse.rdf4j.sail.nativerdf.datastore;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
-import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
+import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
 import java.util.BitSet;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -317,20 +317,9 @@ public class HashFile implements Closeable {
 	 * Utility methods *
 	 *-----------------*/
 
-	private RandomAccessFile createEmptyFile(File file) throws IOException {
-		// Make sure the file exists
-		if (!file.exists()) {
-			boolean created = file.createNewFile();
-			if (!created) {
-				throw new IOException("Failed to create file " + file);
-			}
-		}
-
-		// Open the file in read-write mode and make sure the file is empty
-		RandomAccessFile raf = new RandomAccessFile(file, "rw");
-		raf.setLength(0L);
-
-		return raf;
+	private FileChannel createEmptyFile(File file) throws IOException {
+		return FileChannel.open(file.toPath(), StandardOpenOption.CREATE, StandardOpenOption.READ,
+				StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING);
 	}
 
 	/**
@@ -405,8 +394,7 @@ public class HashFile implements Closeable {
 
 		// Move any overflow buckets out of the way to a temporary file
 		File tmpFile = new File(getFile().getParentFile(), "rehash_" + getFile().getName());
-		try (RandomAccessFile tmpRaf = createEmptyFile(tmpFile)) {
-			FileChannel tmpChannel = tmpRaf.getChannel();
+		try (FileChannel tmpChannel = createEmptyFile(tmpFile)) {
 			// Transfer the overflow buckets to the temp file
 			// FIXME: work around java bug 6431344:
 			// "FileChannel.transferTo() doesn't work if address space runs out"

--- a/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/datastore/IDFile.java
+++ b/core/sail/nativerdf/src/main/java/org/eclipse/rdf4j/sail/nativerdf/datastore/IDFile.java
@@ -14,9 +14,15 @@ import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.math.RoundingMode;
+import java.nio.ByteBuffer;
+import java.nio.channels.ClosedByInterruptException;
+import java.nio.channels.ClosedChannelException;
+import java.nio.channels.FileChannel;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
-
-import org.eclipse.rdf4j.common.io.NioFile;
+import java.util.EnumSet;
+import java.util.Set;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
@@ -60,7 +66,14 @@ public class IDFile implements Closeable {
 	 * Variables *
 	 *-----------*/
 
-	private final NioFile nioFile;
+	private static final Set<StandardOpenOption> FILE_OPEN_OPTIONS = EnumSet
+			.of(StandardOpenOption.CREATE, StandardOpenOption.READ, StandardOpenOption.WRITE);
+
+	private final Path path;
+	private final Set<StandardOpenOption> openOptions;
+	private final Object channelLock = new Object();
+	private volatile FileChannel fileChannel;
+	private volatile boolean explicitlyClosed;
 
 	private final boolean forceSync;
 
@@ -78,7 +91,7 @@ public class IDFile implements Closeable {
 	private Long[] gcReducingCache;
 
 	// cached file size
-	private volatile long nioFileSize;
+	private volatile long fileSize;
 
 	/*--------------*
 	 * Constructors *
@@ -86,42 +99,45 @@ public class IDFile implements Closeable {
 
 	public IDFile(File file) throws IOException {
 		this(file, false);
-		nioFileSize = nioFile.size();
 	}
 
 	public IDFile(File file, boolean forceSync) throws IOException {
-		this.nioFile = new NioFile(file);
+		this.path = file.toPath();
+		this.openOptions = EnumSet.copyOf(FILE_OPEN_OPTIONS);
 		this.forceSync = forceSync;
+		this.explicitlyClosed = false;
 
 		try {
-			if (nioFile.size() == 0L) {
-				// Empty file, write header
-				nioFile.writeBytes(MAGIC_NUMBER, 0);
-				nioFile.writeByte(FILE_FORMAT_VERSION, 3);
-				nioFile.writeBytes(new byte[] { 0, 0, 0, 0 }, 4);
+			synchronized (channelLock) {
+				this.fileChannel = FileChannel.open(path, openOptions);
+			}
 
+			long initialSize = size();
+			if (initialSize == 0L) {
+				writeBytes(MAGIC_NUMBER, 0L);
+				writeByte(FILE_FORMAT_VERSION, 3L);
+				writeBytes(new byte[] { 0, 0, 0, 0 }, 4L);
 				sync();
-			} else if (nioFile.size() < HEADER_LENGTH) {
+			} else if (initialSize < HEADER_LENGTH) {
 				throw new IOException("File too small to be a compatible ID file");
 			} else {
-				// Verify file header
-				if (!Arrays.equals(MAGIC_NUMBER, nioFile.readBytes(0, MAGIC_NUMBER.length))) {
+				if (!Arrays.equals(MAGIC_NUMBER, readBytes(0L, MAGIC_NUMBER.length))) {
 					throw new IOException("File doesn't contain compatible ID records");
 				}
 
-				byte version = nioFile.readByte(MAGIC_NUMBER.length);
+				byte version = readByte(MAGIC_NUMBER.length);
 				if (version > FILE_FORMAT_VERSION) {
 					throw new IOException("Unable to read ID file; it uses a newer file format");
 				} else if (version != FILE_FORMAT_VERSION) {
 					throw new IOException("Unable to read ID file; invalid file format version: " + version);
 				}
 			}
+
+			fileSize = size();
 		} catch (IOException e) {
-			this.nioFile.close();
+			closeQuietly();
 			throw e;
 		}
-
-		nioFileSize = nioFile.size();
 
 	}
 
@@ -130,7 +146,7 @@ public class IDFile implements Closeable {
 	 *---------*/
 
 	public final File getFile() {
-		return nioFile.getFile();
+		return path.toFile();
 	}
 
 	/**
@@ -139,17 +155,17 @@ public class IDFile implements Closeable {
 	 * @return The largest ID, or <var>0</var> if the file does not contain any data.
 	 */
 	public int getMaxID() {
-		return (int) (nioFileSize / ITEM_SIZE) - 1;
+		return (int) (fileSize / ITEM_SIZE) - 1;
 	}
 
 	/**
 	 * Stores the offset of a new data entry, returning the ID under which is stored.
 	 */
 	public int storeOffset(long offset) throws IOException {
-		long fileSize = nioFileSize;
-		nioFile.writeLong(offset, fileSize);
-		nioFileSize += ITEM_SIZE;
-		return (int) (fileSize / ITEM_SIZE);
+		long currentSize = fileSize;
+		writeLong(offset, currentSize);
+		fileSize += ITEM_SIZE;
+		return (int) (currentSize / ITEM_SIZE);
 	}
 
 	/**
@@ -161,7 +177,7 @@ public class IDFile implements Closeable {
 	public void setOffset(int id, long offset) throws IOException {
 		assert id > 0 : "id must be larger than 0, is: " + id;
 
-		nioFile.writeLong(offset, ITEM_SIZE * id);
+		writeLong(offset, ITEM_SIZE * id);
 
 		// We need to update the cache after writing to file (not before) so that if anyone refreshes the cache it will
 		// include the write above.
@@ -208,7 +224,7 @@ public class IDFile implements Closeable {
 		if (getMaxID() > cacheLineSize && id < getMaxID() - cacheLineSize) {
 
 			// doing one big read is considerably faster than doing a single read per id
-			byte[] bytes = nioFile.readBytes(ITEM_SIZE * (cacheLookupIndex << cacheLineShift),
+			byte[] bytes = readBytes(ITEM_SIZE * (cacheLookupIndex << cacheLineShift),
 					(int) (ITEM_SIZE * cacheLineSize));
 
 			cacheLine = convertBytesToLongs(bytes);
@@ -227,7 +243,7 @@ public class IDFile implements Closeable {
 		}
 
 		// we did not find a cached value and we did not create a new cache line
-		return nioFile.readLong(ITEM_SIZE * id);
+		return readLong(ITEM_SIZE * id);
 	}
 
 	/**
@@ -240,7 +256,7 @@ public class IDFile implements Closeable {
 	 */
 	public long getOffsetNoCache(int id) throws IOException {
 		assert id > 0 : "id must be larger than 0, is: " + id;
-		return nioFile.readLong(ITEM_SIZE * id);
+		return readLong(ITEM_SIZE * id);
 	}
 
 	/**
@@ -249,8 +265,8 @@ public class IDFile implements Closeable {
 	 * @throws IOException If an I/O error occurred.
 	 */
 	public void clear() throws IOException {
-		nioFile.truncate(HEADER_LENGTH);
-		nioFileSize = nioFile.size();
+		truncate(HEADER_LENGTH);
+		fileSize = HEADER_LENGTH;
 		clearCache();
 	}
 
@@ -259,12 +275,12 @@ public class IDFile implements Closeable {
 	 */
 	public void sync() throws IOException {
 		if (forceSync) {
-			nioFile.force(false);
+			force(false);
 		}
 	}
 
 	public void sync(boolean force) throws IOException {
-		nioFile.force(force);
+		force(force);
 	}
 
 	/**
@@ -274,7 +290,7 @@ public class IDFile implements Closeable {
 	 */
 	@Override
 	public void close() throws IOException {
-		nioFile.close();
+		closeChannel();
 	}
 
 	synchronized private Long[] getCacheLine(int cacheLookupIndex) {
@@ -282,6 +298,188 @@ public class IDFile implements Closeable {
 			return gcReducingCache;
 		} else {
 			return cache.getIfPresent(cacheLookupIndex);
+		}
+	}
+
+	private FileChannel ensureChannel() throws IOException {
+		FileChannel channel = fileChannel;
+		if (channel != null && channel.isOpen()) {
+			return channel;
+		}
+
+		synchronized (channelLock) {
+			if (explicitlyClosed) {
+				throw new ClosedChannelException();
+			}
+			channel = fileChannel;
+			if (channel == null || !channel.isOpen()) {
+				fileChannel = FileChannel.open(path, openOptions);
+				channel = fileChannel;
+			}
+			return channel;
+		}
+	}
+
+	private void reopen(ClosedChannelException e) throws IOException {
+		if (explicitlyClosed) {
+			throw e;
+		}
+
+		synchronized (channelLock) {
+			FileChannel channel = fileChannel;
+			if (channel != null && channel.isOpen()) {
+				return;
+			}
+			fileChannel = FileChannel.open(path, openOptions);
+		}
+	}
+
+	private long size() throws IOException {
+		while (true) {
+			try {
+				return ensureChannel().size();
+			} catch (ClosedByInterruptException e) {
+				throw e;
+			} catch (ClosedChannelException e) {
+				reopen(e);
+			}
+		}
+	}
+
+	private void truncate(long newSize) throws IOException {
+		while (true) {
+			try {
+				ensureChannel().truncate(newSize);
+				return;
+			} catch (ClosedByInterruptException e) {
+				throw e;
+			} catch (ClosedChannelException e) {
+				reopen(e);
+			}
+		}
+	}
+
+	private void force(boolean metaData) throws IOException {
+		while (true) {
+			try {
+				ensureChannel().force(metaData);
+				return;
+			} catch (ClosedByInterruptException e) {
+				throw e;
+			} catch (ClosedChannelException e) {
+				reopen(e);
+			}
+		}
+	}
+
+	private int writeFully(ByteBuffer buffer, long offset) throws IOException {
+		final int startPosition = buffer.position();
+		while (buffer.hasRemaining()) {
+			try {
+				FileChannel channel = ensureChannel();
+				long position = offset + (buffer.position() - startPosition);
+				int written = channel.write(buffer, position);
+				if (written == 0) {
+					continue;
+				}
+			} catch (ClosedByInterruptException e) {
+				throw e;
+			} catch (ClosedChannelException e) {
+				reopen(e);
+			}
+		}
+		return buffer.position() - startPosition;
+	}
+
+	private int readFully(ByteBuffer buffer, long offset) throws IOException {
+		final int startPosition = buffer.position();
+		while (buffer.hasRemaining()) {
+			try {
+				FileChannel channel = ensureChannel();
+				long position = offset + (buffer.position() - startPosition);
+				int read = channel.read(buffer, position);
+				if (read < 0) {
+					if (buffer.position() == startPosition) {
+						return -1;
+					}
+					break;
+				}
+				if (read == 0) {
+					continue;
+				}
+			} catch (ClosedByInterruptException e) {
+				throw e;
+			} catch (ClosedChannelException e) {
+				reopen(e);
+			}
+		}
+		return buffer.position() - startPosition;
+	}
+
+	private void writeLong(long value, long offset) throws IOException {
+		ByteBuffer buf = ByteBuffer.allocate(Long.BYTES);
+		buf.putLong(0, value);
+		buf.position(0);
+		writeFully(buf, offset);
+	}
+
+	private long readLong(long offset) throws IOException {
+		ByteBuffer buf = ByteBuffer.allocate(Long.BYTES);
+		int read = readFully(buf, offset);
+		if (read < Long.BYTES) {
+			throw new IOException("Unexpected EOF in IDFile.readLong: expected " + Long.BYTES + ", read " + read);
+		}
+		return buf.getLong(0);
+	}
+
+	private void writeBytes(byte[] value, long offset) throws IOException {
+		ByteBuffer buf = ByteBuffer.wrap(value);
+		writeFully(buf, offset);
+	}
+
+	private byte[] readBytes(long offset, int length) throws IOException {
+		ByteBuffer buf = ByteBuffer.allocate(length);
+		int read = readFully(buf, offset);
+		if (read < length) {
+			throw new IOException("Unexpected EOF in IDFile.readBytes: expected " + length + ", read " + read);
+		}
+		return buf.array();
+	}
+
+	private void writeByte(byte value, long offset) throws IOException {
+		ByteBuffer buf = ByteBuffer.allocate(1);
+		buf.put(0, value);
+		buf.position(0);
+		writeFully(buf, offset);
+	}
+
+	private byte readByte(long offset) throws IOException {
+		byte[] bytes = readBytes(offset, 1);
+		return bytes[0];
+	}
+
+	private void closeChannel() throws IOException {
+		FileChannel channel;
+		synchronized (channelLock) {
+			if (explicitlyClosed) {
+				channel = fileChannel;
+				fileChannel = null;
+			} else {
+				explicitlyClosed = true;
+				channel = fileChannel;
+				fileChannel = null;
+			}
+		}
+		if (channel != null) {
+			channel.close();
+		}
+	}
+
+	private void closeQuietly() {
+		try {
+			closeChannel();
+		} catch (IOException e) {
+			// ignore
 		}
 	}
 

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/ValueStorePartialWriteCorruptionTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/ValueStorePartialWriteCorruptionTest.java
@@ -141,15 +141,11 @@ public class ValueStorePartialWriteCorruptionTest {
 			dfField.setAccessible(true);
 			Object dataFile = dfField.get(ds);
 
-			Field nioField = dataFile.getClass().getDeclaredField("nioFile");
-			nioField.setAccessible(true);
-			Object nioFile = nioField.get(dataFile);
+			Field channelField = dataFile.getClass().getDeclaredField("fileChannel");
+			channelField.setAccessible(true);
+			FileChannel original = (FileChannel) channelField.get(dataFile);
 
-			Field fcField = nioFile.getClass().getDeclaredField("fc");
-			fcField.setAccessible(true);
-			FileChannel original = (FileChannel) fcField.get(nioFile);
-
-			fcField.set(nioFile, new ChoppyFileChannel(original, partialWriteFrequency));
+			channelField.set(dataFile, new ChoppyFileChannel(original, partialWriteFrequency));
 		} catch (ReflectiveOperationException e) {
 			throw new RuntimeException(e);
 		}

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/datastore/DataAndIdFileFileChannelMigrationTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/datastore/DataAndIdFileFileChannelMigrationTest.java
@@ -1,0 +1,127 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.nativerdf.datastore;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+import org.eclipse.rdf4j.common.io.NioFile;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Guard-rail tests that enforce the ongoing migration from {@link NioFile} to direct {@link FileChannel} usage in the
+ * NativeStore data files.
+ */
+public class DataAndIdFileFileChannelMigrationTest {
+
+	@TempDir
+	File tempDir;
+
+	@Test
+	public void dataFileUsesDirectFileChannel() throws Exception {
+		File path = new File(tempDir, "values.dat");
+
+		try (DataFile dataFile = new DataFile(path)) {
+			assertNoNioFileField(DataFile.class);
+			assertHasOpenFileChannelField(dataFile);
+		}
+	}
+
+	@Test
+	public void dataFileRecoversFromUnexpectedChannelClose() throws Exception {
+		File path = new File(tempDir, "values.dat");
+
+		try (DataFile dataFile = new DataFile(path)) {
+			long firstOffset = dataFile.storeData("alpha".getBytes(StandardCharsets.UTF_8));
+			Field channelField = DataFile.class.getDeclaredField("fileChannel");
+			channelField.setAccessible(true);
+			FileChannel original = (FileChannel) channelField.get(dataFile);
+			original.close();
+
+			long secondOffset = dataFile.storeData("beta".getBytes(StandardCharsets.UTF_8));
+			assertThat(secondOffset).isGreaterThan(firstOffset);
+
+			byte[] recovered = dataFile.tryRecoverBetweenOffsets(firstOffset, secondOffset);
+			assertThat(recovered).isEqualTo("alpha".getBytes(StandardCharsets.UTF_8));
+
+			FileChannel reopened = (FileChannel) channelField.get(dataFile);
+			assertThat(reopened).isNotSameAs(original);
+			assertThat(reopened.isOpen()).isTrue();
+		}
+	}
+
+	@Test
+	public void idFileUsesDirectFileChannel() throws Exception {
+		File path = new File(tempDir, "values.id");
+
+		try (IDFile idFile = new IDFile(path)) {
+			assertNoNioFileField(IDFile.class);
+			assertHasOpenFileChannelField(idFile);
+		}
+	}
+
+	@Test
+	public void idFileRecoversFromUnexpectedChannelClose() throws Exception {
+		File path = new File(tempDir, "values.id");
+
+		try (IDFile idFile = new IDFile(path)) {
+			int id = idFile.storeOffset(42L);
+			Field channelField = IDFile.class.getDeclaredField("fileChannel");
+			channelField.setAccessible(true);
+			FileChannel original = (FileChannel) channelField.get(idFile);
+			original.close();
+
+			idFile.setOffset(id, 84L);
+			assertThat(idFile.getOffset(id)).isEqualTo(84L);
+
+			FileChannel reopened = (FileChannel) channelField.get(idFile);
+			assertThat(reopened).isNotSameAs(original);
+			assertThat(reopened.isOpen()).isTrue();
+		}
+	}
+
+	private static void assertNoNioFileField(Class<?> type) {
+		boolean hasNioFile = Arrays.stream(type.getDeclaredFields())
+				.anyMatch(field -> field.getType().equals(NioFile.class));
+
+		assertThat(hasNioFile)
+				.as("%s should not retain NioFile fields during the FileChannel migration", type.getSimpleName())
+				.isFalse();
+	}
+
+	private static void assertHasOpenFileChannelField(Object instance) throws Exception {
+		Field channelField = Arrays.stream(instance.getClass().getDeclaredFields())
+				.filter(field -> FileChannel.class.isAssignableFrom(field.getType()))
+				.peek(field -> field.setAccessible(true))
+				.findFirst()
+				.orElseThrow(() -> new AssertionError(
+						instance.getClass().getSimpleName() + " should expose a FileChannel-backed field"));
+
+		Object value = channelField.get(instance);
+
+		assertThat(value)
+				.as("%s should expose an initialized FileChannel instance", instance.getClass().getSimpleName())
+				.isInstanceOf(FileChannel.class);
+
+		if (value instanceof FileChannel) {
+			FileChannel fileChannel = (FileChannel) value;
+			assertThat(fileChannel.isOpen())
+					.as("FileChannel field %s should be open", channelField.getName())
+					.isTrue();
+		}
+	}
+}

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/datastore/HashFileFileChannelMigrationTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/datastore/HashFileFileChannelMigrationTest.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.nativerdf.datastore;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.Closeable;
+import java.io.File;
+import java.lang.reflect.Method;
+import java.nio.channels.FileChannel;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Guard-rail test ensuring HashFile#createEmptyFile(File) returns a {@link FileChannel}. This enforces the migration
+ * away from {@link java.io.RandomAccessFile} when preparing overflow bucket files.
+ */
+public class HashFileFileChannelMigrationTest {
+
+	@TempDir
+	File tempDir;
+
+	@Test
+	public void createEmptyFileReturnsFileChannel() throws Exception {
+		File hashPath = new File(tempDir, "values.hash");
+		File tmpFile = new File(tempDir, "overflow.tmp");
+
+		try (HashFile hashFile = new HashFile(hashPath)) {
+			Method method = HashFile.class.getDeclaredMethod("createEmptyFile", File.class);
+			method.setAccessible(true);
+
+			Object resource = null;
+			try {
+				resource = method.invoke(hashFile, tmpFile);
+
+				assertThat(resource)
+						.as("createEmptyFile should expose FileChannel usage instead of RandomAccessFile")
+						.isInstanceOf(FileChannel.class);
+			} finally {
+				if (resource instanceof Closeable) {
+					((Closeable) resource).close();
+				} else if (resource instanceof AutoCloseable) {
+					((AutoCloseable) resource).close();
+				}
+			}
+		}
+	}
+}

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/datastore/IDFileSyncBehaviorTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/datastore/IDFileSyncBehaviorTest.java
@@ -19,7 +19,6 @@ import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
 
-import org.eclipse.rdf4j.common.io.NioFile;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -47,16 +46,12 @@ public class IDFileSyncBehaviorTest {
 	}
 
 	private static TrackingFileChannel injectTrackingChannel(IDFile id) throws Exception {
-		Field nioFileField = IDFile.class.getDeclaredField("nioFile");
-		nioFileField.setAccessible(true);
-		NioFile nio = (NioFile) nioFileField.get(id);
-
-		Field fcField = NioFile.class.getDeclaredField("fc");
-		fcField.setAccessible(true);
-		FileChannel delegate = (FileChannel) fcField.get(nio);
+		Field channelField = IDFile.class.getDeclaredField("fileChannel");
+		channelField.setAccessible(true);
+		FileChannel delegate = (FileChannel) channelField.get(id);
 
 		TrackingFileChannel tracking = new TrackingFileChannel(delegate);
-		fcField.set(nio, tracking);
+		channelField.set(id, tracking);
 		return tracking;
 	}
 


### PR DESCRIPTION
## Summary
- replace HashFile temporary file handling with FileChannel-based creation to eliminate RandomAccessFile usage
- refactor DirectoryLockManager to acquire, release, and validate directory locks using FileChannel APIs
- add guard-rail tests and update the exec plan to document the FileChannel migration

## Testing
- `mvn -pl core/sail/nativerdf -Dtest=HashFileFileChannelMigrationTest test`
- `mvn -pl core/sail/api -Dtest=DirectoryLockManagerFileChannelTest test`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691220b3b464832eb60447cc93a001c1)