### PR TITLE
Streamline Maven-based e2e workflow

### DIFF
--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -150,6 +150,28 @@ jobs:
         working-directory: ./e2e
         run: ./run.sh
 
+  e2e-local:
+    needs: formatting-and-quick-compile
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: 11
+          distribution: 'temurin'
+          cache: maven
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Build Workbench artifacts for the Maven dev server
+        run: mvn -pl tools/workbench -am -T 2C -Pquick -DskipTests -DskipITs -DskipSlowTests -Dmaven.javadoc.skip -Djapicmp.skip -Denforcer.skip -Danimal.sniffer.skip install
+      - name: Run end-to-end tests via the Maven-hosted dev server
+        env:
+          SKIP_BUILD: "1"
+        run: ./e2e/run-local.sh
+
   copyright-check:
     runs-on: ubuntu-latest
     steps:

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -7,13 +7,43 @@ The tests are written using Microsoft Playwright and interact with the server an
 ## Running the tests
 
 Requirements:
- - docker
+ - docker (only needed when using the legacy docker-based workflow)
  - java
  - maven
  - npm
  - npx
 
-The tests can be run using the `run.sh` script. This script will build the project, start the server and workbench and run the tests.
+The tests can be run using the `run.sh` script. This script will build the project, start the server and workbench using docker and run the tests.
+
+### Running without docker
+
+When developing locally it can be convenient to run the RDF4J server and workbench directly from Maven without relying on docker.
+
+```
+# build and install the server/workbench artifacts once
+mvn -pl tools/workbench -am -Pquick -DskipTests -DskipITs install
+
+# start the server/workbench on http://localhost:8080
+mvn -pl tools/workbench jetty:run -Prdf4j-dev-server
+
+# stop the embedded Jetty instance
+mvn -pl tools/workbench jetty:stop -Prdf4j-dev-server
+```
+
+Set `RDF4J_HTTP_PORT` if you need a different port and Jetty will be configured accordingly.
+
+The `run-local.sh` script automates those steps, wires the correct base URL into the Playwright tests, and runs them against the embedded Jetty server:
+
+```
+./run-local.sh
+# or for a custom port
+RDF4J_HTTP_PORT=8091 ./run-local.sh
+```
+
+`run-local.sh` reuses the same quick-build defaults as CI (`-Pquick -DskipTests -DskipITs -DskipSlowTests`) so it finishes in
+minutes instead of hours. If you already ran the install step yourself, export `SKIP_BUILD=1` to skip the redundant build. The
+exact Maven arguments can be overridden (for example to remove the quick profile) by setting `RDF4J_DEV_BUILD_OPTS` before
+invoking the script.
 
 To run the tests interactively use `npx playwright test --ui`
 

