### PR TITLE
Handle filters in acyclic join tree builder

### DIFF
--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/optimizer/AcyclicJoinTreeBuilder.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/optimizer/AcyclicJoinTreeBuilder.java
@@ -1,0 +1,194 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ ******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.optimizer;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.eclipse.rdf4j.query.algebra.Filter;
+import org.eclipse.rdf4j.query.algebra.Join;
+import org.eclipse.rdf4j.query.algebra.StatementPattern;
+import org.eclipse.rdf4j.query.algebra.TupleExpr;
+import org.eclipse.rdf4j.query.algebra.Var;
+
+/**
+ * Builds a join tree for acyclic basic graph patterns composed of {@link Join}, {@link Filter}, and
+ * {@link StatementPattern} nodes.
+ */
+public final class AcyclicJoinTreeBuilder {
+
+	private AcyclicJoinTreeBuilder() {
+	}
+
+	public static Optional<JoinTree> build(TupleExpr tupleExpr) {
+		List<StatementPattern> patterns = new ArrayList<>();
+		if (!collectPatterns(tupleExpr, patterns)) {
+			return Optional.empty();
+		}
+
+		Map<StatementPattern, Set<String>> originalVars = buildVarTable(patterns);
+		if (patterns.size() == 1) {
+			JoinTreeNode root = new JoinTreeNode(patterns.get(0));
+			return Optional.of(new JoinTree(root));
+		}
+
+		return buildJoinTree(patterns, originalVars);
+	}
+
+	private static Optional<JoinTree> buildJoinTree(List<StatementPattern> patterns,
+			Map<StatementPattern, Set<String>> originalVars) {
+		List<StatementPattern> workingEdges = new ArrayList<>(patterns);
+		Map<StatementPattern, Set<String>> workingVars = workingEdges.stream()
+				.collect(Collectors.toMap(edge -> edge, edge -> new HashSet<>(originalVars.get(edge))));
+
+		Map<StatementPattern, StatementPattern> parent = new HashMap<>();
+
+		boolean changed;
+		do {
+			changed = false;
+			Map<String, Integer> frequency = variableFrequency(workingVars.values());
+
+			for (StatementPattern edge : new ArrayList<>(workingEdges)) {
+				Set<String> vars = workingVars.get(edge);
+				if (vars.removeIf(v -> frequency.getOrDefault(v, 0) == 1)) {
+					changed = true;
+				}
+			}
+
+			StatementPattern removed = null;
+			StatementPattern parentEdge = null;
+			outer: for (StatementPattern edge : workingEdges) {
+				for (StatementPattern candidateParent : workingEdges) {
+					if (edge == candidateParent) {
+						continue;
+					}
+					Set<String> edgeVars = workingVars.get(edge);
+					Set<String> parentVars = workingVars.get(candidateParent);
+					if (!edgeVars.isEmpty() && parentVars.containsAll(edgeVars)) {
+						removed = edge;
+						parentEdge = candidateParent;
+						break outer;
+					}
+				}
+			}
+
+			if (removed != null) {
+				workingEdges.remove(removed);
+				parent.put(removed, parentEdge);
+				changed = true;
+			}
+		} while (changed && workingEdges.size() > 1);
+
+		if (workingEdges.size() != 1) {
+			boolean allVarsRemoved = workingEdges.stream().allMatch(edge -> workingVars.get(edge).isEmpty());
+			if (!allVarsRemoved) {
+				return Optional.empty();
+			}
+		}
+
+		StatementPattern preferredRoot = patterns.get(0);
+		StatementPattern rootEdge = workingEdges.contains(preferredRoot) ? preferredRoot : workingEdges.get(0);
+		Map<StatementPattern, JoinTreeNode> nodes = new HashMap<>();
+		patterns.forEach(p -> nodes.put(p, new JoinTreeNode(p)));
+
+		Set<StatementPattern> attached = new HashSet<>();
+		for (Map.Entry<StatementPattern, StatementPattern> entry : parent.entrySet()) {
+			StatementPattern child = entry.getKey();
+			StatementPattern parentPattern = entry.getValue();
+			attachChild(nodes, originalVars, parentPattern, child);
+			attached.add(child);
+		}
+
+		for (StatementPattern pattern : patterns) {
+			if (pattern == rootEdge || attached.contains(pattern)) {
+				continue;
+			}
+			attachChild(nodes, originalVars, rootEdge, pattern);
+		}
+
+		return Optional.of(new JoinTree(nodes.get(rootEdge)));
+	}
+
+	private static void attachChild(Map<StatementPattern, JoinTreeNode> nodes,
+			Map<StatementPattern, Set<String>> originalVars,
+			StatementPattern parentPattern, StatementPattern childPattern) {
+		Set<String> joinVars = intersection(originalVars.get(childPattern), originalVars.get(parentPattern));
+		JoinTreeNode childNode = nodes.get(childPattern);
+		childNode.setJoinVariables(joinVars);
+		nodes.get(parentPattern).addChild(childNode);
+	}
+
+	private static Map<StatementPattern, Set<String>> buildVarTable(List<StatementPattern> patterns) {
+		Map<StatementPattern, Set<String>> vars = new HashMap<>();
+		for (StatementPattern pattern : patterns) {
+			vars.put(pattern, extractVarNames(pattern));
+		}
+		return vars;
+	}
+
+	private static boolean collectPatterns(TupleExpr expr, List<StatementPattern> out) {
+		if (expr instanceof Join) {
+			Join join = (Join) expr;
+			return collectPatterns(join.getLeftArg(), out) && collectPatterns(join.getRightArg(), out);
+		}
+
+		if (expr instanceof Filter) {
+			return collectPatterns(((Filter) expr).getArg(), out);
+		}
+
+		if (expr instanceof StatementPattern) {
+			out.add((StatementPattern) expr);
+			return true;
+		}
+
+		return false;
+	}
+
+	private static Map<String, Integer> variableFrequency(Iterable<Set<String>> edgeVars) {
+		Map<String, Integer> frequency = new HashMap<>();
+		for (Set<String> vars : edgeVars) {
+			for (String var : vars) {
+				frequency.merge(var, 1, Integer::sum);
+			}
+		}
+		return frequency;
+	}
+
+	private static Set<String> extractVarNames(StatementPattern pattern) {
+		Set<String> names = new HashSet<>();
+		collectVar(pattern.getSubjectVar(), names);
+		collectVar(pattern.getPredicateVar(), names);
+		collectVar(pattern.getObjectVar(), names);
+		collectVar(pattern.getContextVar(), names);
+		return names;
+	}
+
+	private static void collectVar(Var var, Set<String> names) {
+		if (var != null && !var.hasValue()) {
+			names.add(var.getName());
+		}
+	}
+
+	private static Set<String> intersection(Set<String> left, Set<String> right) {
+		if (left.isEmpty() || right.isEmpty()) {
+			return Set.of();
+		}
+		Set<String> result = new HashSet<>(left);
+		result.retainAll(right);
+		return result;
+	}
+}

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/optimizer/JoinTree.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/optimizer/JoinTree.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ ******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.optimizer;
+
+import java.util.Objects;
+
+/**
+ * A join tree covering an acyclic basic graph pattern.
+ */
+public class JoinTree {
+
+	private final JoinTreeNode root;
+
+	public JoinTree(JoinTreeNode root) {
+		this.root = Objects.requireNonNull(root);
+	}
+
+	public JoinTreeNode getRoot() {
+		return root;
+	}
+}

