### PR TITLE
Add isolation-level select to Workbench upload form

### DIFF
--- a/e2e/tests/workbench.spec.js
+++ b/e2e/tests/workbench.spec.js
@@ -57,7 +57,7 @@ test('Upload form lists isolation levels', async ({page}) => {
         {value: 'NONE', text: 'None'},
         {value: 'READ_UNCOMMITTED', text: 'Read Uncommitted'},
         {value: 'READ_COMMITTED', text: 'Read Committed'},
-        {value: 'SNAPSHOT_READ', text: 'Snapshot read'},
+        {value: 'SNAPSHOT_READ', text: 'Snapshot Read'},
         {value: 'SNAPSHOT', text: 'Snapshot'},
         {value: 'SERIALIZABLE', text: 'Serializable'}
     ];

--- a/e2e/tests/workbench.spec.js
+++ b/e2e/tests/workbench.spec.js
@@ -56,7 +56,7 @@ test('Upload form lists isolation levels', async ({page}) => {
     const expectedLevels = [
         {value: 'NONE', text: 'None'},
         {value: 'READ_UNCOMMITTED', text: 'Read Uncommitted'},
-        {value: 'READ_COMMITTED', text: 'Read committed'},
+        {value: 'READ_COMMITTED', text: 'Read Committed'},
         {value: 'SNAPSHOT_READ', text: 'Snapshot read'},
         {value: 'SNAPSHOT', text: 'Snapshot'},
         {value: 'SERIALIZABLE', text: 'Serializable'}

--- a/e2e/tests/workbench.spec.js
+++ b/e2e/tests/workbench.spec.js
@@ -55,7 +55,7 @@ test('Upload form lists isolation levels', async ({page}) => {
 
     const expectedLevels = [
         {value: 'NONE', text: 'None'},
-        {value: 'READ_UNCOMMITTED', text: 'Read uncommitted'},
+        {value: 'READ_UNCOMMITTED', text: 'Read Uncommitted'},
         {value: 'READ_COMMITTED', text: 'Read committed'},
         {value: 'SNAPSHOT_READ', text: 'Snapshot read'},
         {value: 'SNAPSHOT', text: 'Snapshot'},

--- a/e2e/tests/workbench.spec.js
+++ b/e2e/tests/workbench.spec.js
@@ -33,6 +33,44 @@ async function createRepo(page) {
 
 }
 
+test('Upload form lists isolation levels', async ({page}) => {
+    await page.goto('http://localhost:8080/rdf4j-workbench/');
+
+    await createRepo(page);
+
+    await page.goto('http://localhost:8080/rdf4j-workbench/repositories/testrepo1/add');
+    await expect(page).toHaveTitle('RDF4J Workbench - Add RDF');
+
+    const options = await page.locator('#isolation-level option').evaluateAll(options => options.map(option => ({
+        value: option.value,
+        text: option.textContent.trim(),
+        selected: option.selected
+    })));
+
+    expect(options[0]).toEqual({
+        value: '',
+        text: 'Use repository default',
+        selected: true
+    });
+
+    const expectedLevels = [
+        {value: 'NONE', text: 'None'},
+        {value: 'READ_UNCOMMITTED', text: 'Read uncommitted'},
+        {value: 'READ_COMMITTED', text: 'Read committed'},
+        {value: 'SNAPSHOT_READ', text: 'Snapshot read'},
+        {value: 'SNAPSHOT', text: 'Snapshot'},
+        {value: 'SERIALIZABLE', text: 'Serializable'}
+    ];
+
+    for (const expectedOption of expectedLevels) {
+        const match = options.find(option => option.value === expectedOption.value);
+        if (!match) {
+            throw new Error(`Missing option for isolation level ${expectedOption.value}`);
+        }
+        expect(match.text).toBe(expectedOption.text);
+    }
+});
+
 test('Create repo', async ({page}) => {
     await page.goto('http://localhost:8080/rdf4j-workbench/');
     page.on('dialog', dialog => {

--- a/tools/workbench/src/main/java/org/eclipse/rdf4j/workbench/commands/AddServlet.java
+++ b/tools/workbench/src/main/java/org/eclipse/rdf4j/workbench/commands/AddServlet.java
@@ -15,9 +15,12 @@ import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.List;
+import java.util.Locale;
 
 import javax.servlet.http.HttpServletResponse;
 
+import org.eclipse.rdf4j.common.transaction.IsolationLevel;
+import org.eclipse.rdf4j.common.transaction.IsolationLevels;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.query.QueryResultHandlerException;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
@@ -35,6 +38,7 @@ import org.slf4j.LoggerFactory;
 public class AddServlet extends TransformationServlet {
 
 	private static final String URL = "url";
+	private static final String ISOLATION_LEVEL = "isolation-level";
 
 	private final Logger logger = LoggerFactory.getLogger(AddServlet.class);
 
@@ -42,39 +46,41 @@ public class AddServlet extends TransformationServlet {
 	protected void doPost(WorkbenchRequest req, HttpServletResponse resp, String xslPath)
 			throws IOException, RepositoryException, QueryResultHandlerException {
 		try {
+			IsolationLevel isolationLevel = getIsolationLevel(req);
 			String baseURI = req.getParameter("baseURI");
 			String contentType = req.getParameter("Content-Type");
 			if (req.isParameterPresent(CONTEXT)) {
 				Resource context = req.getResource(CONTEXT);
 				if (req.isParameterPresent(URL)) {
-					add(req.getUrl(URL), baseURI, contentType, context);
+					add(req.getUrl(URL), baseURI, contentType, isolationLevel, context);
 				} else {
-					add(req.getContentParameter(), baseURI, contentType, req.getContentFileName(), context);
+					add(req.getContentParameter(), baseURI, contentType, req.getContentFileName(),
+							isolationLevel, context);
 				}
 			} else {
 				if (req.isParameterPresent(URL)) {
-					add(req.getUrl(URL), baseURI, contentType);
+					add(req.getUrl(URL), baseURI, contentType, isolationLevel);
 				} else {
-					add(req.getContentParameter(), baseURI, contentType, req.getContentFileName());
+					add(req.getContentParameter(), baseURI, contentType, req.getContentFileName(),
+							isolationLevel);
 				}
 			}
 			resp.sendRedirect("summary");
 		} catch (BadRequestException exc) {
 			logger.warn(exc.toString(), exc);
 			TupleResultBuilder builder = getTupleResultBuilder(req, resp, resp.getOutputStream());
-			builder.transform(xslPath, "add.xsl");
-			builder.start("error-message", "baseURI", CONTEXT, "Content-Type");
-			builder.link(List.of(INFO));
 			String baseURI = req.getParameter("baseURI");
 			String context = req.getParameter(CONTEXT);
 			String contentType = req.getParameter("Content-Type");
-			builder.result(exc.getMessage(), baseURI, context, contentType);
-			builder.end();
+			String isolationLevelParam = req.getParameter(ISOLATION_LEVEL);
+			renderForm(builder, xslPath, exc.getMessage(), baseURI, context, contentType,
+					isolationLevelParam, toKnownIsolationLevelName(isolationLevelParam));
 		}
 	}
 
 	private void add(InputStream stream, String baseURI, String contentType, String contentFileName,
-			Resource... context) throws BadRequestException, RepositoryException, IOException {
+			IsolationLevel isolationLevel, Resource... context)
+			throws BadRequestException, RepositoryException, IOException {
 		if (contentType == null) {
 			throw new BadRequestException("No Content-Type provided");
 		}
@@ -90,14 +96,15 @@ public class AddServlet extends TransformationServlet {
 		}
 
 		try (RepositoryConnection con = repository.getConnection()) {
+			setIsolationLevel(con, isolationLevel);
 			con.add(stream, baseURI, format, context);
 		} catch (RDFParseException | IllegalArgumentException exc) {
 			throw new BadRequestException(exc.getMessage(), exc);
 		}
 	}
 
-	private void add(URL url, String baseURI, String contentType, Resource... context)
-			throws BadRequestException, RepositoryException, IOException {
+	private void add(URL url, String baseURI, String contentType, IsolationLevel isolationLevel,
+			Resource... context) throws BadRequestException, RepositoryException, IOException {
 		if (contentType == null) {
 			throw new BadRequestException("No Content-Type provided");
 		}
@@ -114,6 +121,7 @@ public class AddServlet extends TransformationServlet {
 
 		try {
 			try (RepositoryConnection con = repository.getConnection()) {
+				setIsolationLevel(con, isolationLevel);
 				con.add(url, baseURI, format, context);
 			}
 		} catch (RDFParseException | MalformedURLException | IllegalArgumentException exc) {
@@ -121,14 +129,115 @@ public class AddServlet extends TransformationServlet {
 		}
 	}
 
+	private IsolationLevel getIsolationLevel(WorkbenchRequest req) throws BadRequestException {
+		String isolationLevelName = req.getParameter(ISOLATION_LEVEL);
+		if (isolationLevelName == null || isolationLevelName.isBlank()) {
+			return null;
+		}
+
+		try {
+			return IsolationLevels.valueOf(isolationLevelName.toUpperCase(Locale.ENGLISH));
+		} catch (IllegalArgumentException e) {
+			throw new BadRequestException("Unknown isolation level: " + isolationLevelName, e);
+		}
+	}
+
+	private void setIsolationLevel(RepositoryConnection connection, IsolationLevel isolationLevel)
+			throws BadRequestException {
+		if (isolationLevel == null) {
+			return;
+		}
+
+		try {
+			connection.setIsolationLevel(isolationLevel);
+		} catch (IllegalArgumentException e) {
+			throw new BadRequestException(
+					"Unsupported isolation level for this repository: " + isolationLevel, e);
+		}
+	}
+
+	@Override
+	protected void service(WorkbenchRequest req, HttpServletResponse resp, String xslPath)
+			throws Exception {
+		TupleResultBuilder builder = getTupleResultBuilder(req, resp, resp.getOutputStream());
+		String baseURI = req.getParameter("baseURI");
+		String context = req.getParameter(CONTEXT);
+		String contentType = req.getParameter("Content-Type");
+		String isolationLevelParam = req.getParameter(ISOLATION_LEVEL);
+		renderForm(builder, xslPath, null, baseURI, context, contentType, isolationLevelParam,
+				toKnownIsolationLevelName(isolationLevelParam));
+	}
+
 	@Override
 	public void service(TupleResultBuilder builder, String xslPath)
 			throws RepositoryException, QueryResultHandlerException {
-		// TupleResultBuilder builder = getTupleResultBuilder(req, resp);
+		renderForm(builder, xslPath, null, null, null, null, null, null);
+	}
+
+	private void renderForm(TupleResultBuilder builder, String xslPath, String errorMessage, String baseURI,
+			String context, String contentType, String isolationLevelParam, String selectedIsolationLevel)
+			throws RepositoryException, QueryResultHandlerException {
 		builder.transform(xslPath, "add.xsl");
-		builder.start();
+		if (errorMessage != null) {
+			builder.start("error-message", "baseURI", CONTEXT, "Content-Type", ISOLATION_LEVEL);
+		} else {
+			builder.start("baseURI", CONTEXT, "Content-Type", ISOLATION_LEVEL);
+		}
 		builder.link(List.of(INFO));
+		if (errorMessage != null) {
+			builder.result(errorMessage, baseURI, context, contentType, isolationLevelParam);
+		} else if (baseURI != null || context != null || contentType != null || isolationLevelParam != null) {
+			builder.result(baseURI, context, contentType, isolationLevelParam);
+		}
+		addIsolationLevelBindings(builder, selectedIsolationLevel);
 		builder.end();
+	}
+
+	private void addIsolationLevelBindings(TupleResultBuilder builder, String selectedIsolationLevel)
+			throws QueryResultHandlerException {
+		for (IsolationLevels level : IsolationLevels.values()) {
+			builder.namedResult("available-isolation-level",
+					level.name() + " " + isolationLevelLabel(level));
+		}
+		if (selectedIsolationLevel != null) {
+			builder.namedResult("selected-isolation-level", selectedIsolationLevel);
+		}
+	}
+
+	private String toKnownIsolationLevelName(String isolationLevelParam) {
+		if (isolationLevelParam == null) {
+			return null;
+		}
+		String trimmed = isolationLevelParam.trim();
+		if (trimmed.isEmpty()) {
+			return null;
+		}
+		String normalized = trimmed.toUpperCase(Locale.ENGLISH);
+		try {
+			IsolationLevels.valueOf(normalized);
+			return normalized;
+		} catch (IllegalArgumentException e) {
+			return null;
+		}
+	}
+
+	private String isolationLevelLabel(IsolationLevels level) {
+		String name = level.name().toLowerCase(Locale.ENGLISH);
+		StringBuilder label = new StringBuilder(name.length());
+		boolean capitalizeNext = true;
+		for (int i = 0; i < name.length(); i++) {
+			char ch = name.charAt(i);
+			if (ch == '_') {
+				label.append(' ');
+				capitalizeNext = true;
+			} else if (capitalizeNext) {
+				label.append(Character.toTitleCase(ch));
+				capitalizeNext = false;
+			} else {
+				label.append(ch);
+			}
+		}
+		return label.toString();
 	}
 
 }

--- a/tools/workbench/src/main/webapp/locale/messages.xsl
+++ b/tools/workbench/src/main/webapp/locale/messages.xsl
@@ -141,15 +141,17 @@
 		Enter the RDF data you wish to upload
 	</variable>
 	<variable name="upload-text.label">RDF Content</variable>
-	<variable name="upload-url.desc">
-		Location of the RDF data you wish to upload
-	</variable>
-	<variable name="upload-url.label">RDF Data URL</variable>
-	<variable name="value-encoding.desc">
-		Please specify subject, predicate, object and/or context of the
-		statements that should be removed. Empty fields match with any
-		subject, predicate, object or context. URIs, bNodes and literals should
-		be entered using the N-Triples encoding. Example values in
+        <variable name="upload-url.desc">
+                Location of the RDF data you wish to upload
+        </variable>
+        <variable name="upload-url.label">RDF Data URL</variable>
+        <variable name="isolation-level.label">Isolation level</variable>
+        <variable name="isolation-level.default-option">Use repository default</variable>
+        <variable name="value-encoding.desc">
+                Please specify subject, predicate, object and/or context of the
+                statements that should be removed. Empty fields match with any
+                subject, predicate, object or context. URIs, bNodes and literals should
+                be entered using the N-Triples encoding. Example values in
 		N-Triples encoding are:
 	</variable>
 	<variable name="result-limit.label">Results per page</variable>

--- a/tools/workbench/src/main/webapp/transformations/add.xsl
+++ b/tools/workbench/src/main/webapp/transformations/add.xsl
@@ -53,10 +53,10 @@
 						<td></td>
 
 					</tr>
-					<tr>
-						<th>
-							<xsl:value-of select="$data-format.label" />
-						</th>
+                                        <tr>
+                                                <th>
+                                                        <xsl:value-of select="$data-format.label" />
+                                                </th>
 						<td>
 							<select id="Content-Type" name="Content-Type"
 								onchange="workbench.add.handleFormatSelection(this.value)">
@@ -68,15 +68,45 @@
 										<xsl:value-of select="substring-after(sparql:literal, ' ')" />
 									</option>
 								</xsl:for-each>
-							</select>
-						</td>
-						<td></td>
-					</tr>
+                                                        </select>
+                                                </td>
+                                                <td></td>
+                                        </tr>
 
-					<tr>
-						<td></td>
-						<td>
-							<input type="radio" id="source-url" name="source" value="url"
+                                        <tr>
+                                                <th>
+                                                        <xsl:value-of select="$isolation-level.label" />
+                                                </th>
+                                                <td>
+                                                        <select id="isolation-level" name="isolation-level">
+                                                                <option value="">
+                                                                        <xsl:if
+                                                                                test="not(string(//sparql:binding[@name='selected-isolation-level']/sparql:literal))">
+                                                                                <xsl:attribute name="selected">selected</xsl:attribute>
+                                                                        </xsl:if>
+                                                                        <xsl:value-of select="$isolation-level.default-option" />
+                                                                </option>
+                                                                <xsl:for-each
+                                                                        select="//sparql:binding[@name='available-isolation-level']">
+                                                                        <xsl:variable name="levelValue"
+                                                                                select="substring-before(sparql:literal, ' ')" />
+                                                                        <option value="{$levelValue}">
+                                                                                <xsl:if
+                                                                                        test="$levelValue = //sparql:binding[@name='selected-isolation-level']/sparql:literal">
+                                                                                        <xsl:attribute name="selected">selected</xsl:attribute>
+                                                                                </xsl:if>
+                                                                                <xsl:value-of select="substring-after(sparql:literal, ' ')" />
+                                                                        </option>
+                                                                </xsl:for-each>
+                                                        </select>
+                                                </td>
+                                                <td></td>
+                                        </tr>
+
+                                        <tr>
+                                                <td></td>
+                                                <td>
+                                                        <input type="radio" id="source-url" name="source" value="url"
 								onchange="workbench.add.enabledInput('url')" />
 							<xsl:value-of select="$upload-url.desc" />
 						</td>

--- a/tools/workbench/src/test/java/org/eclipse/rdf4j/workbench/commands/AddServletTest.java
+++ b/tools/workbench/src/test/java/org/eclipse/rdf4j/workbench/commands/AddServletTest.java
@@ -1,0 +1,106 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Contributors and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.workbench.commands;
+
+import static org.eclipse.rdf4j.workbench.base.TransformationServlet.CONTEXT;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.servlet.http.HttpServletResponse;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.eclipse.rdf4j.common.transaction.IsolationLevels;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.query.QueryResultHandlerException;
+import org.eclipse.rdf4j.query.resultio.sparqlxml.SPARQLResultsXMLWriter;
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.eclipse.rdf4j.repository.RepositoryException;
+import org.eclipse.rdf4j.workbench.exceptions.BadRequestException;
+import org.eclipse.rdf4j.workbench.util.TupleResultBuilder;
+import org.eclipse.rdf4j.workbench.util.WorkbenchRequest;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+class AddServletTest {
+
+	private static final String URL = "url";
+
+	private final AddServlet servlet = new AddServlet();
+
+	@Test
+	void setsIsolationLevelForUploadedContent() throws RepositoryException, QueryResultHandlerException, IOException,
+			BadRequestException {
+		WorkbenchRequest request = mock(WorkbenchRequest.class);
+		when(request.getParameter("baseURI")).thenReturn(null);
+		when(request.getParameter("Content-Type")).thenReturn("application/rdf+xml");
+		when(request.isParameterPresent(URL)).thenReturn(false);
+		when(request.isParameterPresent(CONTEXT)).thenReturn(false);
+		when(request.getContentParameter()).thenReturn(new ByteArrayInputStream("".getBytes(StandardCharsets.UTF_8)));
+		when(request.getContentFileName()).thenReturn("data.rdf");
+		when(request.getParameter("isolation-level")).thenReturn("NONE");
+
+		HttpServletResponse response = mock(HttpServletResponse.class);
+
+		Repository repository = mock(Repository.class);
+		servlet.setRepository(repository);
+		RepositoryConnection connection = mock(RepositoryConnection.class);
+		when(repository.getConnection()).thenReturn(connection);
+
+		servlet.doPost(request, response, "");
+
+		verify(connection).setIsolationLevel(IsolationLevels.NONE);
+	}
+
+	@Test
+	void serviceListsAllIsolationLevels() throws Exception {
+		ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+		TupleResultBuilder builder = new TupleResultBuilder(new SPARQLResultsXMLWriter(buffer),
+				SimpleValueFactory.getInstance());
+
+		servlet.service(builder, "/transformations");
+
+		DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+		factory.setNamespaceAware(true);
+		Document document = factory.newDocumentBuilder().parse(new ByteArrayInputStream(buffer.toByteArray()));
+		NodeList bindingNodes = document.getElementsByTagNameNS("http://www.w3.org/2005/sparql-results#", "binding");
+		Set<String> isolationLevels = new HashSet<>();
+		for (int i = 0; i < bindingNodes.getLength(); i++) {
+			Element binding = (Element) bindingNodes.item(i);
+			if (!"available-isolation-level".equals(binding.getAttribute("name"))) {
+				continue;
+			}
+			NodeList literalNodes = binding.getElementsByTagNameNS("http://www.w3.org/2005/sparql-results#", "literal");
+			for (int j = 0; j < literalNodes.getLength(); j++) {
+				String value = literalNodes.item(j).getTextContent().trim();
+				int separator = value.indexOf(' ');
+				if (separator >= 0) {
+					value = value.substring(0, separator);
+				}
+				isolationLevels.add(value);
+			}
+		}
+
+		String[] expected = Arrays.stream(IsolationLevels.values()).map(Enum::name).toArray(String[]::new);
+		org.assertj.core.api.Assertions.assertThat(isolationLevels).containsExactlyInAnyOrder(expected);
+	}
+}


### PR DESCRIPTION
## Summary
- populate the Workbench add form with the available isolation levels and remember the user selection when the form is redisplayed
- expose localized strings and a new select control so uploads can specify an isolation level from the UI
- extend `AddServletTest` to assert that the servlet lists every supported isolation level

## Testing
- mvn -pl tools/workbench test -Dtest=AddServletTest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916ff64ec30832ebc64b9f4f251916f)