### PR TITLE
Add LMDB LFTJ executor and integration tests

### DIFF
--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/lftj/IndexSelector.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/lftj/IndexSelector.java
@@ -1,0 +1,135 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.lmdb.lftj;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Chooses an index order for a pattern using the provided variable order as guidance.
+ */
+public final class IndexSelector {
+	private IndexSelector() {
+	}
+
+	public static QuadKeyOrder chooseBestOrder(QuadPattern pattern, List<String> variableOrder,
+			List<QuadKeyOrder> candidates) {
+		Objects.requireNonNull(pattern, "pattern");
+		Objects.requireNonNull(variableOrder, "variableOrder");
+		Objects.requireNonNull(candidates, "candidates");
+		if (candidates.isEmpty()) {
+			throw new IllegalArgumentException("No candidate orders provided");
+		}
+
+		Map<String, Integer> orderIndex = indexMap(variableOrder);
+		Map<String, Slot> variableSlots = pattern.variableSlots();
+		if (variableSlots.isEmpty()) {
+			return candidates.get(0);
+		}
+
+		QuadKeyOrder bestOrder = null;
+		Compatibility bestScore = null;
+
+		for (QuadKeyOrder candidate : candidates) {
+			Compatibility compatibility = compatibilityScore(candidate, variableSlots, orderIndex);
+			if (bestScore == null || isBetter(compatibility, bestScore)) {
+				bestOrder = candidate;
+				bestScore = compatibility;
+			} else if (compatibility.equals(bestScore)
+					&& candidates.indexOf(candidate) < candidates.indexOf(bestOrder)) {
+				bestOrder = candidate;
+				bestScore = compatibility;
+			}
+		}
+
+		return bestOrder;
+	}
+
+	private static Compatibility compatibilityScore(QuadKeyOrder order, Map<String, Slot> variableSlots,
+			Map<String, Integer> orderIndex) {
+		int satisfied = 0;
+		int positionSum = 0;
+		Set<String> variables = variableSlots.keySet();
+
+		for (String variable : variables) {
+			Slot slot = variableSlots.get(variable);
+			int slotPosition = order.indexOf(slot);
+			positionSum += slotPosition;
+			Integer variablePosition = orderIndex.get(variable);
+			if (variablePosition == null) {
+				continue;
+			}
+			if (allEarlierVariablesBeforeSlot(variablePosition, slotPosition, order, variableSlots, orderIndex)) {
+				satisfied++;
+			}
+		}
+		return new Compatibility(satisfied, positionSum);
+	}
+
+	private static boolean allEarlierVariablesBeforeSlot(int variablePosition, int slotPosition, QuadKeyOrder order,
+			Map<String, Slot> variableSlots, Map<String, Integer> orderIndex) {
+		for (Map.Entry<String, Slot> entry : variableSlots.entrySet()) {
+			Integer otherPosition = orderIndex.get(entry.getKey());
+			if (otherPosition == null || otherPosition >= variablePosition) {
+				continue;
+			}
+			if (order.indexOf(entry.getValue()) > slotPosition) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	private static Map<String, Integer> indexMap(List<String> variableOrder) {
+		Map<String, Integer> map = new HashMap<>();
+		for (int i = 0; i < variableOrder.size(); i++) {
+			map.put(variableOrder.get(i), i);
+		}
+		return map;
+	}
+
+	private static boolean isBetter(Compatibility candidate, Compatibility best) {
+		if (candidate.score != best.score) {
+			return candidate.score > best.score;
+		}
+		return candidate.positionSum < best.positionSum;
+	}
+
+	private static final class Compatibility {
+		private final int score;
+		private final int positionSum;
+
+		private Compatibility(int score, int positionSum) {
+			this.score = score;
+			this.positionSum = positionSum;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj) {
+				return true;
+			}
+			if (obj == null || getClass() != obj.getClass()) {
+				return false;
+			}
+			Compatibility other = (Compatibility) obj;
+			return score == other.score && positionSum == other.positionSum;
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(score, positionSum);
+		}
+	}
+}

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/lftj/LFTJExecutor.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/lftj/LFTJExecutor.java
@@ -1,0 +1,181 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.lmdb.lftj;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.LongConsumer;
+
+/**
+ * Executes Leapfrog Triejoin over LMDB-backed quad indexes.
+ */
+public final class LFTJExecutor {
+
+	private final long txn;
+
+	private final Map<QuadKeyOrder, Integer> indexMapping;
+
+	public LFTJExecutor(long txn, Map<QuadKeyOrder, Integer> indexMapping) {
+		this.txn = txn;
+		this.indexMapping = Map.copyOf(Objects.requireNonNull(indexMapping, "indexMapping"));
+		if (this.indexMapping.isEmpty()) {
+			throw new IllegalArgumentException("At least one index must be provided");
+		}
+	}
+
+	public List<Map<String, Long>> evaluate(List<QuadPattern> patterns) throws IOException {
+		Objects.requireNonNull(patterns, "patterns");
+		List<String> variableOrder = chooseVariableOrder(patterns);
+		Map<QuadPattern, QuadKeyOrder> chosenOrders = chooseOrders(patterns, variableOrder);
+		List<Map<String, Long>> results = new ArrayList<>();
+		recurse(variableOrder, 0, patterns, chosenOrders, new HashMap<>(), results);
+		return results;
+	}
+
+	public static List<String> chooseVariableOrder(List<QuadPattern> patterns) {
+		Objects.requireNonNull(patterns, "patterns");
+		Map<String, Integer> frequency = new HashMap<>();
+		for (QuadPattern pattern : patterns) {
+			for (String variable : pattern.variables()) {
+				frequency.merge(variable, 1, Integer::sum);
+			}
+		}
+		List<String> order = new ArrayList<>(frequency.keySet());
+		order.sort(Comparator.<String>comparingInt(var -> frequency.getOrDefault(var, 0))
+				.reversed()
+				.thenComparing(Comparator.naturalOrder()));
+		return order;
+	}
+
+	private Map<QuadPattern, QuadKeyOrder> chooseOrders(List<QuadPattern> patterns, List<String> variableOrder) {
+		List<QuadKeyOrder> candidates = new ArrayList<>(indexMapping.keySet());
+		Map<QuadPattern, QuadKeyOrder> chosen = new HashMap<>();
+		for (QuadPattern pattern : patterns) {
+			QuadKeyOrder order = IndexSelector.chooseBestOrder(pattern, variableOrder, candidates);
+			chosen.put(pattern, order);
+		}
+		return chosen;
+	}
+
+	private void recurse(List<String> variableOrder, int depth, List<QuadPattern> patterns,
+			Map<QuadPattern, QuadKeyOrder> chosenOrders, Map<String, Long> bindings,
+			List<Map<String, Long>> results) throws IOException {
+		if (depth >= variableOrder.size()) {
+			results.add(Map.copyOf(bindings));
+			return;
+		}
+
+		String variable = variableOrder.get(depth);
+		List<QuadPattern> participating = patternsWithVariable(patterns, variable);
+		List<LMDBTrieIterator> iterators = new ArrayList<>(participating.size());
+		try {
+			for (QuadPattern pattern : participating) {
+				QuadKeyOrder order = chosenOrders.get(pattern);
+				Integer dbi = indexMapping.get(order);
+				if (dbi == null) {
+					throw new IllegalStateException("No DBI registered for order " + order);
+				}
+				Slot slot = pattern.variableSlots().get(variable);
+				Prefix prefix = PrefixBuilder.buildPrefix(pattern, variableOrder, variable, bindings);
+				LMDBTrieIterator iterator = new LMDBTrieIterator(txn, dbi.intValue(), order, slot);
+				iterator.open(prefix);
+				if (iterator.atEnd()) {
+					return;
+				}
+				iterators.add(iterator);
+			}
+
+			try {
+				leapfrog(iterators, value -> {
+					bindings.put(variable, value);
+					try {
+						recurse(variableOrder, depth + 1, patterns, chosenOrders, bindings, results);
+					} catch (IOException e) {
+						throw new EvaluationException(e);
+					}
+				});
+			} catch (EvaluationException e) {
+				throw e.ioException;
+			}
+			bindings.remove(variable);
+		} finally {
+			for (LMDBTrieIterator iterator : iterators) {
+				iterator.close();
+			}
+		}
+	}
+
+	private static final class EvaluationException extends RuntimeException {
+		private static final long serialVersionUID = 1L;
+
+		private final IOException ioException;
+
+		EvaluationException(IOException ioException) {
+			super(ioException);
+			this.ioException = ioException;
+		}
+	}
+
+	private void leapfrog(List<LMDBTrieIterator> iterators, LongConsumer consumer) {
+		if (iterators.isEmpty()) {
+			return;
+		}
+		for (TrieIterator iterator : iterators) {
+			if (iterator.atEnd()) {
+				return;
+			}
+		}
+		iterators.sort(Comparator.comparingLong(TrieIterator::key));
+		while (true) {
+			long maxKey = iterators.get(iterators.size() - 1).key();
+			boolean advanced = false;
+			for (int i = 0; i < iterators.size() - 1; i++) {
+				TrieIterator iterator = iterators.get(i);
+				if (iterator.key() < maxKey) {
+					iterator.seek(maxKey);
+					advanced = true;
+					if (iterator.atEnd()) {
+						return;
+					}
+				}
+			}
+
+			if (!advanced) {
+				consumer.accept(maxKey);
+				for (TrieIterator iterator : iterators) {
+					iterator.next();
+					if (iterator.atEnd()) {
+						return;
+					}
+				}
+			}
+			iterators.sort(Comparator.comparingLong(TrieIterator::key));
+		}
+	}
+
+	private List<QuadPattern> patternsWithVariable(List<QuadPattern> patterns, String variable) {
+		List<QuadPattern> participating = new ArrayList<>();
+		for (QuadPattern pattern : patterns) {
+			if (pattern.variables().contains(variable)) {
+				participating.add(pattern);
+			}
+		}
+		if (participating.isEmpty()) {
+			throw new IllegalArgumentException("Variable not found in any pattern: " + variable);
+		}
+		return participating;
+	}
+}

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/lftj/LMDBTrieIterator.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/lftj/LMDBTrieIterator.java
@@ -1,0 +1,195 @@
+/*******************************************************************************
+* Copyright (c) 2025 Eclipse RDF4J contributors.
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Eclipse Distribution License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/org/documents/edl-v10.php.
+*
+* SPDX-License-Identifier: BSD-3-Clause
+*******************************************************************************/
+package org.eclipse.rdf4j.sail.lmdb.lftj;
+
+import static org.lwjgl.system.MemoryStack.stackPush;
+import static org.lwjgl.util.lmdb.LMDB.MDB_NEXT;
+import static org.lwjgl.util.lmdb.LMDB.MDB_NOTFOUND;
+import static org.lwjgl.util.lmdb.LMDB.MDB_SET_RANGE;
+import static org.lwjgl.util.lmdb.LMDB.MDB_SUCCESS;
+import static org.lwjgl.util.lmdb.LMDB.mdb_cursor_close;
+import static org.lwjgl.util.lmdb.LMDB.mdb_cursor_get;
+import static org.lwjgl.util.lmdb.LMDB.mdb_cursor_open;
+import static org.lwjgl.util.lmdb.LMDB.mdb_strerror;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Objects;
+
+import org.lwjgl.PointerBuffer;
+import org.lwjgl.system.MemoryStack;
+import org.lwjgl.util.lmdb.MDBVal;
+
+/**
+ * LMDB-backed implementation of {@link TrieIterator} for quad indexes.
+ */
+public class LMDBTrieIterator implements TrieIterator, Closeable {
+
+	private final long cursor;
+
+	private final int dbi;
+
+	private final QuadKeyOrder order;
+
+	private final Slot role;
+
+	private final MDBVal keyVal = MDBVal.malloc();
+
+	private final MDBVal dataVal = MDBVal.malloc();
+
+	private final ByteBuffer seekKeyBuffer = ByteBuffer.allocateDirect(Long.BYTES * 4);
+
+	private boolean end = true;
+
+	private Prefix prefix = Prefix.builder().build();
+
+	private QuadKey currentKey;
+
+	public LMDBTrieIterator(long txn, int dbi, QuadKeyOrder order, Slot role) throws IOException {
+		this.dbi = dbi;
+		this.order = Objects.requireNonNull(order, "order");
+		this.role = Objects.requireNonNull(role, "role");
+		try (MemoryStack stack = stackPush()) {
+			PointerBuffer cursorPtr = stack.mallocPointer(1);
+			assertSuccess(mdb_cursor_open(txn, dbi, cursorPtr));
+			this.cursor = cursorPtr.get(0);
+		}
+	}
+
+	@Override
+	public void open(Prefix prefix) {
+		Objects.requireNonNull(prefix, "prefix");
+		this.prefix = prefix;
+		end = false;
+		QuadKey startKey = QuadKeyEncoding.minimalKeyForPrefix(prefix);
+		positionCursor(startKey);
+	}
+
+	@Override
+	public boolean atEnd() {
+		return end;
+	}
+
+	@Override
+	public long key() {
+		if (end) {
+			throw new IllegalStateException("Iterator is at end");
+		}
+		return QuadKeyEncoding.componentForRole(currentKey, role);
+	}
+
+	@Override
+	public void next() {
+		if (end) {
+			return;
+		}
+
+		long currentValue = QuadKeyEncoding.componentForRole(currentKey, role);
+		while (true) {
+			int rc = mdb_cursor_get(cursor, keyVal, dataVal, MDB_NEXT);
+			if (rc == MDB_NOTFOUND) {
+				end = true;
+				return;
+			}
+			assertSuccess(rc);
+			loadCurrentKey();
+			if (!QuadKeyEncoding.matchesPrefix(currentKey, prefix)) {
+				end = true;
+				return;
+			}
+			long newValue = QuadKeyEncoding.componentForRole(currentKey, role);
+			if (newValue != currentValue) {
+				return;
+			}
+		}
+	}
+
+	@Override
+	public void seek(long value) {
+		if (end) {
+			return;
+		}
+		if (value <= QuadKeyEncoding.componentForRole(currentKey, role)) {
+			return;
+		}
+		QuadKey seekKey = buildSeekKey(value);
+		positionCursor(seekKey);
+	}
+
+	@Override
+	public void close() {
+		mdb_cursor_close(cursor);
+	}
+
+	private QuadKey buildSeekKey(long value) {
+		long s = prefix.hasSubject() ? prefix.subject() : QuadKeyEncoding.MIN_TERM_ID;
+		long p = prefix.hasPredicate() ? prefix.predicate() : QuadKeyEncoding.MIN_TERM_ID;
+		long o = prefix.hasObject() ? prefix.object() : QuadKeyEncoding.MIN_TERM_ID;
+		long c = prefix.hasContext() ? prefix.context() : QuadKeyEncoding.MIN_TERM_ID;
+		switch (role) {
+		case S:
+			s = value;
+			break;
+		case P:
+			p = value;
+			break;
+		case O:
+			o = value;
+			break;
+		case C:
+			c = value;
+			break;
+		default:
+			throw new IllegalStateException("Unexpected slot: " + role);
+		}
+		return new QuadKey(s, p, o, c);
+	}
+
+	private void positionCursor(QuadKey targetKey) {
+		byte[] encoded = QuadKeyEncoding.encode(targetKey, order);
+		seekKeyBuffer.clear();
+		seekKeyBuffer.put(encoded);
+		seekKeyBuffer.flip();
+		keyVal.mv_data(seekKeyBuffer);
+		keyVal.mv_size(seekKeyBuffer.remaining());
+		dataVal.mv_data((ByteBuffer) null);
+		dataVal.mv_size(0);
+		int rc = mdb_cursor_get(cursor, keyVal, dataVal, MDB_SET_RANGE);
+		while (true) {
+			if (rc == MDB_NOTFOUND) {
+				end = true;
+				return;
+			}
+			assertSuccess(rc);
+			loadCurrentKey();
+			if (QuadKeyEncoding.matchesPrefix(currentKey, prefix)) {
+				end = false;
+				return;
+			}
+			rc = mdb_cursor_get(cursor, keyVal, dataVal, MDB_NEXT);
+		}
+	}
+
+	private void loadCurrentKey() {
+		ByteBuffer buffer = keyVal.mv_data();
+		byte[] keyBytes = new byte[(int) keyVal.mv_size()];
+		buffer.get(keyBytes);
+		buffer.rewind();
+		currentKey = QuadKeyEncoding.decode(keyBytes, order);
+	}
+
+	private void assertSuccess(int rc) {
+		if (rc != MDB_SUCCESS) {
+			throw new IllegalStateException(mdb_strerror(rc));
+		}
+	}
+}

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/lftj/Prefix.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/lftj/Prefix.java
@@ -1,0 +1,97 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.lmdb.lftj;
+
+import java.util.OptionalLong;
+
+/**
+ * Encapsulates bound quad components for a specific pattern prefix.
+ */
+public final class Prefix {
+	private final OptionalLong subject;
+	private final OptionalLong predicate;
+	private final OptionalLong object;
+	private final OptionalLong context;
+
+	private Prefix(Builder builder) {
+		this.subject = builder.subject;
+		this.predicate = builder.predicate;
+		this.object = builder.object;
+		this.context = builder.context;
+	}
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public boolean hasSubject() {
+		return subject.isPresent();
+	}
+
+	public long subject() {
+		return subject.orElseThrow();
+	}
+
+	public boolean hasPredicate() {
+		return predicate.isPresent();
+	}
+
+	public long predicate() {
+		return predicate.orElseThrow();
+	}
+
+	public boolean hasObject() {
+		return object.isPresent();
+	}
+
+	public long object() {
+		return object.orElseThrow();
+	}
+
+	public boolean hasContext() {
+		return context.isPresent();
+	}
+
+	public long context() {
+		return context.orElseThrow();
+	}
+
+	public static final class Builder {
+		private OptionalLong subject = OptionalLong.empty();
+		private OptionalLong predicate = OptionalLong.empty();
+		private OptionalLong object = OptionalLong.empty();
+		private OptionalLong context = OptionalLong.empty();
+
+		public Builder subject(long value) {
+			this.subject = OptionalLong.of(value);
+			return this;
+		}
+
+		public Builder predicate(long value) {
+			this.predicate = OptionalLong.of(value);
+			return this;
+		}
+
+		public Builder object(long value) {
+			this.object = OptionalLong.of(value);
+			return this;
+		}
+
+		public Builder context(long value) {
+			this.context = OptionalLong.of(value);
+			return this;
+		}
+
+		public Prefix build() {
+			return new Prefix(this);
+		}
+	}
+}

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/lftj/PrefixBuilder.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/lftj/PrefixBuilder.java
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.lmdb.lftj;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Builds {@link Prefix} instances for a pattern at a specific position in the global variable order.
+ */
+public final class PrefixBuilder {
+	private PrefixBuilder() {
+	}
+
+	public static Prefix buildPrefix(QuadPattern pattern, List<String> variableOrder, String currentVariable,
+			Map<String, Long> bindings) {
+		Objects.requireNonNull(pattern, "pattern");
+		Objects.requireNonNull(variableOrder, "variableOrder");
+		Objects.requireNonNull(currentVariable, "currentVariable");
+		Objects.requireNonNull(bindings, "bindings");
+
+		int currentIndex = indexOf(variableOrder, currentVariable);
+		Prefix.Builder prefix = Prefix.builder();
+
+		assignSlot(prefix, Slot.S, pattern.term(Slot.S), variableOrder, bindings, currentIndex);
+		assignSlot(prefix, Slot.P, pattern.term(Slot.P), variableOrder, bindings, currentIndex);
+		assignSlot(prefix, Slot.O, pattern.term(Slot.O), variableOrder, bindings, currentIndex);
+		assignSlot(prefix, Slot.C, pattern.term(Slot.C), variableOrder, bindings, currentIndex);
+
+		return prefix.build();
+	}
+
+	private static void assignSlot(Prefix.Builder prefix, Slot slot, QuadPatternTerm term, List<String> variableOrder,
+			Map<String, Long> bindings, int currentIndex) {
+		if (term.isConstant()) {
+			write(prefix, slot, term.constant());
+			return;
+		}
+
+		int termIndex = indexOf(variableOrder, term.variable());
+		if (termIndex < currentIndex) {
+			Long boundValue = bindings.get(term.variable());
+			if (boundValue != null) {
+				write(prefix, slot, boundValue);
+			}
+		}
+	}
+
+	private static void write(Prefix.Builder prefix, Slot slot, long value) {
+		switch (slot) {
+		case S:
+			prefix.subject(value);
+			break;
+		case P:
+			prefix.predicate(value);
+			break;
+		case O:
+			prefix.object(value);
+			break;
+		case C:
+			prefix.context(value);
+			break;
+		default:
+			throw new IllegalArgumentException("Unknown slot: " + slot);
+		}
+	}
+
+	private static int indexOf(List<String> variableOrder, String variable) {
+		int idx = variableOrder.indexOf(variable);
+		if (idx < 0) {
+			throw new IllegalArgumentException("Variable not present in order: " + variable);
+		}
+		return idx;
+	}
+}

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/lftj/QuadKey.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/lftj/QuadKey.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.lmdb.lftj;
+
+import java.util.Objects;
+
+/**
+ * Immutable tuple representing a quad key with subject, predicate, object, and context identifiers.
+ */
+public final class QuadKey {
+	private final long s;
+	private final long p;
+	private final long o;
+	private final long c;
+
+	public QuadKey(long s, long p, long o, long c) {
+		this.s = s;
+		this.p = p;
+		this.o = o;
+		this.c = c;
+	}
+
+	public long s() {
+		return s;
+	}
+
+	public long p() {
+		return p;
+	}
+
+	public long o() {
+		return o;
+	}
+
+	public long c() {
+		return c;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (!(o instanceof QuadKey)) {
+			return false;
+		}
+		QuadKey quadKey = (QuadKey) o;
+		return s == quadKey.s && p == quadKey.p && this.o == quadKey.o && c == quadKey.c;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(s, p, o, c);
+	}
+
+	@Override
+	public String toString() {
+		return "QuadKey{" + "s=" + s + ", p=" + p + ", o=" + o + ", c=" + c + '}';
+	}
+}

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/lftj/QuadKeyEncoding.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/lftj/QuadKeyEncoding.java
@@ -1,0 +1,111 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.lmdb.lftj;
+
+import java.nio.ByteBuffer;
+import java.util.Objects;
+
+/**
+ * Utility methods for encoding and decoding quad keys according to a {@link QuadKeyOrder}.
+ */
+public final class QuadKeyEncoding {
+	public static final long MIN_TERM_ID = 0L;
+
+	private QuadKeyEncoding() {
+	}
+
+	public static byte[] encode(QuadKey key, QuadKeyOrder order) {
+		Objects.requireNonNull(key, "key");
+		Objects.requireNonNull(order, "order");
+		ByteBuffer buffer = ByteBuffer.allocate(Long.BYTES * 4);
+		for (int i = 0; i < 4; i++) {
+			Slot slot = order.positionAt(i);
+			buffer.putLong(componentForRole(key, slot));
+		}
+		return buffer.array();
+	}
+
+	public static QuadKey decode(byte[] bytes, QuadKeyOrder order) {
+		Objects.requireNonNull(bytes, "bytes");
+		Objects.requireNonNull(order, "order");
+		if (bytes.length != Long.BYTES * 4) {
+			throw new IllegalArgumentException("QuadKey encoding must be 32 bytes");
+		}
+		long s = 0;
+		long p = 0;
+		long o = 0;
+		long c = 0;
+		ByteBuffer buffer = ByteBuffer.wrap(bytes);
+		for (int i = 0; i < 4; i++) {
+			long value = buffer.getLong();
+			Slot slot = order.positionAt(i);
+			switch (slot) {
+			case S:
+				s = value;
+				break;
+			case P:
+				p = value;
+				break;
+			case O:
+				o = value;
+				break;
+			case C:
+				c = value;
+				break;
+			default:
+				throw new IllegalStateException("Unexpected slot: " + slot);
+			}
+		}
+		return new QuadKey(s, p, o, c);
+	}
+
+	public static boolean matchesPrefix(QuadKey key, Prefix prefix) {
+		Objects.requireNonNull(key, "key");
+		Objects.requireNonNull(prefix, "prefix");
+		if (prefix.hasSubject() && key.s() != prefix.subject()) {
+			return false;
+		}
+		if (prefix.hasPredicate() && key.p() != prefix.predicate()) {
+			return false;
+		}
+		if (prefix.hasObject() && key.o() != prefix.object()) {
+			return false;
+		}
+		if (prefix.hasContext() && key.c() != prefix.context()) {
+			return false;
+		}
+		return true;
+	}
+
+	public static QuadKey minimalKeyForPrefix(Prefix prefix) {
+		Objects.requireNonNull(prefix, "prefix");
+		long s = prefix.hasSubject() ? prefix.subject() : MIN_TERM_ID;
+		long p = prefix.hasPredicate() ? prefix.predicate() : MIN_TERM_ID;
+		long o = prefix.hasObject() ? prefix.object() : MIN_TERM_ID;
+		long c = prefix.hasContext() ? prefix.context() : MIN_TERM_ID;
+		return new QuadKey(s, p, o, c);
+	}
+
+	public static long componentForRole(QuadKey key, Slot role) {
+		switch (role) {
+		case S:
+			return key.s();
+		case P:
+			return key.p();
+		case O:
+			return key.o();
+		case C:
+			return key.c();
+		default:
+			throw new IllegalStateException("Unexpected slot: " + role);
+		}
+	}
+}

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/lftj/QuadKeyOrder.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/lftj/QuadKeyOrder.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.lmdb.lftj;
+
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Describes the positional order of quad components inside an index key.
+ */
+public final class QuadKeyOrder {
+	private static final int KEY_LENGTH = 4;
+
+	private final Slot[] positions;
+
+	private QuadKeyOrder(Slot[] positions) {
+		this.positions = positions;
+	}
+
+	public static QuadKeyOrder of(Slot... positions) {
+		Objects.requireNonNull(positions, "positions");
+		if (positions.length != KEY_LENGTH) {
+			throw new IllegalArgumentException("QuadKeyOrder must contain exactly four slots");
+		}
+		EnumSet<Slot> unique = EnumSet.noneOf(Slot.class);
+		unique.addAll(Arrays.asList(positions));
+		if (unique.size() != KEY_LENGTH) {
+			throw new IllegalArgumentException("QuadKeyOrder must contain each slot exactly once");
+		}
+		return new QuadKeyOrder(Arrays.copyOf(positions, positions.length));
+	}
+
+	public List<Slot> positions() {
+		return List.copyOf(Arrays.asList(positions));
+	}
+
+	public Slot positionAt(int index) {
+		return positions[index];
+	}
+
+	public int indexOf(Slot slot) {
+		for (int i = 0; i < positions.length; i++) {
+			if (positions[i] == slot) {
+				return i;
+			}
+		}
+		return -1;
+	}
+}

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/lftj/QuadPattern.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/lftj/QuadPattern.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.lmdb.lftj;
+
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Describes a quad pattern with per-slot variables or constants.
+ */
+public final class QuadPattern {
+	private final Map<Slot, QuadPatternTerm> terms;
+	private final Map<String, Slot> variableSlots;
+
+	private QuadPattern(QuadPatternTerm subject, QuadPatternTerm predicate, QuadPatternTerm object,
+			QuadPatternTerm context) {
+		terms = new EnumMap<>(Slot.class);
+		terms.put(Slot.S, Objects.requireNonNull(subject, "subject"));
+		terms.put(Slot.P, Objects.requireNonNull(predicate, "predicate"));
+		terms.put(Slot.O, Objects.requireNonNull(object, "object"));
+		terms.put(Slot.C, Objects.requireNonNull(context, "context"));
+		variableSlots = computeVariableSlots();
+	}
+
+	public static QuadPattern of(QuadPatternTerm subject, QuadPatternTerm predicate, QuadPatternTerm object,
+			QuadPatternTerm context) {
+		return new QuadPattern(subject, predicate, object, context);
+	}
+
+	public QuadPatternTerm term(Slot slot) {
+		return terms.get(slot);
+	}
+
+	public Optional<Slot> slotOfVariable(String variable) {
+		return Optional.ofNullable(variableSlots.get(variable));
+	}
+
+	public Set<String> variables() {
+		return Collections.unmodifiableSet(variableSlots.keySet());
+	}
+
+	public Map<String, Slot> variableSlots() {
+		return Collections.unmodifiableMap(variableSlots);
+	}
+
+	private Map<String, Slot> computeVariableSlots() {
+		Map<String, Slot> slots = new HashMap<>();
+		for (Map.Entry<Slot, QuadPatternTerm> entry : terms.entrySet()) {
+			QuadPatternTerm term = entry.getValue();
+			if (term.isVariable()) {
+				slots.put(term.variable(), entry.getKey());
+			}
+		}
+		return slots;
+	}
+}

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/lftj/QuadPatternTerm.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/lftj/QuadPatternTerm.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.lmdb.lftj;
+
+import java.util.Objects;
+
+/**
+ * Represents a single quad component inside a {@link QuadPattern}. The component is either a constant term id or a
+ * named query variable.
+ */
+public final class QuadPatternTerm {
+	private final Long constant;
+	private final String variable;
+
+	private QuadPatternTerm(Long constant, String variable) {
+		this.constant = constant;
+		this.variable = variable;
+	}
+
+	public static QuadPatternTerm constant(long value) {
+		return new QuadPatternTerm(value, null);
+	}
+
+	public static QuadPatternTerm variable(String name) {
+		Objects.requireNonNull(name, "name");
+		return new QuadPatternTerm(null, name);
+	}
+
+	public boolean isConstant() {
+		return constant != null;
+	}
+
+	public boolean isVariable() {
+		return variable != null;
+	}
+
+	public long constant() {
+		if (constant == null) {
+			throw new IllegalStateException("Term is not a constant");
+		}
+		return constant;
+	}
+
+	public String variable() {
+		if (variable == null) {
+			throw new IllegalStateException("Term is not a variable");
+		}
+		return variable;
+	}
+}

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/lftj/Slot.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/lftj/Slot.java
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.lmdb.lftj;
+
+/**
+ * Logical slots for quad components. The ordering of these slots inside a {@link QuadKeyOrder} determines how quad IDs
+ * are laid out in LMDB index keys.
+ */
+public enum Slot {
+	S,
+	P,
+	O,
+	C
+}

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/lftj/TrieIterator.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/lftj/TrieIterator.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.lmdb.lftj;
+
+/**
+ * Iterator abstraction over trie-like navigation of quad components.
+ */
+public interface TrieIterator {
+	void open(Prefix prefix);
+
+	boolean atEnd();
+
+	long key();
+
+	void next();
+
+	void seek(long value);
+}

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/lftj/LFTJExecutionTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/lftj/LFTJExecutionTest.java
@@ -1,0 +1,220 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.lmdb.lftj;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.lwjgl.system.MemoryStack.stackPush;
+import static org.lwjgl.util.lmdb.LMDB.MDB_CREATE;
+import static org.lwjgl.util.lmdb.LMDB.MDB_NOSUBDIR;
+import static org.lwjgl.util.lmdb.LMDB.MDB_NOTFOUND;
+import static org.lwjgl.util.lmdb.LMDB.MDB_RDONLY;
+import static org.lwjgl.util.lmdb.LMDB.MDB_SUCCESS;
+import static org.lwjgl.util.lmdb.LMDB.mdb_dbi_open;
+import static org.lwjgl.util.lmdb.LMDB.mdb_env_close;
+import static org.lwjgl.util.lmdb.LMDB.mdb_env_create;
+import static org.lwjgl.util.lmdb.LMDB.mdb_env_open;
+import static org.lwjgl.util.lmdb.LMDB.mdb_env_set_mapsize;
+import static org.lwjgl.util.lmdb.LMDB.mdb_env_set_maxdbs;
+import static org.lwjgl.util.lmdb.LMDB.mdb_put;
+import static org.lwjgl.util.lmdb.LMDB.mdb_strerror;
+import static org.lwjgl.util.lmdb.LMDB.mdb_txn_abort;
+import static org.lwjgl.util.lmdb.LMDB.mdb_txn_begin;
+import static org.lwjgl.util.lmdb.LMDB.mdb_txn_commit;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.IntBuffer;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.lwjgl.PointerBuffer;
+import org.lwjgl.system.MemoryStack;
+import org.lwjgl.system.MemoryUtil;
+import org.lwjgl.util.lmdb.MDBVal;
+
+class LFTJExecutionTest {
+
+	private static final QuadKeyOrder SPOC = QuadKeyOrder.of(Slot.S, Slot.P, Slot.O, Slot.C);
+
+	@TempDir
+	Path tempDir;
+
+	private long env;
+	private int dbi;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		env = createEnvironment(tempDir);
+		dbi = openDatabase(env, "spoc");
+		insertQuad(new QuadKey(1L, 2L, 3L, 0L));
+		insertQuad(new QuadKey(1L, 2L, 4L, 0L));
+		insertQuad(new QuadKey(2L, 2L, 4L, 0L));
+		insertQuad(new QuadKey(3L, 4L, 5L, 0L));
+		insertQuad(new QuadKey(4L, 4L, 5L, 0L));
+		insertQuad(new QuadKey(10L, 1L, 11L, 0L));
+		insertQuad(new QuadKey(11L, 2L, 12L, 0L));
+		insertQuad(new QuadKey(12L, 3L, 10L, 0L));
+	}
+
+	@AfterEach
+	void tearDown() {
+		if (env != 0) {
+			mdb_env_close(env);
+		}
+	}
+
+	@Test
+	void choosesVariableOrderByFrequency() {
+		QuadPattern first = QuadPattern.of(
+				QuadPatternTerm.variable("s"),
+				QuadPatternTerm.constant(2L),
+				QuadPatternTerm.variable("o"),
+				QuadPatternTerm.constant(0L));
+
+		QuadPattern second = QuadPattern.of(
+				QuadPatternTerm.variable("o"),
+				QuadPatternTerm.constant(4L),
+				QuadPatternTerm.variable("x"),
+				QuadPatternTerm.constant(0L));
+
+		List<String> order = LFTJExecutor.chooseVariableOrder(List.of(first, second));
+
+		assertThat(order).containsExactly("o", "s", "x");
+	}
+
+	@Test
+	void evaluatesChainJoinAgainstLMDBIndexes() throws Exception {
+		QuadPattern first = QuadPattern.of(
+				QuadPatternTerm.variable("s"),
+				QuadPatternTerm.constant(2L),
+				QuadPatternTerm.variable("o"),
+				QuadPatternTerm.constant(0L));
+
+		QuadPattern second = QuadPattern.of(
+				QuadPatternTerm.variable("o"),
+				QuadPatternTerm.constant(4L),
+				QuadPatternTerm.variable("x"),
+				QuadPatternTerm.constant(0L));
+
+		try (MemoryStack stack = stackPush()) {
+			long txn = beginReadTransaction(stack);
+			try {
+				LFTJExecutor executor = new LFTJExecutor(txn, Map.of(SPOC, dbi));
+				List<Map<String, Long>> results = executor.evaluate(List.of(first, second));
+
+				assertThat(results).containsExactlyInAnyOrder(
+						Map.of("o", 3L, "s", 1L, "x", 5L),
+						Map.of("o", 4L, "s", 1L, "x", 5L),
+						Map.of("o", 4L, "s", 2L, "x", 5L));
+			} finally {
+				mdb_txn_abort(txn);
+			}
+		}
+	}
+
+	@Test
+	void evaluatesTriangleJoin() throws Exception {
+		QuadPattern first = QuadPattern.of(
+				QuadPatternTerm.variable("a"),
+				QuadPatternTerm.constant(1L),
+				QuadPatternTerm.variable("b"),
+				QuadPatternTerm.constant(0L));
+
+		QuadPattern second = QuadPattern.of(
+				QuadPatternTerm.variable("b"),
+				QuadPatternTerm.constant(2L),
+				QuadPatternTerm.variable("c"),
+				QuadPatternTerm.constant(0L));
+
+		QuadPattern third = QuadPattern.of(
+				QuadPatternTerm.variable("c"),
+				QuadPatternTerm.constant(3L),
+				QuadPatternTerm.variable("a"),
+				QuadPatternTerm.constant(0L));
+
+		try (MemoryStack stack = stackPush()) {
+			long txn = beginReadTransaction(stack);
+			try {
+				LFTJExecutor executor = new LFTJExecutor(txn, Map.of(SPOC, dbi));
+				List<Map<String, Long>> results = executor.evaluate(List.of(first, second, third));
+
+				assertThat(results).containsExactly(Map.of(
+						"a", 10L,
+						"b", 11L,
+						"c", 12L));
+			} finally {
+				mdb_txn_abort(txn);
+			}
+		}
+	}
+
+	private long createEnvironment(Path path) throws IOException {
+		try (MemoryStack stack = stackPush()) {
+			PointerBuffer envPtr = stack.mallocPointer(1);
+			assertSuccess(mdb_env_create(envPtr));
+			long createdEnv = envPtr.get(0);
+			mdb_env_set_maxdbs(createdEnv, 4);
+			mdb_env_set_mapsize(createdEnv, 16 * 1024 * 1024);
+			Path envFile = path.resolve("env.lmdb");
+			assertSuccess(mdb_env_open(createdEnv, envFile.toString(), MDB_NOSUBDIR, 0664));
+			return createdEnv;
+		}
+	}
+
+	private int openDatabase(long environment, String name) throws IOException {
+		try (MemoryStack stack = stackPush()) {
+			PointerBuffer txnPtr = stack.mallocPointer(1);
+			assertSuccess(mdb_txn_begin(environment, MemoryUtil.NULL, 0, txnPtr));
+			long txn = txnPtr.get(0);
+			IntBuffer dbiBuf = stack.mallocInt(1);
+			assertSuccess(mdb_dbi_open(txn, name, MDB_CREATE, dbiBuf));
+			assertSuccess(mdb_txn_commit(txn));
+			return dbiBuf.get(0);
+		}
+	}
+
+	private void insertQuad(QuadKey quadKey) throws IOException {
+		byte[] encoded = QuadKeyEncoding.encode(quadKey, SPOC);
+		try (MemoryStack stack = stackPush()) {
+			PointerBuffer txnPtr = stack.mallocPointer(1);
+			assertSuccess(mdb_txn_begin(env, MemoryUtil.NULL, 0, txnPtr));
+			long txn = txnPtr.get(0);
+			MDBVal keyVal = MDBVal.callocStack(stack);
+			MDBVal dataVal = MDBVal.callocStack(stack);
+			ByteBuffer keyBuffer = stack.malloc(encoded.length);
+			keyBuffer.put(encoded);
+			keyBuffer.flip();
+			keyVal.mv_data(keyBuffer);
+			keyVal.mv_size(keyBuffer.remaining());
+			dataVal.mv_size(0);
+			dataVal.mv_data((ByteBuffer) null);
+			assertSuccess(mdb_put(txn, dbi, keyVal, dataVal, 0));
+			assertSuccess(mdb_txn_commit(txn));
+		}
+	}
+
+	private long beginReadTransaction(MemoryStack stack) throws IOException {
+		PointerBuffer txnPtr = stack.mallocPointer(1);
+		assertSuccess(mdb_txn_begin(env, MemoryUtil.NULL, MDB_RDONLY, txnPtr));
+		return txnPtr.get(0);
+	}
+
+	private void assertSuccess(int rc) throws IOException {
+		if (rc != MDB_SUCCESS && rc != MDB_NOTFOUND) {
+			throw new IOException(mdb_strerror(rc));
+		}
+	}
+}

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/lftj/LMDBTrieIteratorTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/lftj/LMDBTrieIteratorTest.java
@@ -1,0 +1,195 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.lmdb.lftj;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.lwjgl.system.MemoryStack.stackPush;
+import static org.lwjgl.util.lmdb.LMDB.MDB_CREATE;
+import static org.lwjgl.util.lmdb.LMDB.MDB_NOSUBDIR;
+import static org.lwjgl.util.lmdb.LMDB.MDB_NOTFOUND;
+import static org.lwjgl.util.lmdb.LMDB.MDB_RDONLY;
+import static org.lwjgl.util.lmdb.LMDB.MDB_SUCCESS;
+import static org.lwjgl.util.lmdb.LMDB.mdb_dbi_open;
+import static org.lwjgl.util.lmdb.LMDB.mdb_env_close;
+import static org.lwjgl.util.lmdb.LMDB.mdb_env_create;
+import static org.lwjgl.util.lmdb.LMDB.mdb_env_open;
+import static org.lwjgl.util.lmdb.LMDB.mdb_env_set_mapsize;
+import static org.lwjgl.util.lmdb.LMDB.mdb_env_set_maxdbs;
+import static org.lwjgl.util.lmdb.LMDB.mdb_put;
+import static org.lwjgl.util.lmdb.LMDB.mdb_strerror;
+import static org.lwjgl.util.lmdb.LMDB.mdb_txn_abort;
+import static org.lwjgl.util.lmdb.LMDB.mdb_txn_begin;
+import static org.lwjgl.util.lmdb.LMDB.mdb_txn_commit;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.IntBuffer;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.lwjgl.PointerBuffer;
+import org.lwjgl.system.MemoryStack;
+import org.lwjgl.system.MemoryUtil;
+import org.lwjgl.util.lmdb.MDBVal;
+
+class LMDBTrieIteratorTest {
+
+	private static final QuadKeyOrder ORDER = QuadKeyOrder.of(Slot.S, Slot.P, Slot.O, Slot.C);
+
+	@TempDir
+	Path tempDir;
+
+	private long env;
+	private int dbi;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		env = createEnvironment(tempDir);
+		dbi = openDatabase(env, "spoc");
+		insertQuad(new QuadKey(1L, 2L, 3L, 0L));
+		insertQuad(new QuadKey(1L, 2L, 3L, 1L));
+		insertQuad(new QuadKey(1L, 2L, 4L, 0L));
+		insertQuad(new QuadKey(2L, 2L, 3L, 0L));
+		insertQuad(new QuadKey(2L, 2L, 3L, 2L));
+		insertQuad(new QuadKey(3L, 2L, 5L, 0L));
+		insertQuad(new QuadKey(4L, 3L, 6L, 0L));
+	}
+
+	@AfterEach
+	void tearDown() {
+		if (env != 0) {
+			mdb_env_close(env);
+		}
+	}
+
+	@Test
+	void deduplicatesValuesWithinPrefix() throws Exception {
+		Prefix prefix = Prefix.builder().predicate(2L).build();
+
+		try (MemoryStack stack = stackPush()) {
+			long txn = beginReadTransaction(stack);
+			try (LMDBTrieIterator iterator = new LMDBTrieIterator(txn, dbi, ORDER, Slot.S)) {
+				iterator.open(prefix);
+				assertThat(collect(iterator)).containsExactly(1L, 2L, 3L);
+			} finally {
+				mdb_txn_abort(txn);
+			}
+		}
+	}
+
+	@Test
+	void seekAdvancesWithinPrefix() throws Exception {
+		Prefix prefix = Prefix.builder().subject(1L).predicate(2L).build();
+
+		try (MemoryStack stack = stackPush()) {
+			long txn = beginReadTransaction(stack);
+			try (LMDBTrieIterator iterator = new LMDBTrieIterator(txn, dbi, ORDER, Slot.O)) {
+				iterator.open(prefix);
+				assertThat(iterator.atEnd()).isFalse();
+				assertThat(iterator.key()).isEqualTo(3L);
+
+				iterator.seek(4L);
+				assertThat(iterator.atEnd()).isFalse();
+				assertThat(iterator.key()).isEqualTo(4L);
+
+				iterator.seek(5L);
+				assertThat(iterator.atEnd()).isTrue();
+			} finally {
+				mdb_txn_abort(txn);
+			}
+		}
+	}
+
+	@Test
+	void openToMissingPrefixMarksEnd() throws Exception {
+		Prefix prefix = Prefix.builder().predicate(99L).build();
+
+		try (MemoryStack stack = stackPush()) {
+			long txn = beginReadTransaction(stack);
+			try (LMDBTrieIterator iterator = new LMDBTrieIterator(txn, dbi, ORDER, Slot.S)) {
+				iterator.open(prefix);
+				assertThat(iterator.atEnd()).isTrue();
+			} finally {
+				mdb_txn_abort(txn);
+			}
+		}
+	}
+
+	private long createEnvironment(Path path) throws IOException {
+		try (MemoryStack stack = stackPush()) {
+			PointerBuffer envPtr = stack.mallocPointer(1);
+			assertSuccess(mdb_env_create(envPtr));
+			long createdEnv = envPtr.get(0);
+			mdb_env_set_maxdbs(createdEnv, 4);
+			mdb_env_set_mapsize(createdEnv, 16 * 1024 * 1024);
+			assertSuccess(mdb_env_open(createdEnv, path.toString(), 0, 0664));
+			return createdEnv;
+		}
+	}
+
+	private int openDatabase(long environment, String name) throws IOException {
+		try (MemoryStack stack = stackPush()) {
+			PointerBuffer txnPtr = stack.mallocPointer(1);
+			assertSuccess(mdb_txn_begin(environment, MemoryUtil.NULL, 0, txnPtr));
+			long txn = txnPtr.get(0);
+			IntBuffer dbiBuf = stack.mallocInt(1);
+			assertSuccess(mdb_dbi_open(txn, name, MDB_CREATE, dbiBuf));
+			assertSuccess(mdb_txn_commit(txn));
+			return dbiBuf.get(0);
+		}
+	}
+
+	private void insertQuad(QuadKey quadKey) throws IOException {
+		byte[] encoded = QuadKeyEncoding.encode(quadKey, ORDER);
+		try (MemoryStack stack = stackPush()) {
+			PointerBuffer txnPtr = stack.mallocPointer(1);
+			assertSuccess(mdb_txn_begin(env, MemoryUtil.NULL, 0, txnPtr));
+			long txn = txnPtr.get(0);
+			MDBVal keyVal = MDBVal.callocStack(stack);
+			MDBVal dataVal = MDBVal.callocStack(stack);
+			ByteBuffer keyBuffer = stack.malloc(encoded.length);
+			keyBuffer.put(encoded);
+			keyBuffer.flip();
+			keyVal.mv_data(keyBuffer);
+			keyVal.mv_size(keyBuffer.remaining());
+			dataVal.mv_size(0);
+			dataVal.mv_data((ByteBuffer) null);
+			assertSuccess(mdb_put(txn, dbi, keyVal, dataVal, 0));
+			assertSuccess(mdb_txn_commit(txn));
+		}
+	}
+
+	private long beginReadTransaction(MemoryStack stack) throws IOException {
+		PointerBuffer txnPtr = stack.mallocPointer(1);
+		assertSuccess(mdb_txn_begin(env, MemoryUtil.NULL, MDB_RDONLY, txnPtr));
+		return txnPtr.get(0);
+	}
+
+	private void assertSuccess(int rc) throws IOException {
+		if (rc != MDB_SUCCESS && rc != MDB_NOTFOUND) {
+			throw new IOException(mdb_strerror(rc));
+		}
+	}
+
+	private List<Long> collect(LMDBTrieIterator iterator) {
+		List<Long> values = new ArrayList<>();
+		while (!iterator.atEnd()) {
+			values.add(iterator.key());
+			iterator.next();
+		}
+		return values;
+	}
+}

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/lftj/PatternIndexMappingTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/lftj/PatternIndexMappingTest.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.lmdb.lftj;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+class PatternIndexMappingTest {
+
+	@Test
+	void buildsPrefixForFirstVariableWithOnlyConstants() {
+		QuadPattern pattern = QuadPattern.of(
+				QuadPatternTerm.variable("s"),
+				QuadPatternTerm.constant(2L),
+				QuadPatternTerm.variable("o"),
+				QuadPatternTerm.constant(9L));
+
+		Prefix prefix = PrefixBuilder.buildPrefix(pattern, List.of("s", "o"), "s", Map.of());
+
+		assertThat(prefix.hasSubject()).isFalse();
+		assertThat(prefix.hasPredicate()).isTrue();
+		assertThat(prefix.predicate()).isEqualTo(2L);
+		assertThat(prefix.hasObject()).isFalse();
+		assertThat(prefix.hasContext()).isTrue();
+		assertThat(prefix.context()).isEqualTo(9L);
+	}
+
+	@Test
+	void buildsPrefixWithEarlierBindingsAndConstants() {
+		QuadPattern pattern = QuadPattern.of(
+				QuadPatternTerm.variable("s"),
+				QuadPatternTerm.constant(2L),
+				QuadPatternTerm.variable("o"),
+				QuadPatternTerm.constant(9L));
+
+		Prefix prefix = PrefixBuilder.buildPrefix(pattern, List.of("s", "o"), "o", Map.of("s", 42L));
+
+		assertThat(prefix.hasSubject()).isTrue();
+		assertThat(prefix.subject()).isEqualTo(42L);
+		assertThat(prefix.hasPredicate()).isTrue();
+		assertThat(prefix.predicate()).isEqualTo(2L);
+		assertThat(prefix.hasObject()).isFalse();
+		assertThat(prefix.hasContext()).isTrue();
+		assertThat(prefix.context()).isEqualTo(9L);
+	}
+
+	@Test
+	void choosesIndexOrderFavouringEarlierVariables() {
+		QuadPattern pattern = QuadPattern.of(
+				QuadPatternTerm.variable("s"),
+				QuadPatternTerm.constant(2L),
+				QuadPatternTerm.variable("o"),
+				QuadPatternTerm.variable("c"));
+
+		List<QuadKeyOrder> orders = List.of(
+				QuadKeyOrder.of(Slot.S, Slot.P, Slot.O, Slot.C),
+				QuadKeyOrder.of(Slot.O, Slot.S, Slot.P, Slot.C),
+				QuadKeyOrder.of(Slot.P, Slot.S, Slot.O, Slot.C));
+
+		QuadKeyOrder chosen = IndexSelector.chooseBestOrder(pattern, List.of("s", "o", "c"), orders);
+
+		assertThat(chosen.positionAt(0)).isEqualTo(Slot.S);
+		assertThat(chosen.positionAt(1)).isEqualTo(Slot.P);
+		assertThat(chosen.positionAt(2)).isEqualTo(Slot.O);
+		assertThat(chosen.positionAt(3)).isEqualTo(Slot.C);
+	}
+}

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/lftj/QuadKeyEncodingTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/lftj/QuadKeyEncodingTest.java
@@ -1,0 +1,111 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.lmdb.lftj;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Field;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class QuadKeyEncodingTest {
+
+	@Test
+	void encodeDecodeRoundTripAcrossOrders() {
+		QuadKey key = new QuadKey(1L, 2L, 3L, 4L);
+		QuadKeyOrder spoc = QuadKeyOrder.of(Slot.S, Slot.P, Slot.O, Slot.C);
+		QuadKeyOrder psoc = QuadKeyOrder.of(Slot.P, Slot.S, Slot.O, Slot.C);
+
+		byte[] spocBytes = QuadKeyEncoding.encode(key, spoc);
+		QuadKey decodedSpoc = QuadKeyEncoding.decode(spocBytes, spoc);
+		assertThat(decodedSpoc).isEqualTo(key);
+
+		byte[] psocBytes = QuadKeyEncoding.encode(key, psoc);
+		QuadKey decodedPsoc = QuadKeyEncoding.decode(psocBytes, psoc);
+		assertThat(decodedPsoc).isEqualTo(key);
+	}
+
+	@Test
+	void positionsReturnsEachSlotInOrder() {
+		QuadKeyOrder order = QuadKeyOrder.of(Slot.S, Slot.P, Slot.O, Slot.C);
+
+		List<Slot> positions = order.positions();
+
+		assertThat(positions).containsExactly(Slot.S, Slot.P, Slot.O, Slot.C);
+	}
+
+	@Test
+	void positionsReturnsDefensiveSnapshot() throws Exception {
+		QuadKeyOrder order = QuadKeyOrder.of(Slot.S, Slot.P, Slot.O, Slot.C);
+
+		List<Slot> snapshot = order.positions();
+
+		Field field = QuadKeyOrder.class.getDeclaredField("positions");
+		field.setAccessible(true);
+		Slot[] internal = (Slot[]) field.get(order);
+		internal[0] = Slot.C;
+
+		assertThat(snapshot).containsExactly(Slot.S, Slot.P, Slot.O, Slot.C);
+	}
+
+	@Test
+	void encodedOrderMatchesIndexLayout() {
+		QuadKey key = new QuadKey(10L, 20L, 30L, 40L);
+		QuadKeyOrder psoc = QuadKeyOrder.of(Slot.P, Slot.S, Slot.O, Slot.C);
+
+		byte[] bytes = QuadKeyEncoding.encode(key, psoc);
+		ByteBuffer buffer = ByteBuffer.wrap(bytes);
+
+		assertThat(buffer.getLong()).isEqualTo(key.p());
+		assertThat(buffer.getLong()).isEqualTo(key.s());
+		assertThat(buffer.getLong()).isEqualTo(key.o());
+		assertThat(buffer.getLong()).isEqualTo(key.c());
+	}
+
+	@Test
+	void matchesPrefixRespectsBoundSlots() {
+		Prefix prefix = Prefix.builder().subject(5L).object(7L).build();
+
+		QuadKey matching = new QuadKey(5L, 9L, 7L, 0L);
+		QuadKey wrongSubject = new QuadKey(6L, 9L, 7L, 0L);
+		QuadKey wrongObject = new QuadKey(5L, 9L, 8L, 0L);
+
+		assertThat(QuadKeyEncoding.matchesPrefix(matching, prefix)).isTrue();
+		assertThat(QuadKeyEncoding.matchesPrefix(wrongSubject, prefix)).isFalse();
+		assertThat(QuadKeyEncoding.matchesPrefix(wrongObject, prefix)).isFalse();
+	}
+
+	@Test
+	void minimalKeyUsesPrefixAndMinimums() {
+		Prefix prefix = Prefix.builder().subject(3L).object(11L).build();
+		QuadKey minimal = QuadKeyEncoding.minimalKeyForPrefix(prefix);
+
+		assertThat(minimal.s()).isEqualTo(3L);
+		assertThat(minimal.p()).isEqualTo(QuadKeyEncoding.MIN_TERM_ID);
+		assertThat(minimal.o()).isEqualTo(11L);
+		assertThat(minimal.c()).isEqualTo(QuadKeyEncoding.MIN_TERM_ID);
+	}
+
+	@Test
+	void lexicographicEncodingRespectsOrder() {
+		QuadKeyOrder spoc = QuadKeyOrder.of(Slot.S, Slot.P, Slot.O, Slot.C);
+		QuadKey smaller = new QuadKey(1L, 2L, 3L, 4L);
+		QuadKey larger = new QuadKey(2L, 1L, 3L, 4L);
+
+		byte[] smallerBytes = QuadKeyEncoding.encode(smaller, spoc);
+		byte[] largerBytes = QuadKeyEncoding.encode(larger, spoc);
+
+		assertThat(Arrays.compareUnsigned(smallerBytes, largerBytes)).isLessThan(0);
+	}
+}