--- a/e2e/run-local.sh
+++ b/e2e/run-local.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+MAVEN_BIN="${MAVEN_BIN:-mvn}"
+STOP_PORT="${RDF4J_JETTY_STOP_PORT:-8079}"
+STOP_KEY="${RDF4J_JETTY_STOP_KEY:-rdf4j-dev-stop}"
+HTTP_PORT="${RDF4J_HTTP_PORT:-8080}"
+JETTY_LOG=""
+JETTY_MAVEN_PID=""
+
+cleanup() {
+  echo "Stopping local RDF4J dev server"
+  if [ -n "$JETTY_MAVEN_PID" ]; then
+    if kill -0 "$JETTY_MAVEN_PID" >/dev/null 2>&1; then
+      $MAVEN_BIN -pl tools/workbench jetty:stop -Prdf4j-dev-server \
+        -Drdf4j.dev.stop.port="$STOP_PORT" \
+        -Drdf4j.dev.stop.key="$STOP_KEY" \
+        >/dev/null 2>&1 || true
+      kill "$JETTY_MAVEN_PID" >/dev/null 2>&1 || true
+      wait "$JETTY_MAVEN_PID" >/dev/null 2>&1 || true
+    fi
+  fi
+  if [ -n "$JETTY_LOG" ] && [ -f "$JETTY_LOG" ]; then
+    rm -f "$JETTY_LOG"
+  fi
+}
+trap cleanup EXIT
+
+cd "$ROOT_DIR"
+
+DEFAULT_BUILD_OPTS=(
+  -pl tools/workbench
+  -am
+  -Pquick
+  -DskipTests
+  -DskipITs
+  -DskipSlowTests
+  -Dmaven.javadoc.skip
+  -Djapicmp.skip
+  -Denforcer.skip
+  -Danimal.sniffer.skip
+)
+if [ -n "${RDF4J_DEV_BUILD_OPTS:-}" ]; then
+  # shellcheck disable=SC2206
+  BUILD_OPTS=( ${RDF4J_DEV_BUILD_OPTS} )
+else
+  BUILD_OPTS=( "${DEFAULT_BUILD_OPTS[@]}" )
+fi
+
+if [ -z "${SKIP_BUILD:-}" ]; then
+  echo "Building RDF4J Workbench via Maven (${BUILD_OPTS[*]} install)"
+  $MAVEN_BIN "${BUILD_OPTS[@]}" install
+fi
+
+JETTY_LOG="$(mktemp -t rdf4j-jetty.XXXX.log)"
+$MAVEN_BIN -pl tools/workbench jetty:run -Prdf4j-dev-server \
+  -Drdf4j.dev.stop.port="$STOP_PORT" \
+  -Drdf4j.dev.stop.key="$STOP_KEY" \
+  -Drdf4j.dev.http.port="$HTTP_PORT" \
+  -Djetty.port="$HTTP_PORT" \
+  -Djetty.http.port="$HTTP_PORT" \
+  >"$JETTY_LOG" 2>&1 &
+JETTY_MAVEN_PID=$!
+echo "Jetty logs: $JETTY_LOG"
+
+printf '%s' "Waiting for local server to be ready"
+ready=false
+for _ in $(seq 1 90); do
+  if curl --silent --fail "http://localhost:${HTTP_PORT}/rdf4j-workbench/" >/dev/null; then
+    echo " - ready"
+    ready=true
+    break
+  fi
+  printf '%s' '.'
+  sleep 1
+done
+
+if [ "$ready" != true ]; then
+  echo ""
+  echo "Failed to detect a running server on port ${HTTP_PORT}" >&2
+  if [ -f "$JETTY_LOG" ]; then
+    echo "---- Jetty output ----" >&2
+    tail -n 200 "$JETTY_LOG" >&2 || true
+    echo "---------------------" >&2
+  fi
+  exit 1
+fi
+
+cd "$ROOT_DIR/e2e"
+
+npm ci
+npx playwright install --with-deps
+export RDF4J_BASE_URL="http://localhost:${HTTP_PORT}/"
+npx playwright test "$@"

--- a/e2e/tests/server.spec.js
+++ b/e2e/tests/server.spec.js
@@ -1,9 +1,11 @@
 // @ts-check
 const {test, expect} = require('@playwright/test');
 