--- a/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/optimizer/JoinTreeNode.java
+++ b/core/queryalgebra/evaluation/src/main/java/org/eclipse/rdf4j/query/algebra/evaluation/optimizer/JoinTreeNode.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ ******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.optimizer;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+import org.eclipse.rdf4j.query.algebra.StatementPattern;
+
+/**
+ * Node in a join tree for an acyclic basic graph pattern.
+ */
+public class JoinTreeNode {
+
+	private final StatementPattern statementPattern;
+	private final List<JoinTreeNode> children = new ArrayList<>();
+	private Set<String> joinVariables = Collections.emptySet();
+
+	JoinTreeNode(StatementPattern statementPattern) {
+		this.statementPattern = Objects.requireNonNull(statementPattern);
+	}
+
+	public StatementPattern getStatementPattern() {
+		return statementPattern;
+	}
+
+	public List<JoinTreeNode> getChildren() {
+		return children;
+	}
+
+	public Set<String> getJoinVariables() {
+		return joinVariables;
+	}
+
+	void setJoinVariables(Set<String> joinVariables) {
+		this.joinVariables = Set.copyOf(joinVariables);
+	}
+
+	void addChild(JoinTreeNode child) {
+		children.add(child);
+	}
+}

--- a/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/optimizer/AcyclicJoinTreeBuilderTest.java
+++ b/core/queryalgebra/evaluation/src/test/java/org/eclipse/rdf4j/query/algebra/evaluation/optimizer/AcyclicJoinTreeBuilderTest.java
@@ -1,0 +1,117 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ ******************************************************************************/
+package org.eclipse.rdf4j.query.algebra.evaluation.optimizer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.query.algebra.Filter;
+import org.eclipse.rdf4j.query.algebra.Join;
+import org.eclipse.rdf4j.query.algebra.StatementPattern;
+import org.eclipse.rdf4j.query.algebra.TupleExpr;
+import org.eclipse.rdf4j.query.algebra.Var;
+import org.junit.jupiter.api.Test;
+
+class AcyclicJoinTreeBuilderTest {
+
+	private final ValueFactory vf = SimpleValueFactory.getInstance();
+
+	@Test
+	void buildsJoinTreeForAcyclicBgp() {
+		StatementPattern first = statement("a", iri("p1"), "b");
+		StatementPattern second = statement("b", iri("p2"), "c");
+		StatementPattern third = statement("c", iri("p3"), "d");
+
+		TupleExpr bgp = join(first, join(second, third));
+
+		Optional<JoinTree> result = AcyclicJoinTreeBuilder.build(bgp);
+
+		assertThat(result).isPresent();
+		JoinTree tree = result.get();
+
+		JoinTreeNode root = tree.getRoot();
+		assertThat(root.getStatementPattern()).isEqualTo(second);
+		assertThat(root.getJoinVariables()).isEmpty();
+		assertThat(root.getChildren()).hasSize(2);
+		assertThat(root.getChildren())
+				.anySatisfy(node -> {
+					assertThat(node.getStatementPattern()).isEqualTo(first);
+					assertThat(node.getJoinVariables()).containsExactly("b");
+				})
+				.anySatisfy(node -> {
+					assertThat(node.getStatementPattern()).isEqualTo(third);
+					assertThat(node.getJoinVariables()).containsExactly("c");
+				});
+	}
+
+	@Test
+	void returnsEmptyForCyclicBgp() {
+		StatementPattern first = statement("a", iri("p1"), "b");
+		StatementPattern second = statement("b", iri("p2"), "c");
+		StatementPattern third = statement("c", iri("p3"), "a");
+
+		TupleExpr cycle = join(first, join(second, third));
+
+		assertThat(AcyclicJoinTreeBuilder.build(cycle)).isEmpty();
+	}
+
+	@Test
+	void buildsJoinTreeForDisconnectedBgp() {
+		StatementPattern first = statement("a", iri("p1"), "b");
+		StatementPattern second = statement("c", iri("p2"), "d");
+		StatementPattern third = statement("e", iri("p3"), "f");
+
+		TupleExpr disconnected = join(first, join(second, third));
+
+		Optional<JoinTree> result = AcyclicJoinTreeBuilder.build(disconnected);
+
+		assertThat(result).isPresent();
+		JoinTreeNode root = result.get().getRoot();
+		assertThat(root.getJoinVariables()).isEmpty();
+		assertThat(root.getChildren()).hasSize(2);
+		root.getChildren().forEach(child -> assertThat(child.getJoinVariables()).isEmpty());
+	}
+
+	@Test
+	void buildsJoinTreeWhenFiltersArePresent() {
+		StatementPattern first = statement("a", iri("p1"), "b");
+		StatementPattern second = statement("b", iri("p2"), "c");
+
+		TupleExpr filtered = new Filter(join(first, second), new Var("b"));
+
+		Optional<JoinTree> result = AcyclicJoinTreeBuilder.build(filtered);
+
+		assertThat(result).isPresent();
+		JoinTreeNode root = result.get().getRoot();
+		assertThat(root.getStatementPattern()).isEqualTo(second);
+		assertThat(root.getChildren()).singleElement()
+				.satisfies(node -> {
+					assertThat(node.getStatementPattern()).isEqualTo(first);
+					assertThat(node.getJoinVariables()).containsExactly("b");
+				});
+	}
+
+	private TupleExpr join(TupleExpr left, TupleExpr right) {
+		return new Join(left, right);
+	}
+
+	private StatementPattern statement(String subj, IRI pred, String obj) {
+		return new StatementPattern(new Var(subj), new Var(pred.stringValue(), pred), new Var(obj));
+	}
+
+	private IRI iri(String localName) {
+		return vf.createIRI("http://example.org/", localName);
+	}
+}

