### PR TITLE
GH-0000 Add Cassandra adjacency Sail scaffolding

### DIFF
--- a/core/sail/cassandra-adj/pom.xml
+++ b/core/sail/cassandra-adj/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.eclipse.rdf4j</groupId>
+		<artifactId>rdf4j-sail</artifactId>
+		<version>5.2.1-SNAPSHOT</version>
+	</parent>
+	<artifactId>rdf4j-sail-cassandra-adj</artifactId>
+	<name>RDF4J: Cassandra adjacency Sail</name>
+	<description>Sail implementation that stores RDF data in Cassandra using adjacency lists.</description>
+	<properties>
+		<cassandra.driver.version>4.17.0</cassandra.driver.version>
+	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>rdf4j-sail-base</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>rdf4j-sail-api</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>rdf4j-model</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.datastax.oss</groupId>
+			<artifactId>java-driver-core</artifactId>
+			<version>${cassandra.driver.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>rdf4j-query</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>rdf4j-repository-sail</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+</project>

--- a/core/sail/cassandra-adj/pom.xml
+++ b/core/sail/cassandra-adj/pom.xml
@@ -11,6 +11,7 @@
 	<description>Sail implementation that stores RDF data in Cassandra using adjacency lists.</description>
 	<properties>
 		<cassandra.driver.version>4.17.0</cassandra.driver.version>
+		<testcontainers.version>1.20.3</testcontainers.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -46,6 +47,24 @@
 			<groupId>${project.groupId}</groupId>
 			<artifactId>rdf4j-repository-sail</artifactId>
 			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>testcontainers</artifactId>
+			<version>${testcontainers.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>cassandra</artifactId>
+			<version>${testcontainers.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<version>${testcontainers.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/core/sail/cassandra-adj/src/main/java/org/eclipse/rdf4j/sail/cassandra/adjacency/CassandraAdjacencySail.java
+++ b/core/sail/cassandra-adj/src/main/java/org/eclipse/rdf4j/sail/cassandra/adjacency/CassandraAdjacencySail.java
@@ -1,0 +1,48 @@
+package org.eclipse.rdf4j.sail.cassandra.adjacency;
+
+import java.util.Objects;
+
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.sail.NotifyingSailConnection;
+import org.eclipse.rdf4j.sail.SailException;
+import org.eclipse.rdf4j.sail.helpers.AbstractNotifyingSail;
+
+/**
+ * Minimal NotifyingSail implementation that delegates storage to a CassandraGraphStore.
+ */
+public class CassandraAdjacencySail extends AbstractNotifyingSail {
+
+	private final CassandraGraphStore graphStore;
+	private final NamespaceManager namespaceManager;
+	private final ValueFactory valueFactory = SimpleValueFactory.getInstance();
+
+	public CassandraAdjacencySail(CassandraGraphStore graphStore, NamespaceManager namespaceManager) {
+		this.graphStore = Objects.requireNonNull(graphStore, "graphStore");
+		this.namespaceManager = Objects.requireNonNull(namespaceManager, "namespaceManager");
+	}
+
+	public void initialize() throws SailException {
+		init();
+	}
+
+	@Override
+	protected NotifyingSailConnection getConnectionInternal() throws SailException {
+		return new CassandraAdjacencySailConnection(this, graphStore, namespaceManager);
+	}
+
+	@Override
+	protected void shutDownInternal() throws SailException {
+		// nothing to do for the in-memory scaffolding
+	}
+
+	@Override
+	public ValueFactory getValueFactory() {
+		return valueFactory;
+	}
+
+	@Override
+	public boolean isWritable() throws SailException {
+		return true;
+	}
+}

--- a/core/sail/cassandra-adj/src/main/java/org/eclipse/rdf4j/sail/cassandra/adjacency/CassandraAdjacencySailConnection.java
+++ b/core/sail/cassandra-adj/src/main/java/org/eclipse/rdf4j/sail/cassandra/adjacency/CassandraAdjacencySailConnection.java
@@ -1,0 +1,239 @@
+package org.eclipse.rdf4j.sail.cassandra.adjacency;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+import org.eclipse.rdf4j.common.iteration.CloseableIteration;
+import org.eclipse.rdf4j.common.iteration.CloseableIteratorIteration;
+import org.eclipse.rdf4j.common.iteration.EmptyIteration;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Namespace;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.impl.SimpleNamespace;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.Dataset;
+import org.eclipse.rdf4j.query.algebra.TupleExpr;
+import org.eclipse.rdf4j.sail.SailException;
+import org.eclipse.rdf4j.sail.helpers.AbstractNotifyingSailConnection;
+
+/**
+ * Connection implementation that buffers mutations and delegates to a CassandraGraphStore.
+ */
+public class CassandraAdjacencySailConnection extends AbstractNotifyingSailConnection {
+
+	private final CassandraGraphStore graphStore;
+	private final NamespaceManager namespaceManager;
+	private final Map<String, String> namespaces = new ConcurrentHashMap<>();
+	private final List<Statement> pendingAdd = new ArrayList<>();
+	private final List<Statement> pendingRemove = new ArrayList<>();
+
+	public CassandraAdjacencySailConnection(CassandraAdjacencySail sail, CassandraGraphStore graphStore,
+			NamespaceManager namespaceManager) {
+		super(sail);
+		this.graphStore = Objects.requireNonNull(graphStore, "graphStore");
+		this.namespaceManager = Objects.requireNonNull(namespaceManager, "namespaceManager");
+	}
+
+	@Override
+	protected void startTransactionInternal() throws SailException {
+		pendingAdd.clear();
+		pendingRemove.clear();
+	}
+
+	@Override
+	protected void commitInternal() throws SailException {
+		graphStore.applyMutations(new ArrayList<>(pendingAdd), new ArrayList<>(pendingRemove));
+
+		if (hasConnectionListeners()) {
+			pendingAdd.forEach(st -> notifyStatementAdded(st, false));
+			pendingRemove.forEach(st -> notifyStatementRemoved(st, false));
+		}
+
+		pendingAdd.clear();
+		pendingRemove.clear();
+	}
+
+	@Override
+	protected void rollbackInternal() throws SailException {
+		pendingAdd.clear();
+		pendingRemove.clear();
+	}
+
+	@Override
+	protected void closeInternal() throws SailException {
+		pendingAdd.clear();
+		pendingRemove.clear();
+	}
+
+	@Override
+	protected CloseableIteration<? extends BindingSet> evaluateInternal(TupleExpr tupleExpr, Dataset dataset,
+			BindingSet bindings, boolean includeInferred) throws SailException {
+		return new EmptyIteration<>();
+	}
+
+	@Override
+	protected CloseableIteration<? extends Resource> getContextIDsInternal() throws SailException {
+		Set<Resource> contexts = new HashSet<>();
+		try (CloseableIteration<? extends Statement> iter = graphStore.queryStatements(null, null, null,
+				new Resource[0],
+				false)) {
+			while (iter.hasNext()) {
+				Statement st = iter.next();
+				if (st.getContext() != null) {
+					contexts.add(st.getContext());
+				}
+			}
+		}
+		return new CloseableIteratorIteration<>(contexts.iterator());
+	}
+
+	@Override
+	protected CloseableIteration<? extends Statement> getStatementsInternal(Resource subj, IRI pred, Value obj,
+			boolean includeInferred, Resource... contexts) throws SailException {
+		Set<Statement> results = new HashSet<>();
+
+		try (CloseableIteration<? extends Statement> iter = graphStore.queryStatements(subj, pred, obj, contexts,
+				includeInferred)) {
+			while (iter.hasNext()) {
+				results.add(iter.next());
+			}
+		}
+
+		for (Statement st : pendingAdd) {
+			if (matchesFilters(st, subj, pred, obj, contexts)) {
+				results.add(st);
+			}
+		}
+
+		for (Statement st : pendingRemove) {
+			if (matchesFilters(st, subj, pred, obj, contexts)) {
+				results.remove(st);
+			}
+		}
+
+		return new CloseableIteratorIteration<>(results.iterator());
+	}
+
+	@Override
+	protected long sizeInternal(Resource... contexts) throws SailException {
+		long count = 0;
+		try (CloseableIteration<? extends Statement> iter = getStatementsInternal(null, null, null, false, contexts)) {
+			while (iter.hasNext()) {
+				iter.next();
+				count++;
+			}
+		}
+		return count;
+	}
+
+	@Override
+	protected void addStatementInternal(Resource subj, IRI pred, Value obj, Resource... contexts) throws SailException {
+		List<Statement> statementsToAdd = createStatements(subj, pred, obj, contexts);
+		pendingAdd.addAll(statementsToAdd);
+		pendingRemove.removeAll(statementsToAdd);
+	}
+
+	@Override
+	protected void removeStatementsInternal(Resource subj, IRI pred, Value obj, Resource... contexts)
+			throws SailException {
+		Set<Statement> statements = new HashSet<>();
+
+		try (CloseableIteration<? extends Statement> iter = graphStore.queryStatements(subj, pred, obj, contexts,
+				false)) {
+			while (iter.hasNext()) {
+				statements.add(iter.next());
+			}
+		}
+
+		statements.addAll(pendingAdd.stream()
+				.filter(st -> matchesFilters(st, subj, pred, obj, contexts))
+				.collect(Collectors.toSet()));
+
+		pendingAdd.removeIf(statements::contains);
+		pendingRemove.addAll(statements);
+	}
+
+	@Override
+	protected void clearInternal(Resource... contexts) throws SailException {
+		removeStatementsInternal(null, null, null, contexts);
+	}
+
+	@Override
+	protected CloseableIteration<? extends Namespace> getNamespacesInternal() {
+		List<Namespace> list = namespaces.entrySet()
+				.stream()
+				.map(e -> new SimpleNamespace(e.getKey(), e.getValue()))
+				.collect(Collectors.toList());
+		return new CloseableIteratorIteration<>(list.iterator());
+	}
+
+	@Override
+	protected String getNamespaceInternal(String prefix) throws SailException {
+		return namespaces.get(prefix);
+	}
+
+	@Override
+	protected void setNamespaceInternal(String prefix, String name) throws SailException {
+		namespaces.put(prefix, name);
+	}
+
+	@Override
+	protected void removeNamespaceInternal(String prefix) throws SailException {
+		namespaces.remove(prefix);
+	}
+
+	@Override
+	protected void clearNamespacesInternal() throws SailException {
+		namespaces.clear();
+	}
+
+	private List<Statement> createStatements(Resource subj, IRI pred, Value obj, Resource... contexts) {
+		List<Statement> statements = new ArrayList<>();
+		if (contexts == null || contexts.length == 0) {
+			statements.add(SimpleValueFactory.getInstance().createStatement(subj, pred, obj));
+		} else {
+			for (Resource ctx : contexts) {
+				if (ctx == null) {
+					statements.add(SimpleValueFactory.getInstance().createStatement(subj, pred, obj));
+				} else {
+					statements.add(SimpleValueFactory.getInstance().createStatement(subj, pred, obj, ctx));
+				}
+			}
+		}
+		return statements;
+	}
+
+	private boolean matchesFilters(Statement st, Resource subj, IRI pred, Value obj, Resource[] contexts) {
+		if (subj != null && !subj.equals(st.getSubject())) {
+			return false;
+		}
+		if (pred != null && !pred.equals(st.getPredicate())) {
+			return false;
+		}
+		if (obj != null && !obj.equals(st.getObject())) {
+			return false;
+		}
+		if (contexts == null || contexts.length == 0) {
+			return true;
+		}
+		Resource ctx = st.getContext();
+		for (Resource filter : contexts) {
+			if (filter == null && ctx == null) {
+				return true;
+			}
+			if (filter != null && filter.equals(ctx)) {
+				return true;
+			}
+		}
+		return false;
+	}
+}

--- a/core/sail/cassandra-adj/src/main/java/org/eclipse/rdf4j/sail/cassandra/adjacency/CassandraAdjacencySailConnection.java
+++ b/core/sail/cassandra-adj/src/main/java/org/eclipse/rdf4j/sail/cassandra/adjacency/CassandraAdjacencySailConnection.java
@@ -21,8 +21,17 @@ import org.eclipse.rdf4j.model.impl.SimpleNamespace;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.Dataset;
+import org.eclipse.rdf4j.query.QueryEvaluationException;
+import org.eclipse.rdf4j.query.algebra.QueryRoot;
 import org.eclipse.rdf4j.query.algebra.TupleExpr;
+import org.eclipse.rdf4j.query.algebra.evaluation.EvaluationStrategy;
+import org.eclipse.rdf4j.query.algebra.evaluation.EvaluationStrategyFactory;
+import org.eclipse.rdf4j.query.algebra.evaluation.QueryEvaluationStep;
+import org.eclipse.rdf4j.query.algebra.evaluation.impl.DefaultEvaluationStrategyFactory;
+import org.eclipse.rdf4j.query.algebra.evaluation.impl.EvaluationStatistics;
+import org.eclipse.rdf4j.query.impl.EmptyBindingSet;
 import org.eclipse.rdf4j.sail.SailException;
+import org.eclipse.rdf4j.sail.evaluation.SailTripleSource;
 import org.eclipse.rdf4j.sail.helpers.AbstractNotifyingSailConnection;
 
 /**
@@ -77,7 +86,27 @@ public class CassandraAdjacencySailConnection extends AbstractNotifyingSailConne
 	@Override
 	protected CloseableIteration<? extends BindingSet> evaluateInternal(TupleExpr tupleExpr, Dataset dataset,
 			BindingSet bindings, boolean includeInferred) throws SailException {
-		return new EmptyIteration<>();
+		TupleExpr expr = tupleExpr.clone();
+
+		if (!(expr instanceof QueryRoot)) {
+			expr = new QueryRoot(expr);
+		}
+
+		EvaluationStrategyFactory strategyFactory = new DefaultEvaluationStrategyFactory();
+		EvaluationStatistics evaluationStatistics = new EvaluationStatistics();
+		BindingSet effectiveBindings = bindings == null ? EmptyBindingSet.getInstance() : bindings;
+		EvaluationStrategy strategy = strategyFactory.createEvaluationStrategy(
+				dataset,
+				new SailTripleSource(this, includeInferred, getSailBase().getValueFactory()),
+				evaluationStatistics);
+
+		try {
+			expr = strategy.optimize(expr, evaluationStatistics, effectiveBindings);
+			QueryEvaluationStep queryEvaluationStep = strategy.precompile(expr);
+			return queryEvaluationStep.evaluate(EmptyBindingSet.getInstance());
+		} catch (QueryEvaluationException e) {
+			throw new SailException(e);
+		}
 	}
 
 	@Override

--- a/core/sail/cassandra-adj/src/main/java/org/eclipse/rdf4j/sail/cassandra/adjacency/CassandraGraphStore.java
+++ b/core/sail/cassandra-adj/src/main/java/org/eclipse/rdf4j/sail/cassandra/adjacency/CassandraGraphStore.java
@@ -1,0 +1,21 @@
+package org.eclipse.rdf4j.sail.cassandra.adjacency;
+
+import java.util.List;
+
+import org.eclipse.rdf4j.common.iteration.CloseableIteration;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.sail.SailException;
+
+/**
+ * Abstraction over the Cassandra-backed graph store used by the Sail connection.
+ */
+public interface CassandraGraphStore {
+
+	void applyMutations(List<Statement> adds, List<Statement> removes) throws SailException;
+
+	CloseableIteration<? extends Statement> queryStatements(Resource subj, IRI pred, Value obj, Resource[] contexts,
+			boolean includeInferred) throws SailException;
+}

--- a/core/sail/cassandra-adj/src/main/java/org/eclipse/rdf4j/sail/cassandra/adjacency/CassandraSessionManager.java
+++ b/core/sail/cassandra-adj/src/main/java/org/eclipse/rdf4j/sail/cassandra/adjacency/CassandraSessionManager.java
@@ -1,0 +1,14 @@
+package org.eclipse.rdf4j.sail.cassandra.adjacency;
+
+import com.datastax.oss.driver.api.core.CqlSession;
+
+/**
+ * Manages Cassandra driver sessions per namespace or cluster configuration.
+ */
+public interface CassandraSessionManager extends AutoCloseable {
+
+	CqlSession getSession(GraphNamespaceId namespaceId);
+
+	@Override
+	void close();
+}

--- a/core/sail/cassandra-adj/src/main/java/org/eclipse/rdf4j/sail/cassandra/adjacency/ClassifiedStatement.java
+++ b/core/sail/cassandra-adj/src/main/java/org/eclipse/rdf4j/sail/cassandra/adjacency/ClassifiedStatement.java
@@ -1,0 +1,48 @@
+package org.eclipse.rdf4j.sail.cassandra.adjacency;
+
+import java.util.Objects;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Value;
+
+/**
+ * Result of classifying an RDF statement into a Cassandra namespace and category.
+ */
+public final class ClassifiedStatement {
+
+	private final StatementKind kind;
+	private final GraphNamespaceId namespace;
+	private final Resource subject;
+	private final IRI predicate;
+	private final Value object;
+
+	public ClassifiedStatement(StatementKind kind, GraphNamespaceId namespace, Resource subject, IRI predicate,
+			Value object) {
+		this.kind = Objects.requireNonNull(kind, "kind");
+		this.namespace = Objects.requireNonNull(namespace, "namespace");
+		this.subject = Objects.requireNonNull(subject, "subject");
+		this.predicate = Objects.requireNonNull(predicate, "predicate");
+		this.object = Objects.requireNonNull(object, "object");
+	}
+
+	public StatementKind getKind() {
+		return kind;
+	}
+
+	public GraphNamespaceId getNamespace() {
+		return namespace;
+	}
+
+	public Resource getSubject() {
+		return subject;
+	}
+
+	public IRI getPredicate() {
+		return predicate;
+	}
+
+	public Value getObject() {
+		return object;
+	}
+}

--- a/core/sail/cassandra-adj/src/main/java/org/eclipse/rdf4j/sail/cassandra/adjacency/GraphNamespaceId.java
+++ b/core/sail/cassandra-adj/src/main/java/org/eclipse/rdf4j/sail/cassandra/adjacency/GraphNamespaceId.java
@@ -1,0 +1,41 @@
+package org.eclipse.rdf4j.sail.cassandra.adjacency;
+
+import java.util.Objects;
+
+/**
+ * Logical graph namespace identifier used to route nodes and edges.
+ */
+public final class GraphNamespaceId {
+
+	private final String id;
+
+	public GraphNamespaceId(String id) {
+		this.id = Objects.requireNonNull(id, "id");
+	}
+
+	public String id() {
+		return id;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		GraphNamespaceId that = (GraphNamespaceId) o;
+		return id.equals(that.id);
+	}
+
+	@Override
+	public int hashCode() {
+		return id.hashCode();
+	}
+
+	@Override
+	public String toString() {
+		return id;
+	}
+}

--- a/core/sail/cassandra-adj/src/main/java/org/eclipse/rdf4j/sail/cassandra/adjacency/NamespaceManager.java
+++ b/core/sail/cassandra-adj/src/main/java/org/eclipse/rdf4j/sail/cassandra/adjacency/NamespaceManager.java
@@ -1,0 +1,89 @@
+package org.eclipse.rdf4j.sail.cassandra.adjacency;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import org.eclipse.rdf4j.model.IRI;
+
+/**
+ * Resolves RDF classes and predicates to logical graph namespaces.
+ */
+public final class NamespaceManager {
+
+	private final Map<IRI, GraphNamespaceId> nodeNamespaces;
+	private final Map<IRI, GraphNamespaceId> edgeNamespaces;
+	private final GraphNamespaceId defaultNodeNamespace;
+	private final GraphNamespaceId defaultEdgeNamespace;
+
+	private NamespaceManager(Map<IRI, GraphNamespaceId> nodeNamespaces, Map<IRI, GraphNamespaceId> edgeNamespaces,
+			GraphNamespaceId defaultNodeNamespace, GraphNamespaceId defaultEdgeNamespace) {
+		this.nodeNamespaces = nodeNamespaces;
+		this.edgeNamespaces = edgeNamespaces;
+		this.defaultNodeNamespace = defaultNodeNamespace;
+		this.defaultEdgeNamespace = defaultEdgeNamespace;
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public GraphNamespaceId nodeNamespaceFor(IRI type) {
+		if (type != null && nodeNamespaces.containsKey(type)) {
+			return nodeNamespaces.get(type);
+		}
+		return defaultNodeNamespace;
+	}
+
+	public GraphNamespaceId edgeNamespaceFor(IRI predicate) {
+		if (predicate != null && edgeNamespaces.containsKey(predicate)) {
+			return edgeNamespaces.get(predicate);
+		}
+		return defaultEdgeNamespace;
+	}
+
+	public GraphNamespaceId defaultNodeNamespace() {
+		return defaultNodeNamespace;
+	}
+
+	public GraphNamespaceId defaultEdgeNamespace() {
+		return defaultEdgeNamespace;
+	}
+
+	public static final class Builder {
+
+		private final Map<IRI, GraphNamespaceId> nodeNamespaces = new HashMap<>();
+		private final Map<IRI, GraphNamespaceId> edgeNamespaces = new HashMap<>();
+		private GraphNamespaceId defaultNodeNamespace;
+		private GraphNamespaceId defaultEdgeNamespace;
+
+		public Builder defaultNodeNamespace(String namespaceId) {
+			this.defaultNodeNamespace = new GraphNamespaceId(namespaceId);
+			return this;
+		}
+
+		public Builder defaultEdgeNamespace(String namespaceId) {
+			this.defaultEdgeNamespace = new GraphNamespaceId(namespaceId);
+			return this;
+		}
+
+		public Builder addNodeNamespace(IRI type, GraphNamespaceId namespaceId) {
+			nodeNamespaces.put(Objects.requireNonNull(type), Objects.requireNonNull(namespaceId));
+			return this;
+		}
+
+		public Builder addEdgeNamespace(IRI predicate, GraphNamespaceId namespaceId) {
+			edgeNamespaces.put(Objects.requireNonNull(predicate), Objects.requireNonNull(namespaceId));
+			return this;
+		}
+
+		public NamespaceManager build() {
+			Objects.requireNonNull(defaultNodeNamespace, "Default node namespace must be configured");
+			Objects.requireNonNull(defaultEdgeNamespace, "Default edge namespace must be configured");
+			return new NamespaceManager(Collections.unmodifiableMap(new HashMap<>(nodeNamespaces)),
+					Collections.unmodifiableMap(new HashMap<>(edgeNamespaces)), defaultNodeNamespace,
+					defaultEdgeNamespace);
+		}
+	}
+}

--- a/core/sail/cassandra-adj/src/main/java/org/eclipse/rdf4j/sail/cassandra/adjacency/StatementClassifier.java
+++ b/core/sail/cassandra-adj/src/main/java/org/eclipse/rdf4j/sail/cassandra/adjacency/StatementClassifier.java
@@ -1,0 +1,47 @@
+package org.eclipse.rdf4j.sail.cassandra.adjacency;
+
+import java.util.Objects;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+
+/**
+ * Classifies RDF statements into node types, node properties, or edges and associates them with graph namespaces.
+ */
+public final class StatementClassifier {
+
+	private final NamespaceManager namespaceManager;
+
+	public StatementClassifier(NamespaceManager namespaceManager) {
+		this.namespaceManager = Objects.requireNonNull(namespaceManager, "namespaceManager");
+	}
+
+	public ClassifiedStatement classify(Statement statement) {
+		Objects.requireNonNull(statement, "statement");
+
+		Resource subject = statement.getSubject();
+		IRI predicate = statement.getPredicate();
+		Value object = statement.getObject();
+
+		if (predicate.equals(RDF.TYPE) && object instanceof IRI) {
+			GraphNamespaceId namespace = namespaceManager.nodeNamespaceFor((IRI) object);
+			return new ClassifiedStatement(StatementKind.NODE_TYPE, namespace, subject, predicate, object);
+		}
+
+		if (object instanceof Literal) {
+			GraphNamespaceId namespace = namespaceManager.nodeNamespaceFor(null);
+			return new ClassifiedStatement(StatementKind.NODE_PROPERTY, namespace, subject, predicate, object);
+		}
+
+		if (object instanceof Resource) {
+			GraphNamespaceId namespace = namespaceManager.edgeNamespaceFor(predicate);
+			return new ClassifiedStatement(StatementKind.EDGE, namespace, subject, predicate, object);
+		}
+
+		throw new IllegalArgumentException("Unsupported statement object: " + object);
+	}
+}

--- a/core/sail/cassandra-adj/src/main/java/org/eclipse/rdf4j/sail/cassandra/adjacency/StatementKind.java
+++ b/core/sail/cassandra-adj/src/main/java/org/eclipse/rdf4j/sail/cassandra/adjacency/StatementKind.java
@@ -1,0 +1,10 @@
+package org.eclipse.rdf4j.sail.cassandra.adjacency;
+
+/**
+ * Statement classification outcome used to route data to Cassandra namespaces.
+ */
+public enum StatementKind {
+	NODE_TYPE,
+	NODE_PROPERTY,
+	EDGE
+}

--- a/core/sail/cassandra-adj/src/main/java/org/eclipse/rdf4j/sail/cassandra/adjacency/ValueEncoding.java
+++ b/core/sail/cassandra-adj/src/main/java/org/eclipse/rdf4j/sail/cassandra/adjacency/ValueEncoding.java
@@ -1,0 +1,89 @@
+package org.eclipse.rdf4j.sail.cassandra.adjacency;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import org.eclipse.rdf4j.model.BNode;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.ValueFactory;
+
+/**
+ * Utilities for mapping RDF values to stable string encodings suitable for Cassandra keys.
+ */
+public final class ValueEncoding {
+
+	public static final String DEFAULT_CONTEXT = "";
+
+	private ValueEncoding() {
+	}
+
+	public static String encodeResource(Resource resource) {
+		Objects.requireNonNull(resource, "resource");
+		if (resource instanceof BNode) {
+			return "_:" + resource.stringValue();
+		}
+		return resource.stringValue();
+	}
+
+	public static Resource decodeResource(String encoded, ValueFactory valueFactory) {
+		Objects.requireNonNull(encoded, "encoded");
+		Objects.requireNonNull(valueFactory, "valueFactory");
+		if (encoded.startsWith("_:")) {
+			return valueFactory.createBNode(encoded.substring(2));
+		}
+		return valueFactory.createIRI(encoded);
+	}
+
+	public static LiteralFields encodeLiteral(Literal literal) {
+		Objects.requireNonNull(literal, "literal");
+		String language = literal.getLanguage().orElse(null);
+		return new LiteralFields(literal.getLabel(), literal.getDatatype().stringValue(),
+				Optional.ofNullable(language));
+	}
+
+	public static Literal decodeLiteral(LiteralFields fields, ValueFactory valueFactory) {
+		Objects.requireNonNull(fields, "fields");
+		Objects.requireNonNull(valueFactory, "valueFactory");
+		if (fields.language().isPresent()) {
+			return valueFactory.createLiteral(fields.lexical(), fields.language().get());
+		}
+		return valueFactory.createLiteral(fields.lexical(), valueFactory.createIRI(fields.datatype()));
+	}
+
+	public static String encodeContext(Resource context) {
+		return context == null ? DEFAULT_CONTEXT : context.stringValue();
+	}
+
+	public static Resource decodeContext(String encoded, ValueFactory valueFactory) {
+		if (encoded == null || DEFAULT_CONTEXT.equals(encoded)) {
+			return null;
+		}
+		return decodeResource(encoded, valueFactory);
+	}
+
+	public static final class LiteralFields {
+
+		private final String lexical;
+		private final String datatype;
+		private final Optional<String> language;
+
+		public LiteralFields(String lexical, String datatype, Optional<String> language) {
+			this.lexical = Objects.requireNonNull(lexical, "lexical");
+			this.datatype = Objects.requireNonNull(datatype, "datatype");
+			this.language = language == null ? Optional.empty() : language;
+		}
+
+		public String lexical() {
+			return lexical;
+		}
+
+		public String datatype() {
+			return datatype;
+		}
+
+		public Optional<String> language() {
+			return language;
+		}
+	}
+}

--- a/core/sail/cassandra-adj/src/test/java/org/eclipse/rdf4j/sail/cassandra/adjacency/CassandraAdjacencySailIntegrationTest.java
+++ b/core/sail/cassandra-adj/src/test/java/org/eclipse/rdf4j/sail/cassandra/adjacency/CassandraAdjacencySailIntegrationTest.java
@@ -2,6 +2,8 @@ package org.eclipse.rdf4j.sail.cassandra.adjacency;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.stream.Collectors;
+
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Resource;
@@ -80,5 +82,29 @@ class CassandraAdjacencySailIntegrationTest {
 		}
 
 		assertThat(graphStore.fetchTripleCount()).isEqualTo(1L);
+	}
+
+	@Test
+	void loadRdfAndQueryThroughCassandra() {
+		IRI predicate = VF.createIRI("http://example.com/p");
+
+		try (RepositoryConnection connection = repository.getConnection()) {
+			connection.add(VF.createIRI("http://example.com/s1"), predicate, VF.createLiteral("o1"));
+			connection.add(VF.createIRI("http://example.com/s2"), predicate, VF.createLiteral("o2"));
+			connection.commit();
+		}
+
+		try (RepositoryConnection connection = repository.getConnection()) {
+			var results = connection.prepareTupleQuery(
+					"SELECT ?s ?o WHERE { ?s <http://example.com/p> ?o } ORDER BY ?s")
+					.evaluate()
+					.stream()
+					.map(bs -> bs.getValue("s") + " " + bs.getValue("o").stringValue())
+					.collect(Collectors.toList());
+
+			assertThat(results).containsExactly(
+					"http://example.com/s1 o1",
+					"http://example.com/s2 o2");
+		}
 	}
 }

--- a/core/sail/cassandra-adj/src/test/java/org/eclipse/rdf4j/sail/cassandra/adjacency/CassandraAdjacencySailIntegrationTest.java
+++ b/core/sail/cassandra-adj/src/test/java/org/eclipse/rdf4j/sail/cassandra/adjacency/CassandraAdjacencySailIntegrationTest.java
@@ -1,0 +1,84 @@
+package org.eclipse.rdf4j.sail.cassandra.adjacency;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.CassandraContainer;
+
+class CassandraAdjacencySailIntegrationTest {
+
+	private static final ValueFactory VF = SimpleValueFactory.getInstance();
+	private static final String KEYSPACE = "rdf4j_adj_test";
+
+	private static CassandraContainer<?> cassandra;
+
+	private static Repository repository;
+	private static CassandraTestGraphStore graphStore;
+
+	@BeforeAll
+	static void setup() {
+		boolean dockerAvailable;
+		try {
+			dockerAvailable = DockerClientFactory.instance().isDockerAvailable();
+		} catch (Throwable t) {
+			dockerAvailable = false;
+		}
+
+		Assumptions.assumeTrue(dockerAvailable, "Docker is required for Cassandra tests");
+		cassandra = new CassandraContainer<>("cassandra:4.1");
+		cassandra.start();
+
+		graphStore = CassandraTestGraphStore.create(cassandra, KEYSPACE, VF);
+		NamespaceManager namespaceManager = NamespaceManager.builder()
+				.defaultNodeNamespace("nodes")
+				.defaultEdgeNamespace("edges")
+				.build();
+
+		repository = new SailRepository(new CassandraAdjacencySail(graphStore, namespaceManager));
+		repository.init();
+	}
+
+	@AfterAll
+	static void tearDown() {
+		if (repository != null) {
+			repository.shutDown();
+		}
+		if (graphStore != null) {
+			graphStore.close();
+		}
+		if (cassandra != null) {
+			cassandra.stop();
+		}
+	}
+
+	@Test
+	void writesAndReadsStatementsAgainstCassandra() {
+		IRI subject = VF.createIRI("urn:subject");
+		IRI predicate = VF.createIRI("urn:predicate");
+		Literal object = VF.createLiteral("value");
+		Resource context = VF.createIRI("urn:context");
+
+		try (RepositoryConnection connection = repository.getConnection()) {
+			connection.add(subject, predicate, object, context);
+			connection.commit();
+		}
+
+		try (RepositoryConnection connection = repository.getConnection()) {
+			assertThat(connection.hasStatement(subject, predicate, object, false, context)).isTrue();
+		}
+
+		assertThat(graphStore.fetchTripleCount()).isEqualTo(1L);
+	}
+}

--- a/core/sail/cassandra-adj/src/test/java/org/eclipse/rdf4j/sail/cassandra/adjacency/CassandraAdjacencySailTest.java
+++ b/core/sail/cassandra-adj/src/test/java/org/eclipse/rdf4j/sail/cassandra/adjacency/CassandraAdjacencySailTest.java
@@ -1,0 +1,93 @@
+package org.eclipse.rdf4j.sail.cassandra.adjacency;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.eclipse.rdf4j.common.iteration.CloseableIteration;
+import org.eclipse.rdf4j.common.iteration.CloseableIteratorIteration;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.sail.SailException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class CassandraAdjacencySailTest {
+
+	private final ValueFactory vf = SimpleValueFactory.getInstance();
+	private CassandraAdjacencySail sail;
+
+	@AfterEach
+	void tearDown() throws SailException {
+		if (sail != null) {
+			sail.shutDown();
+		}
+	}
+
+	@Test
+	void addQueryAndRemoveStatementsThroughSail() throws SailException {
+		InMemoryGraphStore graphStore = new InMemoryGraphStore();
+		sail = new CassandraAdjacencySail(graphStore, namespaceManager());
+		sail.initialize();
+
+		SailRepository repository = new SailRepository(sail);
+		IRI subject = vf.createIRI("http://example.com/s");
+		IRI predicate = vf.createIRI("http://example.com/p");
+
+		try (RepositoryConnection connection = repository.getConnection()) {
+			connection.add(subject, predicate, vf.createLiteral("value"));
+		}
+
+		try (RepositoryConnection connection = repository.getConnection()) {
+			List<Statement> statements = connection.getStatements(null, null, null).asList();
+			assertThat(statements).hasSize(1);
+			connection.remove(subject, null, null);
+		}
+
+		try (RepositoryConnection connection = repository.getConnection()) {
+			assertThat(connection.getStatements(null, null, null).asList()).isEmpty();
+		}
+	}
+
+	private NamespaceManager namespaceManager() {
+		return NamespaceManager.builder()
+				.defaultNodeNamespace("default-node")
+				.defaultEdgeNamespace("default-edge")
+				.build();
+	}
+
+	private static final class InMemoryGraphStore implements CassandraGraphStore {
+
+		private final Set<Statement> statements = new LinkedHashSet<>();
+
+		@Override
+		public synchronized void applyMutations(List<Statement> adds, List<Statement> removes) {
+			statements.removeAll(removes);
+			statements.addAll(adds);
+		}
+
+		@Override
+		public synchronized CloseableIteration<? extends Statement> queryStatements(Resource subj, IRI pred, Value obj,
+				Resource[] contexts, boolean includeInferred) {
+			return new CloseableIteratorIteration<>(statements.stream()
+					.filter(st -> subj == null || st.getSubject().equals(subj))
+					.filter(st -> pred == null || st.getPredicate().equals(pred))
+					.filter(st -> obj == null || st.getObject().equals(obj))
+					.filter(st -> contexts == null || contexts.length == 0
+							|| st.getContext() == null && contexts.length == 1 && contexts[0] == null
+							|| st.getContext() != null && List.of(contexts).contains(st.getContext()))
+					.collect(Collectors.toCollection(ArrayList::new))
+					.iterator());
+		}
+	}
+}

--- a/core/sail/cassandra-adj/src/test/java/org/eclipse/rdf4j/sail/cassandra/adjacency/CassandraAdjacencySailTest.java
+++ b/core/sail/cassandra-adj/src/test/java/org/eclipse/rdf4j/sail/cassandra/adjacency/CassandraAdjacencySailTest.java
@@ -2,6 +2,8 @@ package org.eclipse.rdf4j.sail.cassandra.adjacency;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -18,6 +20,7 @@ import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.sail.SailException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -56,6 +59,61 @@ class CassandraAdjacencySailTest {
 
 		try (RepositoryConnection connection = repository.getConnection()) {
 			assertThat(connection.getStatements(null, null, null).asList()).isEmpty();
+		}
+	}
+
+	@Test
+	void tupleQueryReturnsStoredStatement() {
+		InMemoryGraphStore graphStore = new InMemoryGraphStore();
+		sail = new CassandraAdjacencySail(graphStore, namespaceManager());
+		sail.initialize();
+
+		SailRepository repository = new SailRepository(sail);
+		IRI subject = vf.createIRI("http://example.com/s");
+		IRI predicate = vf.createIRI("http://example.com/p");
+
+		try (RepositoryConnection connection = repository.getConnection()) {
+			connection.add(subject, predicate, vf.createLiteral("value"));
+		}
+
+		try (RepositoryConnection connection = repository.getConnection()) {
+			List<String> values = connection.prepareTupleQuery("SELECT ?o WHERE { <" + subject + "> <" + predicate
+					+ "> ?o }")
+					.evaluate()
+					.stream()
+					.map(bs -> bs.getValue("o").stringValue())
+					.collect(Collectors.toList());
+
+			assertThat(values).containsExactly("value");
+		}
+	}
+
+	@Test
+	void loadRdfAndQueryIt() throws Exception {
+		InMemoryGraphStore graphStore = new InMemoryGraphStore();
+		sail = new CassandraAdjacencySail(graphStore, namespaceManager());
+		sail.initialize();
+
+		String ttl = "@prefix ex: <http://example.com/> .\n"
+				+ "ex:s1 ex:p ex:o1 .\n"
+				+ "ex:s2 ex:p ex:o2 .\n";
+
+		SailRepository repository = new SailRepository(sail);
+		try (RepositoryConnection connection = repository.getConnection()) {
+			connection.add(new ByteArrayInputStream(ttl.getBytes(StandardCharsets.UTF_8)), "", RDFFormat.TURTLE);
+		}
+
+		try (RepositoryConnection connection = repository.getConnection()) {
+			List<String> results = connection.prepareTupleQuery(
+					"SELECT ?s ?o WHERE { ?s <http://example.com/p> ?o } ORDER BY ?s")
+					.evaluate()
+					.stream()
+					.map(bs -> bs.getValue("s") + " " + bs.getValue("o"))
+					.collect(Collectors.toList());
+
+			assertThat(results).containsExactly(
+					"http://example.com/s1 http://example.com/o1",
+					"http://example.com/s2 http://example.com/o2");
 		}
 	}
 

--- a/core/sail/cassandra-adj/src/test/java/org/eclipse/rdf4j/sail/cassandra/adjacency/CassandraTestGraphStore.java
+++ b/core/sail/cassandra-adj/src/test/java/org/eclipse/rdf4j/sail/cassandra/adjacency/CassandraTestGraphStore.java
@@ -1,0 +1,218 @@
+package org.eclipse.rdf4j.sail.cassandra.adjacency;
+
+import java.net.InetSocketAddress;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+import org.eclipse.rdf4j.common.iteration.CloseableIteration;
+import org.eclipse.rdf4j.common.iteration.CloseableIteratorIteration;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.testcontainers.containers.CassandraContainer;
+
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.cql.PreparedStatement;
+import com.datastax.oss.driver.api.core.cql.ResultSet;
+import com.datastax.oss.driver.api.core.cql.Row;
+import com.datastax.oss.driver.api.core.cql.SimpleStatement;
+
+/**
+ * Minimal Cassandra-backed graph store used for integration testing with a live Cassandra instance.
+ */
+class CassandraTestGraphStore implements CassandraGraphStore, AutoCloseable {
+
+	private static final String TABLE = "triples";
+
+	private final CqlSession session;
+	private final String keyspace;
+	private final ValueFactory valueFactory;
+
+	private final PreparedStatement insertStatement;
+	private final PreparedStatement deleteStatement;
+
+	private CassandraTestGraphStore(CqlSession session, String keyspace, ValueFactory valueFactory) {
+		this.session = session;
+		this.keyspace = keyspace;
+		this.valueFactory = valueFactory;
+
+		this.insertStatement = session.prepare(
+				"INSERT INTO " + keyspace + "." + TABLE
+						+ " (subject, predicate, object, object_type, datatype, lang, context)"
+						+ " VALUES (?, ?, ?, ?, ?, ?, ?)");
+		this.deleteStatement = session.prepare(
+				"DELETE FROM " + keyspace + "." + TABLE
+						+ " WHERE subject = ? AND predicate = ? AND object = ? AND context = ?");
+	}
+
+	static CassandraTestGraphStore create(CassandraContainer<?> container, String keyspace, ValueFactory valueFactory) {
+		Objects.requireNonNull(container, "container");
+		Objects.requireNonNull(keyspace, "keyspace");
+
+		InetSocketAddress contactPoint = new InetSocketAddress(container.getHost(), container.getMappedPort(9042));
+
+		CqlSession session = CqlSession.builder()
+				.addContactPoint(contactPoint)
+				.withLocalDatacenter(container.getLocalDatacenter())
+				.build();
+
+		session.execute("CREATE KEYSPACE IF NOT EXISTS " + keyspace
+				+ " WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1}");
+		session.execute("CREATE TABLE IF NOT EXISTS " + keyspace + "." + TABLE + " ("
+				+ "subject text, "
+				+ "predicate text, "
+				+ "object text, "
+				+ "object_type text, "
+				+ "datatype text, "
+				+ "lang text, "
+				+ "context text, "
+				+ "PRIMARY KEY ((subject), predicate, object, context))");
+
+		return new CassandraTestGraphStore(session, keyspace,
+				valueFactory == null ? SimpleValueFactory.getInstance() : valueFactory);
+	}
+
+	long fetchTripleCount() {
+		ResultSet rs = session.execute("SELECT count(*) FROM " + keyspace + "." + TABLE);
+		Row row = rs.one();
+		return row == null ? 0L : row.getLong(0);
+	}
+
+	@Override
+	public void applyMutations(List<Statement> adds, List<Statement> removes) {
+		Objects.requireNonNull(adds, "adds");
+		Objects.requireNonNull(removes, "removes");
+
+		for (Statement st : removes) {
+			EncodedTriple encoded = encodeStatement(st);
+			session.execute(deleteStatement.bind(encoded.subject, encoded.predicate, encoded.object,
+					encoded.context));
+		}
+
+		for (Statement st : adds) {
+			EncodedTriple encoded = encodeStatement(st);
+			session.execute(insertStatement.bind(encoded.subject, encoded.predicate, encoded.object,
+					encoded.objectType, encoded.datatype, encoded.lang, encoded.context));
+		}
+	}
+
+	@Override
+	public CloseableIteration<? extends Statement> queryStatements(Resource subj, IRI pred, Value obj,
+			Resource[] contexts, boolean includeInferred) {
+		Set<Statement> statements = new HashSet<>();
+
+		SimpleStatement statement;
+		if (subj != null) {
+			statement = SimpleStatement.builder(
+					"SELECT subject, predicate, object, object_type, datatype, lang, context FROM " + keyspace
+							+ "." + TABLE + " WHERE subject = ?")
+					.addPositionalValue(ValueEncoding.encodeResource(subj))
+					.build();
+		} else {
+			statement = SimpleStatement.builder(
+					"SELECT subject, predicate, object, object_type, datatype, lang, context FROM " + keyspace
+							+ "." + TABLE)
+					.build();
+		}
+
+		ResultSet rs = session.execute(statement);
+		for (Row row : rs) {
+			Statement decoded = decodeRow(row);
+			if (matches(decoded, subj, pred, obj, contexts)) {
+				statements.add(decoded);
+			}
+		}
+
+		return new CloseableIteratorIteration<>(statements.iterator());
+	}
+
+	@Override
+	public void close() {
+		session.close();
+	}
+
+	private Statement decodeRow(Row row) {
+		Resource subject = ValueEncoding.decodeResource(row.getString("subject"), valueFactory);
+		IRI predicate = valueFactory.createIRI(row.getString("predicate"));
+		String objectType = row.getString("object_type");
+		Value object;
+		if ("LITERAL".equals(objectType)) {
+			ValueEncoding.LiteralFields fields = new ValueEncoding.LiteralFields(row.getString("object"),
+					row.getString("datatype"),
+					row.isNull("lang") ? null : java.util.Optional.ofNullable(row.getString("lang")));
+			object = ValueEncoding.decodeLiteral(fields, valueFactory);
+		} else {
+			object = ValueEncoding.decodeResource(row.getString("object"), valueFactory);
+		}
+		Resource context = ValueEncoding.decodeContext(row.getString("context"), valueFactory);
+		return valueFactory.createStatement(subject, predicate, object, context);
+	}
+
+	private boolean matches(Statement st, Resource subj, IRI pred, Value obj, Resource[] contexts) {
+		if (subj != null && !subj.equals(st.getSubject())) {
+			return false;
+		}
+		if (pred != null && !pred.equals(st.getPredicate())) {
+			return false;
+		}
+		if (obj != null && !obj.equals(st.getObject())) {
+			return false;
+		}
+		if (contexts == null || contexts.length == 0) {
+			return true;
+		}
+		Resource ctx = st.getContext();
+		for (Resource filter : contexts) {
+			if (filter == null && ctx == null) {
+				return true;
+			}
+			if (filter != null && filter.equals(ctx)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private EncodedTriple encodeStatement(Statement st) {
+		String subject = ValueEncoding.encodeResource(st.getSubject());
+		String predicate = st.getPredicate().stringValue();
+		String context = ValueEncoding.encodeContext(st.getContext());
+
+		Value object = st.getObject();
+		if (object instanceof Literal) {
+			ValueEncoding.LiteralFields fields = ValueEncoding.encodeLiteral((Literal) object);
+			return new EncodedTriple(subject, predicate, fields.lexical(), "LITERAL", fields.datatype(),
+					fields.language().orElse(null), context);
+		}
+
+		return new EncodedTriple(subject, predicate, ValueEncoding.encodeResource((Resource) object), "RESOURCE", null,
+				null, context);
+	}
+
+	private static final class EncodedTriple {
+		private final String subject;
+		private final String predicate;
+		private final String object;
+		private final String objectType;
+		private final String datatype;
+		private final String lang;
+		private final String context;
+
+		EncodedTriple(String subject, String predicate, String object, String objectType, String datatype, String lang,
+				String context) {
+			this.subject = subject;
+			this.predicate = predicate;
+			this.object = object;
+			this.objectType = objectType;
+			this.datatype = datatype;
+			this.lang = lang;
+			this.context = context;
+		}
+	}
+}

--- a/core/sail/cassandra-adj/src/test/java/org/eclipse/rdf4j/sail/cassandra/adjacency/StatementClassifierTest.java
+++ b/core/sail/cassandra-adj/src/test/java/org/eclipse/rdf4j/sail/cassandra/adjacency/StatementClassifierTest.java
@@ -1,0 +1,66 @@
+package org.eclipse.rdf4j.sail.cassandra.adjacency;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.junit.jupiter.api.Test;
+
+class StatementClassifierTest {
+
+	private final ValueFactory vf = SimpleValueFactory.getInstance();
+
+	private NamespaceManager namespaceManager() {
+		return NamespaceManager.builder()
+				.defaultNodeNamespace("default-node")
+				.defaultEdgeNamespace("default-edge")
+				.addNodeNamespace(vf.createIRI("http://example.com/Account"), new GraphNamespaceId("member-account"))
+				.addEdgeNamespace(vf.createIRI("http://example.com/startedWatching"),
+						new GraphNamespaceId("started-watching"))
+				.build();
+	}
+
+	@Test
+	void identifiesNodeTypeStatements() {
+		Resource subject = vf.createIRI("http://example.com/user/1");
+		IRI type = vf.createIRI("http://example.com/Account");
+		Statement statement = vf.createStatement(subject, RDF.TYPE, type);
+
+		StatementClassifier classifier = new StatementClassifier(namespaceManager());
+		ClassifiedStatement classified = classifier.classify(statement);
+
+		assertThat(classified.getKind()).isEqualTo(StatementKind.NODE_TYPE);
+		assertThat(classified.getNamespace().id()).isEqualTo("member-account");
+	}
+
+	@Test
+	void identifiesNodePropertyStatements() {
+		Resource subject = vf.createIRI("http://example.com/user/2");
+		Statement statement = vf.createStatement(subject, vf.createIRI("http://example.com/name"),
+				vf.createLiteral("Alice"));
+
+		StatementClassifier classifier = new StatementClassifier(namespaceManager());
+		ClassifiedStatement classified = classifier.classify(statement);
+
+		assertThat(classified.getKind()).isEqualTo(StatementKind.NODE_PROPERTY);
+		assertThat(classified.getNamespace().id()).isEqualTo("default-node");
+	}
+
+	@Test
+	void identifiesEdgeStatements() {
+		Resource subject = vf.createIRI("http://example.com/user/3");
+		Resource target = vf.createIRI("http://example.com/title/7");
+		IRI predicate = vf.createIRI("http://example.com/startedWatching");
+		Statement statement = vf.createStatement(subject, predicate, target);
+
+		StatementClassifier classifier = new StatementClassifier(namespaceManager());
+		ClassifiedStatement classified = classifier.classify(statement);
+
+		assertThat(classified.getKind()).isEqualTo(StatementKind.EDGE);
+		assertThat(classified.getNamespace().id()).isEqualTo("started-watching");
+	}
+}

--- a/core/sail/cassandra-adj/src/test/java/org/eclipse/rdf4j/sail/cassandra/adjacency/ValueEncodingTest.java
+++ b/core/sail/cassandra-adj/src/test/java/org/eclipse/rdf4j/sail/cassandra/adjacency/ValueEncodingTest.java
@@ -1,0 +1,50 @@
+package org.eclipse.rdf4j.sail.cassandra.adjacency;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.junit.jupiter.api.Test;
+
+class ValueEncodingTest {
+
+	private final ValueFactory vf = SimpleValueFactory.getInstance();
+
+	@Test
+	void encodesAndDecodesResources() {
+		IRI iri = vf.createIRI("http://example.com/id/1");
+		Resource bnode = vf.createBNode("b1");
+
+		String encodedIri = ValueEncoding.encodeResource(iri);
+		String encodedBnode = ValueEncoding.encodeResource(bnode);
+
+		assertThat(ValueEncoding.decodeResource(encodedIri, vf)).isEqualTo(iri);
+		assertThat(ValueEncoding.decodeResource(encodedBnode, vf)).isEqualTo(bnode);
+	}
+
+	@Test
+	void encodesAndDecodesLiterals() {
+		Literal literal = vf.createLiteral("Alice", "en");
+		ValueEncoding.LiteralFields encoded = ValueEncoding.encodeLiteral(literal);
+
+		assertThat(encoded.lexical()).isEqualTo("Alice");
+		assertThat(encoded.datatype()).isEqualTo(literal.getDatatype().stringValue());
+		assertThat(encoded.language()).contains("en");
+
+		Literal decoded = ValueEncoding.decodeLiteral(encoded, vf);
+		assertThat(decoded).isEqualTo(literal);
+	}
+
+	@Test
+	void encodesAndDecodesContexts() {
+		Resource context = vf.createIRI("http://example.com/graph");
+		String encoded = ValueEncoding.encodeContext(context);
+		String encodedNull = ValueEncoding.encodeContext(null);
+
+		assertThat(ValueEncoding.decodeContext(encoded, vf)).isEqualTo(context);
+		assertThat(ValueEncoding.decodeContext(encodedNull, vf)).isNull();
+	}
+}

--- a/core/sail/cassandra-adj/src/test/resources/logback-test.xml
+++ b/core/sail/cassandra-adj/src/test/resources/logback-test.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration debug="false">
+	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+		<encoder>
+			<pattern>%d %green([%thread]) %highlight(%level) %logger{50} - %msg%n</pattern>
+		</encoder>
+	</appender>
+	<root>
+		<level value="info"/>
+		<appender-ref ref="STDOUT"/>
+	</root>
+</configuration>

--- a/core/sail/pom.xml
+++ b/core/sail/pom.xml
@@ -24,6 +24,7 @@
 		<module>solr</module>
 		<module>elasticsearch</module>
 		<module>elasticsearch-store</module>
+		<module>cassandra-adj</module>
 		<module>extensible-store</module>
 	</modules>
 </project>

--- a/plans/GH-0000-cassandra-adj.md
+++ b/plans/GH-0000-cassandra-adj.md
@@ -1,0 +1,102 @@
+# Cassandra adjacency-list Sail for RDF4J
+
+This ExecPlan is a living document. The sections `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work proceeds. It follows the repository guidance in PLANS.md.
+
+## Purpose / Big Picture
+
+Deliver a new RDF4J Sail backed by Apache Cassandra using an adjacency-list layout. After completion, a developer can configure a `CassandraAdjacencySail`, load RDF statements into Cassandra, and query them via RDF4J APIs. They will see data persisted in Cassandra tables and retrievable through RDF4J `getStatements` and SPARQL queries using the new module.
+
+## Progress
+
+- [x] (2025-02-06 00:00Z) Drafted initial ExecPlan outlining module creation, data model, and testing strategy.
+- [x] (2025-02-07 00:30Z) Implemented module scaffolding (`core/sail/cassandra-adj` POM) and added initial failing tests for utilities and Sail wiring.
+- [x] (2025-02-07 02:00Z) Implemented ValueEncoding utilities, StatementClassifier, and namespace helpers to satisfy unit expectations.
+- [x] (2025-02-07 02:15Z) Added Cassandra graph/session interfaces and minimal CassandraAdjacencySail plus connection buffering logic to make Sail tests runnable with in-memory store.
+- [ ] Finalize documentation, schema DDL, and example configuration files.
+- [ ] Run formatting/linting and commit changes (formatting and module tests now pass; commit pending).
+
+## Surprises & Discoveries
+
+- Observation: Pending.
+  Evidence: Pending.
+
+## Decision Log
+
+- Decision: Use mockable interfaces for Cassandra access to allow unit tests without real Cassandra. Rationale: Keeps tests lightweight and runnable in CI. Date/Author: 2025-02-06 / AI Agent.
+
+## Outcomes & Retrospective
+
+Pending completion. Will summarize functioning Sail, test coverage, and remaining gaps.
+
+## Context and Orientation
+
+The repository root hosts multiple modules; we will add a new Maven module `rdf4j-sail-cassandra-adj` under `storage/` or a sibling location aligned with other Sail implementations. Key existing patterns include `storage/sail/elasticsearch-store` and `storage/sail/lmdb` for reference. Tests live under `testsuites/` and module-specific `src/test/java` directories. PLANS.md governs this ExecPlan.
+
+## Plan of Work
+
+1. Create a new Maven module `storage/cassandra-adj` (artifact `rdf4j-sail-cassandra-adj`) with dependencies on RDF4J Sail APIs and the DataStax Java driver. Provide module POM and parent references in root `pom.xml` and relevant aggregator POMs.
+2. Introduce configuration classes (`CassandraSailConfig`, `CassandraSailFactory`) supporting contact points, keyspace, and namespace mapping file paths.
+3. Implement utility classes:
+   - `ValueEncoding` to map RDF4J `Value` objects to stable string identifiers and literals to serialized forms.
+   - `StatementClassifier` plus supporting `GraphNamespaceId` and `NamespaceManager` abstractions for namespace resolution.
+4. Create storage abstractions:
+   - `CassandraSessionManager` interface with a default implementation stub that can be mocked in tests.
+   - `CassandraGraphStore` interface and a default implementation skeleton that will later integrate with Cassandra tables (initially mocked or in-memory to satisfy tests).
+5. Implement Sail layer:
+   - `CassandraAdjacencySail` extending `NotifyingSailBase` with configuration loading and connection provisioning.
+   - `CassandraAdjacencySailConnection` extending `NotifyingSailConnectionBase` with buffered mutations and delegation to `CassandraGraphStore` for reads/writes.
+6. Add schema DDL and example configuration resources under the module (e.g., `src/main/resources/cassandra-adj/schema.cql`, `namespace-example.yaml`).
+7. Testing (TDD):
+   - Start with unit tests for `ValueEncoding` and `StatementClassifier` validating round-trips and classification rules.
+   - Add Sail-level tests using an in-memory `CassandraGraphStore` mock to ensure add/query/remove flows produce expected statements.
+   - Ensure tests fail before implementation, then implement to make them pass.
+8. Documentation: add README in the module describing configuration, schema creation, and limitations.
+9. Validation: run module tests via Maven (`mvn -pl storage/cassandra-adj -DskipITs=false test`) and ensure lint/format where applicable.
+
+## Concrete Steps
+
+- From repository root, create module directories and POM scaffolding. Update parent POMs to include the new module.
+- Add placeholder interfaces and stub implementations; compile to ensure module structure is sound.
+- Write unit tests that initially fail due to missing logic (ValueEncoding and StatementClassifier behaviors, Sail add/query paths using a fake store).
+- Implement utilities and Sail classes incrementally until tests pass.
+- Add schema DDL and example configuration resources.
+- Run `mvn -pl storage/cassandra-adj test` and address any failures.
+
+## Validation and Acceptance
+
+Acceptance will be demonstrated by running the new module tests. Before implementation, tests should fail because classes are unimplemented. After coding, the same test command (`mvn -pl storage/cassandra-adj test`) should pass, showing that the Sail can encode values, classify statements, and perform basic add/query operations through the mocked store.
+
+## Idempotence and Recovery
+
+All steps are additive. Re-running Maven tests is safe. If module wiring fails, fix POM references and rerun tests. No destructive database operations are executed in tests because Cassandra interactions are mocked.
+
+## Artifacts and Notes
+
+Expect new files under `core/sail/cassandra-adj/src/main/java/` and `src/test/java/`, plus resources for schema and configuration examples. POM updates integrate the module into the build.
+
+## Interfaces and Dependencies
+
+Define interfaces in `core/sail/cassandra-adj/src/main/java/org/eclipse/rdf4j/sail/cassandra/adjacency/`:
+
+    public interface CassandraGraphStore {
+        void applyMutations(List<Statement> adds, List<Statement> removes) throws SailException;
+        CloseableIteration<? extends Statement> queryStatements(Resource subj, IRI pred, Value obj, Resource[] contexts, boolean includeInferred) throws SailException;
+    }
+
+    public interface CassandraSessionManager extends AutoCloseable {
+        CqlSession getSession(GraphNamespaceId namespace);
+        @Override void close();
+    }
+
+Utility classes:
+
+    public final class ValueEncoding { ... }
+    public final class StatementClassifier { ... }
+    public final class NamespaceManager { ... }
+
+Sail classes:
+
+    public class CassandraAdjacencySail extends NotifyingSailBase { ... }
+    public class CassandraAdjacencySailConnection extends NotifyingSailConnectionBase { ... }
+
+These must compile and satisfy the unit tests without requiring a live Cassandra instance.


### PR DESCRIPTION
## Summary
- add new `rdf4j-sail-cassandra-adj` module with Cassandra adjacency Sail scaffolding and namespace utilities
- implement value encoding, statement classification, and in-memory Sail connection wiring for testing
- document progress updates in the execution plan

## Testing
- mvn -pl core/sail/cassandra-adj test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ee5851710832ebc048cbec6812c73)