+const baseUrl = process.env.RDF4J_BASE_URL || 'http://localhost:8080/';
+const serverUrl = new URL('rdf4j-server/', baseUrl).toString();
 
 test('RDF4J Server has correct title', async ({page}) => {
-    await page.goto('http://localhost:8080/rdf4j-server/');
+    await page.goto(serverUrl);
 
     // Expect a title "to contain" a substring.
     await expect(page).toHaveTitle("RDF4J Server - Home");

--- a/e2e/tests/workbench.spec.js
+++ b/e2e/tests/workbench.spec.js
@@ -1,8 +1,11 @@
 // @ts-check
 const {test, expect} = require('@playwright/test');
 
+const baseUrl = process.env.RDF4J_BASE_URL || 'http://localhost:8080/';
+const workbenchUrl = new URL('rdf4j-workbench/', baseUrl).toString();
+
 test.beforeEach(async ({page}, testInfo) => {
-    await page.goto('http://localhost:8080/rdf4j-workbench/');
+    await page.goto(workbenchUrl);
     await page.getByText("Delete repository").click();
     await page.waitForSelector('#id');
     const optionExists = await page.locator('#id option[value="testrepo1"]').count() > 0;
@@ -15,7 +18,7 @@ test.beforeEach(async ({page}, testInfo) => {
 });
 
 test('RDF4J Workbench has correct title', async ({page}) => {
-    await page.goto('http://localhost:8080/rdf4j-workbench/');
+    await page.goto(workbenchUrl);
 
     // Expect a title "to contain" a substring.
     await expect(page).toHaveTitle("RDF4J Workbench - List of Repositories");
@@ -34,7 +37,7 @@ async function createRepo(page) {
 }
 
 test('Create repo', async ({page}) => {
-    await page.goto('http://localhost:8080/rdf4j-workbench/');
+    await page.goto(workbenchUrl);
     page.on('dialog', dialog => {
         console.log(dialog.message());
         dialog.dismiss();
@@ -53,7 +56,7 @@ test('Create repo', async ({page}) => {
 
 
 test('SPARQL update', async ({page}) => {
-    await page.goto('http://localhost:8080/rdf4j-workbench/');
+    await page.goto(workbenchUrl);
     page.on('dialog', dialog => {
         console.log(dialog.message());
         dialog.dismiss();

--- a/tools/workbench/pom.xml
+++ b/tools/workbench/pom.xml
@@ -10,6 +10,13 @@
 	<packaging>war</packaging>
 	<name>RDF4J: Workbench</name>
 	<description>Workbench to interact with RDF4J servers.</description>
+	<properties>
+		<rdf4j.dev.http.port>8080</rdf4j.dev.http.port>
+		<rdf4j.dev.stop.port>8079</rdf4j.dev.stop.port>
+		<rdf4j.dev.stop.key>rdf4j-dev-stop</rdf4j.dev.stop.key>
+		<rdf4j.dev.jetty.daemon>false</rdf4j.dev.jetty.daemon>
+		<rdf4j.dev.appdata>${project.build.directory}/rdf4j-dev-appdata</rdf4j.dev.appdata>
+	</properties>
 	<dependencies>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
@@ -79,6 +86,26 @@
 							<contextPath>/rdf4j-server</contextPath>
 						</contextHandler>
 					</contextHandlers>
+					<stopPort>${rdf4j.dev.stop.port}</stopPort>
+					<stopKey>${rdf4j.dev.stop.key}</stopKey>
+					<httpConnector>
+						<port>${rdf4j.dev.http.port}</port>
+					</httpConnector>
+					<systemProperties>
+						<systemProperty>
+							<name>org.eclipse.rdf4j.appdata.basedir</name>
+							<value>${rdf4j.dev.appdata}</value>
+						</systemProperty>
+						<systemProperty>
+							<name>jetty.http.port</name>
+							<value>${rdf4j.dev.http.port}</value>
+						</systemProperty>
+						<systemProperty>
+							<name>jetty.port</name>
+							<value>${rdf4j.dev.http.port}</value>
+						</systemProperty>
+					</systemProperties>
+					<daemon>${rdf4j.dev.jetty.daemon}</daemon>
 				</configuration>
 			</plugin>
 			<plugin>
@@ -90,4 +117,15 @@
 			</plugin>
 		</plugins>
 	</build>
+	<profiles>
+		<profile>
+			<id>rdf4j-dev-server</id>
+			<activation>
+				<activeByDefault>false</activeByDefault>
+			</activation>
+			<properties>
+				<rdf4j.dev.jetty.daemon>true</rdf4j.dev.jetty.daemon>
+			</properties>
+		</profile>
+	</profiles>
 </project>


### PR DESCRIPTION
## Summary
- trim the `run-local.sh` build phase to reuse the quick profile, allow overriding the Maven arguments, and document the `SKIP_BUILD`/`RDF4J_DEV_BUILD_OPTS` knobs in the e2e README
- pre-build the Workbench artifacts inside the `e2e-local` workflow job and invoke the helper with `SKIP_BUILD=1` so CI no longer has to recompile the entire reactor before every Maven-hosted Playwright run

## Testing
- ✅ `mvn -pl tools/workbench -am -T 1C -Pquick -DskipTests -DskipITs -DskipSlowTests -Dmaven.javadoc.skip -Djapicmp.skip -Denforcer.skip -Danimal.sniffer.skip install`
- ⚠️ `SKIP_BUILD=1 ./e2e/run-local.sh` *(fails because the Playwright CDN returns HTTP 403 in this proxy-restricted environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919a676a128832e9245370c77c98392)