--- a/notes/yannakakis-plus-integration.md
+++ b/notes/yannakakis-plus-integration.md
@@ -1,0 +1,35 @@
+# Yannakakis+ integration sketch for RDF4J
+
+This note distills the Yannakakis+ algorithm into RDF4J-specific steps so we can prototype an optimizer that rewrites acyclic SPARQL conjunctive queries into a standard relational DAG executed by the existing evaluation pipeline.
+
+## Scope and detection
+- Target SELECT queries whose WHERE clause is a basic graph pattern (BGP) with optional FILTERs and an optional GROUP BY/HAVING.
+- Skip OPTIONAL/UNION/MINUS/VALUES/NOT EXISTS/property paths and any cyclic BGP; fall back to the default optimizers in those cases.
+- In a `QueryOptimizer`, locate maximal BGP subtrees made only of `Join`, `StatementPattern`, and FILTER nodes. Extract their variables to form the hypergraph `H = (V,E)` where each triple pattern is a hyperedge.
+
+## Acyclicity and join tree
+- Apply a GYO-style reduction (Tarjan–Yannakakis) to decide acyclicity and recover a join tree whose nodes are triple patterns and whose edges are labeled by shared variables.
+- If the BGP is acyclic, optionally split into connected components and handle each independently.
+
+## Yannakakis+ plan construction
+- Classify the query per Yannakakis+ (free-connex vs non-free-connex; relation-dominated heuristic to possibly skip semi-joins).
+- Build an internal DAG (e.g., `YOp` records) over scans, filters, semi-joins, joins, aggregation-joins, and aggregations.
+- Push FILTERs to leaves, schedule reduced semi-join passes along the join tree, and place aggregation-joins early when possible to shrink intermediate results.
+
+## Lowering to RDF4J algebra
+- Two lowering strategies:
+  - **Reuse existing operators:** encode semi-joins as `Join` + `Projection` + `Distinct` and agg-joins as `Join` + `Group`. Works with the stock `DefaultEvaluationStrategy` and requires no new nodes.
+  - **Add explicit operators:** define `SemiJoin`/`AggJoin` `TupleExpr` nodes and extend `DefaultEvaluationStrategy` (or `StrictEvaluationStrategy`) to evaluate them with hash-based semi-join logic and partial aggregation. Use RDF4J’s visitor registration hooks so optimizers and renderers recognize the new nodes.
+- Translate the Yannakakis+ DAG back into a `TupleExpr` subtree and splice it into the original algebra in the optimizer.
+- Protect the lowered subtree from `QueryJoinOptimizer` reordering by wrapping it in a sentinel (e.g., a no-op `Slice`) or by teaching `QueryJoinOptimizer` to skip descendants marked with a custom annotation.
+
+## Prototype bring-up checklist
+- Optimizer wiring: add `YannakakisPlusOptimizer` to the optimizer pipeline before `QueryJoinOptimizer` and behind `FilterOptimizer`/`BindingAssignerOptimizer`.
+- Gatekeeping: feature flag + optional SPARQL hint to disable per query; skip cyclic BGPs and any query containing `LeftJoin`, `Union`, `Minus`, `Exists`, `Values`, or property paths.
+- Logging: emit DEBUG logs when a BGP is detected as acyclic, when the Yannakakis+ plan is built, and when the subtree is lowered.
+- Testing: start with unit tests on the join-tree builder and acyclicity detector, then integration tests that optimize/evaluate sample acyclic vs. cyclic queries to verify rewrites and runtime results.
+
+## Execution hooks and safeguards
+- Register the optimizer ahead of `QueryJoinOptimizer` (and ensure it does not reorder protected Yannakakis+ subtrees).
+- Optionally provide a custom `EvaluationStrategy` for efficient semi-join/agg-join execution while still relying on the storage `TripleSource`.
+- Add feature flags/hints to disable Yannakakis+ per query and logging hooks to dump pre/post plans for debugging.


### PR DESCRIPTION
## Summary
- allow the acyclic join tree builder to traverse filter nodes when collecting basic graph patterns
- add a regression test proving filtered acyclic patterns still produce a join tree with the expected join variables

## Testing
- mvn -pl core/queryalgebra/evaluation -DskipITs -Dtest=AcyclicJoinTreeBuilderTest test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69217b65cd60832ea62ddd675b4ccb9c)