--- a/docs/execplans/lftj-lmdb-execplan.md
+++ b/docs/execplans/lftj-lmdb-execplan.md
@@ -1,0 +1,99 @@
+# LMDB Leapfrog Triejoin (WCOJ) ExecPlan
+
+This ExecPlan is a living document. Maintain it according to PLANS.md and update every section as work proceeds.
+
+If PLANS.md file is checked into the repo, reference the path to that file here from the repository root and note that this document must be maintained in accordance with PLANS.md.
+
+Reference: /PLANS.md (repository root). All guidance and formatting rules in that file apply.
+
+## Purpose / Big Picture
+
+Introduce a worst-case optimal join operator based on Leapfrog Triejoin (LFTJ) for RDF4J's LMDB store. After completing this plan, a user can execute conjunctive/BGP-style queries over LMDB-backed quads using LFTJ: the engine will navigate existing SPOC/PSOC/OSPC/CSPO indexes as tries, intersect variable bindings per global order, and emit bindings without building new persistent structures. Successful implementation means the LMDB store can answer cyclic or join-heavy queries with predictable latency using only existing B+tree indexes.
+
+## Progress
+
+Use a list with checkboxes to summarize granular steps. Every stopping point must be documented here, even if it requires splitting a partially completed task into two ("done" vs. "remaining"). This section must always reflect the actual current state of the work.
+
+- [x] (2025-11-22 08:30Z) Draft ExecPlan capturing goals, scope, and initial milestones.
+- [x] (2025-11-22 09:05Z) Stubbed QuadKey/Prefix/TrieIterator scaffolding and added encoding/prefix unit tests.
+- [x] (2025-11-22 09:24Z) Implemented LMDBTrieIterator around LMDB cursors with open/next/seek semantics and unit coverage.
+- [x] (2025-11-22 14:02Z) Added pattern/index mapping utilities and prefix construction for variable orders with unit tests.
+- [x] (2025-11-22 16:29Z) Implemented LFTJ execution driver and leapfrog intersection wired to iterators with LMDB-backed integration tests for chains and triangles.
+- [ ] Integrate WCOJ operator into planner/runtime with heuristics and end-to-end validation.
+- [ ] Add benchmarks and document outcomes; finalize retrospective.
+
+## Surprises & Discoveries
+
+Document unexpected behaviors, bugs, optimizations, or insights discovered during implementation. Provide concise evidence.
+
+- LMDB `MDB_SET_RANGE` seeks can land on keys that satisfy earlier slots but not later constrained slots (e.g., predicate) when those earlier slots are unbound. The LMDBTrieIterator now advances with `MDB_NEXT` until it finds the first key matching the prefix to avoid premature exhaustion of iterators in LFTJ.
+
+## Decision Log
+
+Record every decision made while working on the plan.
+
+- Decision: Use dedicated `docs/execplans` location for this plan to keep it discoverable outside code packages.
+  Rationale: Keeps living design artifacts organized without interfering with source directories.
+  Date/Author: 2025-11-22 / Assistant
+
+## Outcomes & Retrospective
+
+Summarize outcomes, gaps, and lessons learned at major milestones or at completion. Compare the result against the original purpose.
+
+- Pending initial implementation.
+
+## Context and Orientation
+
+RDF4J's LMDB store lives under `core/sail/lmdb`. Existing code manages triple/quad indexes with LMDB B+trees using varint-encoded IDs. There is currently no LFTJ operator. We will introduce new LFTJ-focused abstractions in a dedicated package (e.g., `org.eclipse.rdf4j.sail.lmdb.lftj`) without altering existing persistent layouts. Key supporting utilities like `Varint`, `LmdbUtil`, and `TripleStore` encode IDs and navigate LMDB cursors; these will stay intact while new code wraps LMDB indexes as trie iterators.
+
+The primary artifacts to add are:
+- Data classes to describe quad keys (`QuadKey`), index orders (`QuadKeyOrder`), and binding prefixes (`Prefix`).
+- A `TrieIterator` interface and an `LMDBTrieIterator` implementation that uses LMDB cursor operations (`MDB_SET_RANGE`, `MDB_NEXT`) to walk index tries.
+- LFTJ execution logic that orders variables, constructs iterators per pattern, performs leapfrog intersection, and emits bindings.
+- Planner/runtime integration to select WCOJ for suitable patterns and maintain LMDB transaction semantics.
+
+## Plan of Work
+
+Work proceeds in incremental milestones that each add observable behavior and associated tests.
+
+1. Define quad-centric data structures and encoding helpers. Add unit tests that validate encode/decode reversibility across index orders and prefix matching behavior. This establishes the foundational representation used by iterators.
+2. Implement `LMDBTrieIterator` that wraps LMDB cursors, supporting `open`, `key`, `next`, `seek`, and `atEnd` with prefix-awareness and value deduplication. Add tests using synthetic LMDB datasets to verify prefix handling and iteration semantics.
+3. Build pattern-to-index mapping utilities and prefix construction functions that respect a chosen global variable order. Validate with synthetic patterns and bindings to ensure prefixes materialize constants and prior bindings correctly.
+4. Implement the LFTJ driver with leapfrog intersection across iterators. Introduce variable-order heuristics and compare results with existing join strategies on small datasets to ensure correctness.
+5. Integrate a WCOJ operator into the planner/runtime with heuristics to decide when to use it. Ensure LMDB transaction handling remains snapshot-consistent and visible in explain plans.
+6. Add benchmarks for cyclic and acyclic query patterns to measure latency, LMDB cursor operations, and storage impact. Document results and update retrospective sections.
+
+## Concrete Steps
+
+State the exact commands to run and where to run them (working directory). Update as work proceeds.
+
+- From repository root, run module tests during each milestone: `mvn -pl core/sail/lmdb -DskipITs test`
+- For LMDB iterator prototyping, create temporary LMDB environments under `target/test-lmdb` and clean them per test.
+- Use `rg` for code search and `mvn -pl core/sail/lmdb -DskipTests compile` for quick compile checks when needed.
+
+## Validation and Acceptance
+
+The change is accepted when:
+- New unit tests for key encoding/prefix handling fail before implementations exist and pass afterward.
+- LMDBTrieIterator tests demonstrate correct prefix-respecting iteration (including `seek` and duplicate skipping).
+- LFTJ execution tests match baseline join outputs on sample data.
+- Planner integration shows WCOJ in explain plans for eligible queries and produces correct bindings under LMDB.
+
+## Idempotence and Recovery
+
+All steps are additive and safe to rerun. LMDB test environments should be created under `target/test-lmdb` and removed between runs to avoid residue. If a migration or refactor fails mid-way, revert using git and re-run the same commands; no destructive operations touch production data structures.
+
+## Artifacts and Notes
+
+As work progresses, include test output snippets, sample bindings, and any LMDB cursor operation counts observed during debugging. Keep evidence concise and focused on demonstrating correctness and performance expectations.
+
+## Interfaces and Dependencies
+
+Prescribed interfaces and types to create:
+- `org.eclipse.rdf4j.sail.lmdb.lftj.Slot` enum with entries `S`, `P`, `O`, `C`.
+- `org.eclipse.rdf4j.sail.lmdb.lftj.QuadKey` holding four long term IDs with getters and constructors.
+- `org.eclipse.rdf4j.sail.lmdb.lftj.QuadKeyOrder` describing position order (array of `Slot`) and helpers for common orders (SPOC, PSOC, OSPC, CSPO, etc.).
+- `org.eclipse.rdf4j.sail.lmdb.lftj.Prefix` capturing bound/unbound flags and values for S/P/O/C with builder-style helpers.
+- `org.eclipse.rdf4j.sail.lmdb.lftj.QuadKeyEncoding` (or equivalent) with `encode`/`decode`, `matchesPrefix`, `componentForRole`, and `minimalKeyForPrefix` utilities using monotone big-endian encoding of long term IDs.
+- `org.eclipse.rdf4j.sail.lmdb.lftj.TrieIterator` interface with methods `open(Prefix)`, `boolean atEnd()`, `long key()`, `void next()`, and `void seek(long)`, designed for variable-at-a-time navigation.
+- `LMDBTrieIterator` implementing `TrieIterator` with LMDB cursor operations and prefix-aware navigation.


### PR DESCRIPTION
## Summary
- add an LMDB-backed Leapfrog Triejoin executor with variable ordering, index selection, recursion, and leapfrog intersection
- extend LMDB trie iteration to advance to the first prefix-matching key, avoiding missed bindings across index orders
- introduce integration tests for variable ordering, chain joins, and triangle joins, and update the LFTJ execplan progress

## Testing
- mvn -pl core/sail/lmdb -DskipITs test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692172c6b888832eb35dab839cb799e6)