### PR TITLE
Move LMDB WCOJ benchmarks into LMDB store module

### DIFF
--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/benchmark/LmdbWcojBenchmark.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/benchmark/LmdbWcojBenchmark.java
@@ -1,0 +1,116 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+
+package org.eclipse.rdf4j.sail.lmdb.benchmark;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.io.FileUtils;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.query.TupleQueryResult;
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.sail.lmdb.LmdbStore;
+import org.eclipse.rdf4j.sail.lmdb.config.LmdbStoreConfig;
+import org.eclipse.rdf4j.sail.lmdb.benchmark.WcojDatasetGenerator.GenerationResult;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@Fork(1)
+@State(Scope.Thread)
+@Warmup(iterations = 1)
+@Measurement(iterations = 3)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+public class LmdbWcojBenchmark {
+
+	@Param({ "5000", "20000" })
+	public int triangles;
+
+	@Param({ "2" })
+	public int fanoutPerNode;
+
+	private Path dataDir;
+	private Repository repository;
+	private RepositoryConnection connection;
+	private GenerationResult generationResult;
+
+	@Setup(Level.Trial)
+	public void setup() throws IOException {
+		dataDir = Files.createTempDirectory("lmdb-wcoj-bench");
+
+		LmdbStoreConfig config = new LmdbStoreConfig("spoc,psoc,opsc");
+		repository = new SailRepository(new LmdbStore(dataDir.toFile(), config));
+		repository.init();
+
+		try (RepositoryConnection setupConnection = repository.getConnection()) {
+			WcojDatasetGenerator generator = new WcojDatasetGenerator(setupConnection.getValueFactory());
+			generationResult = generator.generate(setupConnection, triangles, fanoutPerNode);
+		}
+
+		connection = repository.getConnection();
+	}
+
+	@TearDown(Level.Trial)
+	public void tearDown() throws IOException {
+		connection.close();
+		repository.shutDown();
+		FileUtils.deleteDirectory(dataDir.toFile());
+	}
+
+	@Benchmark
+	public void triangleCount(Blackhole blackhole) {
+		blackhole.consume(runCountQuery(WcojBenchmarkQueries.TRIANGLE_COUNT_QUERY));
+	}
+
+	@Benchmark
+	public void fourCycleCount(Blackhole blackhole) {
+		blackhole.consume(runCountQuery(WcojBenchmarkQueries.FOUR_CYCLE_COUNT_QUERY));
+	}
+
+	public long runCountQuery(String query) {
+		try (TupleQueryResult result = connection.prepareTupleQuery(query).evaluate()) {
+			if (result.hasNext()) {
+				Literal count = (Literal) result.next().getValue("count");
+				return count.longValue();
+			}
+			return 0L;
+		}
+	}
+
+	public GenerationResult getGenerationResult() {
+		return generationResult;
+	}
+
+	public static void main(String[] args) throws RunnerException {
+		String regex = ".*" + LmdbWcojBenchmark.class.getSimpleName() + ".*";
+		new Runner(new OptionsBuilder().include(regex).build()).run();
+	}
+}

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/benchmark/LmdbWcojDatasetGeneratorTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/benchmark/LmdbWcojDatasetGeneratorTest.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+
+package org.eclipse.rdf4j.sail.lmdb.benchmark;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+
+import org.eclipse.rdf4j.sail.lmdb.benchmark.WcojBenchmarkQueries;
+import org.eclipse.rdf4j.sail.lmdb.benchmark.WcojDatasetGenerator;
+import org.eclipse.rdf4j.sail.lmdb.benchmark.WcojDatasetGenerator.GenerationResult;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.sail.lmdb.LmdbStore;
+import org.eclipse.rdf4j.sail.lmdb.config.LmdbStoreConfig;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class LmdbWcojDatasetGeneratorTest {
+
+        @TempDir
+        File dataDir;
+
+        @Test
+        void generatorBuildsCyclicDataAndQueriesReturnExpectedCounts() {
+                SailRepository repository = new SailRepository(new LmdbStore(dataDir, new LmdbStoreConfig("spoc,psoc,opsc")));
+                repository.init();
+
+                GenerationResult result;
+                try (RepositoryConnection connection = repository.getConnection()) {
+                        WcojDatasetGenerator generator = new WcojDatasetGenerator(connection.getValueFactory());
+                        result = generator.generate(connection, 5, 2);
+                }
+
+                assertThat(result.getTriangleCount()).isEqualTo(5);
+                assertThat(result.getStatementCount()).isEqualTo(5L * (5 + (4 * 2)));
+
+                try (RepositoryConnection connection = repository.getConnection()) {
+                        long triangleCount = connection.prepareTupleQuery(WcojBenchmarkQueries.TRIANGLE_COUNT_QUERY)
+                                        .evaluate()
+                                        .stream()
+                                        .findFirst()
+                                        .map(binding -> binding.getValue("count"))
+                                        .map(value -> value.stringValue())
+                                        .map(Long::parseLong)
+                                        .orElseThrow();
+
+                        long fourCycleCount = connection.prepareTupleQuery(WcojBenchmarkQueries.FOUR_CYCLE_COUNT_QUERY)
+                                        .evaluate()
+                                        .stream()
+                                        .findFirst()
+                                        .map(binding -> binding.getValue("count"))
+                                        .map(value -> value.stringValue())
+                                        .map(Long::parseLong)
+                                        .orElseThrow();
+
+                        assertThat(triangleCount).isEqualTo(5);
+                        assertThat(fourCycleCount).isEqualTo(5);
+                } finally {
+                        repository.shutDown();
+                }
+        }
+}

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/benchmark/WcojBenchmarkQueries.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/benchmark/WcojBenchmarkQueries.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+
+package org.eclipse.rdf4j.sail.lmdb.benchmark;
+
+/**
+ * SPARQL query templates used by the LMDB WCOJ benchmarks and tests.
+ */
+public final class WcojBenchmarkQueries {
+
+	public static final String NAMESPACE = "http://example.org/wcoj/";
+
+	public static final String TRIANGLE_COUNT_QUERY = "SELECT (COUNT(*) AS ?count) WHERE { "
+			+ "?a <" + NAMESPACE + "connected> ?b . "
+			+ "?b <" + NAMESPACE + "connected> ?c . "
+			+ "?c <" + NAMESPACE + "connected> ?a . "
+			+ "FILTER(STR(?a) < STR(?b) && STR(?b) < STR(?c)) }";
+
+	public static final String FOUR_CYCLE_COUNT_QUERY = "SELECT (COUNT(*) AS ?count) WHERE { "
+			+ "?a <" + NAMESPACE + "connected> ?b . "
+			+ "?b <" + NAMESPACE + "connected> ?c . "
+			+ "?c <" + NAMESPACE + "connected> ?d . "
+			+ "?d <" + NAMESPACE + "connected> ?a . "
+			+ "FILTER(STR(?a) < STR(?b) && STR(?b) < STR(?c) && STR(?c) < STR(?d)) }";
+
+	private WcojBenchmarkQueries() {
+		// utility
+	}
+}

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/benchmark/WcojDatasetGenerator.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/benchmark/WcojDatasetGenerator.java
@@ -1,0 +1,120 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+
+package org.eclipse.rdf4j.sail.lmdb.benchmark;
+
+import java.util.Objects;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+
+/**
+ * Deterministic data generator for producing cyclic join workloads that benefit worst-case optimal joins.
+ */
+public class WcojDatasetGenerator {
+
+	private static final String CONNECTED_LOCAL_NAME = "connected";
+	private static final String TAG_LOCAL_NAME = "tag";
+
+	private final ValueFactory valueFactory;
+	private final String seedToken;
+	private final IRI connected;
+	private final IRI tag;
+
+	public WcojDatasetGenerator(ValueFactory valueFactory) {
+		this(valueFactory, 24L);
+	}
+
+	public WcojDatasetGenerator(ValueFactory valueFactory, long seed) {
+		this.valueFactory = Objects.requireNonNull(valueFactory, "valueFactory");
+		this.seedToken = Long.toHexString(seed);
+		this.connected = valueFactory.createIRI(WcojBenchmarkQueries.NAMESPACE, CONNECTED_LOCAL_NAME);
+		this.tag = valueFactory.createIRI(WcojBenchmarkQueries.NAMESPACE, TAG_LOCAL_NAME);
+	}
+
+	public GenerationResult generate(RepositoryConnection connection, int triangleCount, int fanoutPerNode) {
+		Objects.requireNonNull(connection, "connection");
+		if (triangleCount <= 0) {
+			throw new IllegalArgumentException("triangleCount must be positive");
+		}
+		if (fanoutPerNode < 0) {
+			throw new IllegalArgumentException("fanoutPerNode may not be negative");
+		}
+
+		connection.begin();
+		long statements = 0;
+		for (int i = 0; i < triangleCount; i++) {
+			IRI a = vertex("a", i);
+			IRI b = vertex("b", i);
+			IRI c = vertex("c", i);
+			IRI d = vertex("d", i);
+
+			statements += addEdge(connection, a, b);
+			statements += addEdge(connection, b, c);
+			statements += addEdge(connection, c, a);
+			statements += addEdge(connection, c, d);
+			statements += addEdge(connection, d, a);
+
+			statements += attachFanout(connection, a, i, fanoutPerNode, "a");
+			statements += attachFanout(connection, b, i, fanoutPerNode, "b");
+			statements += attachFanout(connection, c, i, fanoutPerNode, "c");
+			statements += attachFanout(connection, d, i, fanoutPerNode, "d");
+		}
+		connection.commit();
+		return new GenerationResult(triangleCount, fanoutPerNode, statements);
+	}
+
+	private long attachFanout(RepositoryConnection connection, IRI node, int triangleId, int fanoutPerNode,
+			String nodeLabel) {
+		long additions = 0;
+		for (int i = 0; i < fanoutPerNode; i++) {
+			Literal detail = valueFactory.createLiteral(seedToken + "-t-" + triangleId + '-' + nodeLabel + '-' + i);
+			connection.add(node, tag, detail);
+			additions++;
+		}
+		return additions;
+	}
+
+	private long addEdge(RepositoryConnection connection, IRI from, IRI to) {
+		connection.add(from, connected, to);
+		return 1;
+	}
+
+	private IRI vertex(String prefix, int id) {
+		return valueFactory.createIRI(WcojBenchmarkQueries.NAMESPACE, prefix + '-' + id);
+	}
+
+	public static final class GenerationResult {
+		private final int triangleCount;
+		private final int fanoutPerNode;
+		private final long statementCount;
+
+		private GenerationResult(int triangleCount, int fanoutPerNode, long statementCount) {
+			this.triangleCount = triangleCount;
+			this.fanoutPerNode = fanoutPerNode;
+			this.statementCount = statementCount;
+		}
+
+		public int getTriangleCount() {
+			return triangleCount;
+		}
+
+		public int getFanoutPerNode() {
+			return fanoutPerNode;
+		}
+
+		public long getStatementCount() {
+			return statementCount;
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- move the LMDB WCOJ benchmark implementation and dataset generator into the LMDB store module under test sources
- relocate the dataset generator test alongside the store and remove the benchmark-module copies and dependency entry

## Testing
- mvn -pl core/sail/lmdb test *(fails: missing local 5.2.1-SNAPSHOT dependencies for compile)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692176dfedd4832e9ed8f40b54df94d9)