### PR TITLE
Add configurable JMH benchmark runner with JFR profiling helpers

### DIFF
--- a/scripts/run-single-benchmark.sh
+++ b/scripts/run-single-benchmark.sh
@@ -12,15 +12,19 @@ Options:
   --forks <number>                  Number of forks (default: 1)
   --jvm-arg <value>                 Append a JVM argument (can be repeated)
   --jmh-arg <value>                 Append a raw JMH argument (can be repeated)
+  --param <name=value>              Lock a JMH @Param to a single value (can be repeated)
   --enable-jfr                      Enable JFR profiling with fixed iteration and timing settings
-  --enable-jfr-cpu-times            Include Java 25 CPU time JFR options (requires --enable-jfr)
+  --jfr-mode <cpu|alloc>            Choose CPU-only (1ms sampling) or allocation+lock profiling (10ms)
+  --enable-jfr-cpu-times            Force CPU time JFR options (requires --enable-jfr)
   --jfr-output <path>               Override the destination file for the JFR recording
+  --java-cmd <path>                 Java executable to use (default: java)
   --                                Treat the remaining arguments as raw JMH arguments
 USAGE
 }
 
 SCRIPT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+JAVA_CMD="${JAVA_CMD:-java}"
 
 module=""
 benchmark_class=""
@@ -39,6 +43,11 @@ warmup_overridden=false
 measurement_overridden=false
 forks_overridden=false
 jfr_notice=""
+jfr_profile_mode="cpu"
+param_overrides=()
+jfr_settings_file=""
+benchmark_source_file=""
+param_annotation_count=0
 
 while [[ $# -gt 0 ]]; do
         case "$1" in
@@ -77,9 +86,17 @@ while [[ $# -gt 0 ]]; do
                 jmh_extra_args+=("$2")
                 shift 2
                 ;;
+        --param)
+                param_overrides+=("$2")
+                shift 2
+                ;;
         --enable-jfr)
                 enable_jfr=true
                 shift
+                ;;
+        --jfr-mode)
+                jfr_profile_mode="$2"
+                shift 2
                 ;;
         --enable-jfr-cpu-times)
                 enable_jfr_cpu_times=true
@@ -87,6 +104,10 @@ while [[ $# -gt 0 ]]; do
                 ;;
         --jfr-output)
                 jfr_output="$2"
+                shift 2
+                ;;
+        --java-cmd)
+                JAVA_CMD="$2"
                 shift 2
                 ;;
         --dry-run)
@@ -118,6 +139,11 @@ if [[ -z "${module}" || -z "${benchmark_class}" || -z "${benchmark_method}" ]]; 
         exit 1
 fi
 
+if [[ "${jfr_profile_mode}" != "cpu" && "${jfr_profile_mode}" != "alloc" ]]; then
+        echo "Error: --jfr-mode must be 'cpu' or 'alloc'." >&2
+        exit 1
+fi
+
 module_dir="${REPO_ROOT}/${module}"
 if [[ ! -d "${module_dir}" ]]; then
         echo "Error: Module directory '${module}' does not exist." >&2
@@ -129,9 +155,157 @@ if ${enable_jfr_cpu_times} && ! ${enable_jfr}; then
         exit 1
 fi
 
-if ${enable_jfr}; then
+locate_benchmark_source() {
+        local module_path="$1"
+        local class_name="$2"
+        local relative_path candidate
+        relative_path="${class_name//./\/}.java"
+        candidate="$(find "${module_path}/src" -type f -path "*/${relative_path}" | head -n1 || true)"
+        if [[ -z "${candidate}" ]]; then
+                echo "Error: Unable to locate source file for '${class_name}' under '${module_path}/src'." >&2
+                exit 1
+        fi
+        printf '%s\n' "${candidate}"
+}
+
+count_param_annotations() {
+        local source_file="$1"
+        local count
+        count="$( (grep -Eo "[[:space:]]@Param[[:space:]]*\\(" "${source_file}" || true) | wc -l | tr -d ' ' )"
+        printf '%s\n' "${count}"
+}
+
+validate_param_overrides() {
+        if ${enable_jfr} && (( ${#param_overrides[@]} == 0 )); then
+                echo "Error: --enable-jfr requires at least one --param override to lock benchmark parameters." >&2
+                exit 1
+        fi
+
+        if (( param_annotation_count > 0 )) && { ${enable_jfr} || (( ${#param_overrides[@]} > 0 )); }; then
+                if (( ${#param_overrides[@]} < param_annotation_count )); then
+                        echo "Error: Benchmark '${benchmark_class}' declares ${param_annotation_count} @Param values; provide at least ${param_annotation_count} --param overrides." >&2
+                        exit 1
+                fi
+        fi
+}
+
+benchmark_source_file="$(locate_benchmark_source "${module_dir}" "${benchmark_class}")"
+param_annotation_count="$(count_param_annotations "${benchmark_source_file}")"
+validate_param_overrides
+
+escape_regex() {
+        local input="$1"
+        input="${input//\\/\\\\}"
+        input="${input//./\\.}"
+        input="${input//+/\\+}"
+        input="${input//\*/\\*}"
+        input="${input//\?/\\?}"
+        input="${input//^/\\^}"
+        input="${input//\$/\\$}"
+        input="${input//\[/\\[}"
+        input="${input//\]/\\]}"
+        input="${input//|/\\|}"
+        input="${input//(/\\(}"
+        input="${input//)/\\)}"
+        printf '%s' "${input}"
+}
+
+detect_java_major_version() {
+        local version_output version
+        if ! version_output="$(${JAVA_CMD} -version 2>&1 | head -n1)"; then
+                printf '0\n'
+                return
+        fi
+        version="${version_output%%\"*}"
+        version="${version_output#*\"}"
+        version="${version%%\"*}"
+        printf '%s\n' "${version%%.*}"
+}
+
+write_jfr_settings() {
+        local mode="$1"
+        local destination="$2"
+        mkdir -p "$(dirname "${destination}")"
+        if [[ "${mode}" == "cpu" ]]; then
+                cat >"${destination}" <<'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration version="2.0" label="RDF4J CPU Profiling" description="High frequency CPU sampling without allocation events" provider="Eclipse RDF4J">
+    <event name="jdk.ExecutionSample">
+      <setting name="enabled">true</setting>
+      <setting name="period">1 ms</setting>
+      <setting name="stackTraceDepth">256</setting>
+    </event>
+    <event name="jdk.NativeMethodSample">
+      <setting name="enabled">true</setting>
+      <setting name="period">1 ms</setting>
+      <setting name="stackTraceDepth">256</setting>
+    </event>
+    <event name="jdk.ObjectAllocationInNewTLAB">
+      <setting name="enabled">false</setting>
+    </event>
+    <event name="jdk.ObjectAllocationOutsideTLAB">
+      <setting name="enabled">false</setting>
+    </event>
+    <event name="jdk.ObjectAllocationSample">
+      <setting name="enabled">false</setting>
+    </event>
+    <event name="jdk.JavaMonitorEnter">
+      <setting name="enabled">false</setting>
+    </event>
+    <event name="jdk.ThreadPark">
+      <setting name="enabled">false</setting>
+    </event>
+</configuration>
+EOF
+        else
+                cat >"${destination}" <<'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration version="2.0" label="RDF4J Allocation Profiling" description="Allocation and lock profiling with moderate sampling" provider="Eclipse RDF4J">
+    <event name="jdk.ExecutionSample">
+      <setting name="enabled">true</setting>
+      <setting name="period">10 ms</setting>
+      <setting name="stackTraceDepth">256</setting>
+    </event>
+    <event name="jdk.NativeMethodSample">
+      <setting name="enabled">true</setting>
+      <setting name="period">10 ms</setting>
+      <setting name="stackTraceDepth">256</setting>
+    </event>
+    <event name="jdk.ObjectAllocationInNewTLAB">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+    </event>
+    <event name="jdk.ObjectAllocationOutsideTLAB">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+    </event>
+    <event name="jdk.ObjectAllocationSample">
+      <setting name="enabled">true</setting>
+      <setting name="throttle">500/s</setting>
+      <setting name="stackTrace">true</setting>
+    </event>
+    <event name="jdk.JavaMonitorEnter">
+      <setting name="enabled">true</setting>
+      <setting name="threshold">0 ms</setting>
+      <setting name="stackTrace">true</setting>
+    </event>
+    <event name="jdk.ThreadPark">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+    </event>
+</configuration>
+EOF
+        fi
+}
+
+configure_jfr_profile() {
         if (( ${#jmh_extra_args[@]} > 0 )); then
                 echo "Error: --enable-jfr cannot be combined with additional JMH arguments." >&2
+                exit 1
+        fi
+
+        if (( ${#param_overrides[@]} == 0 )); then
+                echo "Error: --enable-jfr requires at least one --param override to lock benchmark parameters." >&2
                 exit 1
         fi
 
@@ -140,8 +314,8 @@ if ${enable_jfr}; then
                 exit 1
         fi
 
-        if ${measurement_overridden} && [[ "${measurement_iterations}" != "10" ]]; then
-                echo "Error: --enable-jfr requires 10 measurement iterations." >&2
+        if ${measurement_overridden} && [[ "${measurement_iterations}" != "3" ]]; then
+                echo "Error: --enable-jfr requires 3 measurement iterations." >&2
                 exit 1
         fi
 
@@ -151,37 +325,54 @@ if ${enable_jfr}; then
         fi
 
         warmup_iterations=0
-        measurement_iterations=10
+        measurement_iterations=3
         measurement_time="10s"
         forks=1
 
         if [[ -z "${jfr_output}" ]]; then
-                local_class="${benchmark_class##*.}"
-                sanitized_class="${local_class//[^A-Za-z0-9_]/_}"
-                sanitized_method="${benchmark_method//[^A-Za-z0-9_]/_}"
-                jfr_output="${module_dir}/target/${sanitized_class}.${sanitized_method}.jfr"
+            local_class="${benchmark_class##*.}"
+            sanitized_class="${local_class//[^A-Za-z0-9_]/_}"
+            sanitized_method="${benchmark_method//[^A-Za-z0-9_]/_}"
+            jfr_output="${module_dir}/target/${sanitized_class}.${sanitized_method}.jfr"
         elif [[ "${jfr_output}" != /* ]]; then
-                jfr_output="${REPO_ROOT}/${jfr_output}"
+            jfr_output="${REPO_ROOT}/${jfr_output}"
         fi
 
-        jvm_args+=("-XX:StartFlightRecording=settings=profile,dumponexit=true,filename=${jfr_output},duration=120s")
+        jfr_settings_file="${module_dir}/target/jfr-${jfr_profile_mode}-settings.jfc"
+        write_jfr_settings "${jfr_profile_mode}" "${jfr_settings_file}"
 
-        if ${enable_jfr_cpu_times}; then
-                jvm_args+=("-XX:FlightRecorderOptions=enableThreadCpuTime=true,enableProcessCpuTime=true")
+        local fr_options="stackdepth=256"
+        local detected_java_version
+        detected_java_version="$(detect_java_major_version)"
+        if ${enable_jfr_cpu_times} || { [[ "$(uname -s)" == "Linux" ]] && [[ "${detected_java_version}" =~ ^[0-9]+$ ]] && (( detected_java_version >= 25 )); }; then
+                fr_options+="\,enableThreadCpuTime=true\,enableProcessCpuTime=true"
         fi
 
-        jfr_notice="JFR profiling enabled: enforcing warmup=0, measurement=10 iterations of 10s, forks=1. Recording will be written to ${jfr_output}."
+        jvm_args+=("-XX:StartFlightRecording=settings=${jfr_settings_file},dumponexit=true,filename=${jfr_output},disk=true")
+        jvm_args+=("-XX:FlightRecorderOptions=${fr_options}")
+
+        jfr_notice="JFR profiling enabled: enforcing warmup=0, measurement=3 iterations of 10s, forks=1. Recording will be written to ${jfr_output}. Settings: ${jfr_settings_file}."
+}
+
+if ${enable_jfr}; then
+        configure_jfr_profile
 fi
 
 mvn_cmd=(mvn "-pl" "${module}" "-am" "-P" "benchmarks" "-DskipTests" package)
 
-benchmark_pattern="${benchmark_class}.${benchmark_method}"
+escaped_class="$(escape_regex "${benchmark_class}")"
+escaped_method="$(escape_regex "${benchmark_method}")"
+benchmark_pattern="^${escaped_class}\\.${escaped_method}$"
+
 jmh_args=(-wi "${warmup_iterations}" -i "${measurement_iterations}" -f "${forks}")
 if [[ -n "${measurement_time}" ]]; then
         jmh_args+=(-r "${measurement_time}")
 fi
 for arg in "${jvm_args[@]}"; do
         jmh_args+=("-jvmArgsAppend" "${arg}")
+done
+for param in "${param_overrides[@]}"; do
+        jmh_args+=(-p "${param}")
 done
 for arg in "${jmh_extra_args[@]}"; do
         jmh_args+=("${arg}")
@@ -211,6 +402,43 @@ find_benchmark_jar() {
         printf '%s\n' "${module_path}/target/jmh.jar"
 }
 
+run_jfr_postprocessing() {
+        local recording="$1"
+        if [[ ! -f "${recording}" ]]; then
+                echo "JFR recording '${recording}' not found; skipping post-processing." >&2
+                return
+        fi
+
+        if ! command -v jfr >/dev/null 2>&1; then
+                echo "The 'jfr' tool is not available on PATH; skipping JFR post-processing." >&2
+                return
+        fi
+
+        local base_dir base_name summary hot_methods exec_samples alloc_events lock_events cpu_load flamegraph
+        base_dir="$(dirname "${recording}")"
+        base_name="$(basename "${recording}" .jfr)"
+        summary="${base_dir}/${base_name}-summary.txt"
+        hot_methods="${base_dir}/${base_name}-hot-methods.txt"
+        exec_samples="${base_dir}/${base_name}-execution-samples.txt"
+        alloc_events="${base_dir}/${base_name}-alloc-events.txt"
+        lock_events="${base_dir}/${base_name}-lock-events.txt"
+        cpu_load="${base_dir}/${base_name}-cpu-load.txt"
+        flamegraph="${base_dir}/${base_name}-flamegraph.txt"
+
+        echo "Post-processing JFR recording at ${recording}" >&2
+
+        jfr summary "${recording}" >"${summary}"
+        jfr view hot-methods "${recording}" >"${hot_methods}" || true
+        jfr print --events "jdk.ExecutionSample" --stack-depth 64 "${recording}" >"${exec_samples}"
+        jfr print --events "jdk.ObjectAllocationInNewTLAB,jdk.ObjectAllocationOutsideTLAB,jdk.ObjectAllocationSample" --stack-depth 64 "${recording}" >"${alloc_events}"
+        jfr print --events "jdk.JavaMonitorEnter,jdk.ThreadPark" --stack-depth 64 "${recording}" >"${lock_events}" || true
+        jfr print --events "jdk.CPULoad,jdk.ThreadCPULoad" "${recording}" >"${cpu_load}" || true
+        jfr view flamegraph "${recording}" >"${flamegraph}" || true
+
+        echo "Generated JFR reports:" >&2
+        printf '  %s\n' "${summary}" "${hot_methods}" "${exec_samples}" "${alloc_events}" "${lock_events}" "${cpu_load}" "${flamegraph}" >&2
+}
+
 print_command() {
         printf '%q ' "$@"
         printf '\n'
@@ -222,7 +450,7 @@ if ${dry_run}; then
         fi
         jar_path="$(find_benchmark_jar "${module_dir}" false)"
         print_command "${mvn_cmd[@]}"
-        java_cmd=(java -jar "${jar_path}" "${jmh_args[@]}" "${benchmark_pattern}")
+        java_cmd=("${JAVA_CMD}" -jar "${jar_path}" "${jmh_args[@]}" "${benchmark_pattern}")
         print_command "${java_cmd[@]}"
         exit 0
 fi
@@ -233,7 +461,7 @@ fi
 )
 
 jar_path="$(find_benchmark_jar "${module_dir}" true)"
-java_cmd=(java -jar "${jar_path}" "${jmh_args[@]}" "${benchmark_pattern}")
+java_cmd=("${JAVA_CMD}" -jar "${jar_path}" "${jmh_args[@]}" "${benchmark_pattern}")
 
 if ${enable_jfr}; then
         echo "${jfr_notice}"
@@ -242,3 +470,7 @@ fi
 
 printf 'Running benchmark with jar %s\n' "${jar_path}"
 "${java_cmd[@]}"
+
+if ${enable_jfr}; then
+        run_jfr_postprocessing "${jfr_output}"
+fi

--- a/testsuites/benchmark/test-run-single-benchmark.sh
+++ b/testsuites/benchmark/test-run-single-benchmark.sh
@@ -21,13 +21,13 @@ if [[ "${OUTPUT}" != *"mvn -pl testsuites/benchmark -am -P benchmarks -DskipTest
         exit 1
 fi
 
-if [[ "${OUTPUT}" != *"ReasoningBenchmark.forwardChainingSchemaCachingRDFSInferencer"* ]]; then
+if [[ "${OUTPUT}" != *"ReasoningBenchmark"*"forwardChainingSchemaCachingRDFSInferencer"* ]]; then
         echo "Expected benchmark method not found in output" >&2
         exit 1
 fi
 
 set +e
-JFR_OUTPUT="$(bash "${SCRIPT}" --dry-run --module testsuites/benchmark --class org.eclipse.rdf4j.benchmark.ReasoningBenchmark --method forwardChainingSchemaCachingRDFSInferencer --enable-jfr 2>&1)"
+JFR_OUTPUT="$(bash "${SCRIPT}" --dry-run --module testsuites/benchmark --class org.eclipse.rdf4j.benchmark.ReasoningBenchmark --method forwardChainingSchemaCachingRDFSInferencer --enable-jfr --param dataset=cache 2>&1)"
 JFR_STATUS=$?
 set -e
 
@@ -53,8 +53,8 @@ if [[ "${JFR_OUTPUT}" != *"-wi 0"* ]]; then
         exit 1
 fi
 
-if [[ "${JFR_OUTPUT}" != *"-i 10"* ]]; then
-        echo "Expected JFR run to force 10 measurement iterations" >&2
+if [[ "${JFR_OUTPUT}" != *"-i 3"* ]]; then
+        echo "Expected JFR run to force 3 measurement iterations" >&2
         exit 1
 fi
 
@@ -68,8 +68,18 @@ if [[ "${JFR_OUTPUT}" != *"-f 1"* ]]; then
         exit 1
 fi
 
-if [[ "${JFR_OUTPUT}" != *"-XX:StartFlightRecording=settings=profile\\,dumponexit=true"* ]]; then
+if [[ "${JFR_OUTPUT}" != *"-p dataset=cache"* ]]; then
+        echo "Expected JFR run to lock parameters to a single value" >&2
+        exit 1
+fi
+
+if [[ "${JFR_OUTPUT}" != *"jfr-cpu-settings.jfc"* ]]; then
         echo "Expected JFR run to enable JFR profiling" >&2
+        exit 1
+fi
+
+if [[ "${JFR_OUTPUT}" != *"-XX:FlightRecorderOptions=stackdepth=256"* ]]; then
+        echo "Expected JFR run to increase stack depth for profiling" >&2
         exit 1
 fi
 
@@ -79,7 +89,23 @@ if [[ "${JFR_OUTPUT}" != *"testsuites/benchmark/target/ReasoningBenchmark.forwar
 fi
 
 set +e
-JFR_CPU_OUTPUT="$(bash "${SCRIPT}" --dry-run --module testsuites/benchmark --class org.eclipse.rdf4j.benchmark.ReasoningBenchmark --method forwardChainingSchemaCachingRDFSInferencer --enable-jfr --enable-jfr-cpu-times 2>&1)"
+PARAM_OUTPUT="$(bash "${SCRIPT}" --dry-run --module testsuites/benchmark --class org.eclipse.rdf4j.benchmark.ReasoningBenchmark --method forwardChainingSchemaCachingRDFSInferencer --param testParam=value 2>&1)"
+PARAM_STATUS=$?
+set -e
+
+echo "${PARAM_OUTPUT}" 
+
+if [[ ${PARAM_STATUS} -ne 0 ]]; then
+        exit ${PARAM_STATUS}
+fi
+
+if [[ "${PARAM_OUTPUT}" != *"-p testParam=value"* ]]; then
+        echo "Expected param override to be passed to JMH" >&2
+        exit 1
+fi
+
+set +e
+JFR_CPU_OUTPUT="$(bash "${SCRIPT}" --dry-run --module testsuites/benchmark --class org.eclipse.rdf4j.benchmark.ReasoningBenchmark --method forwardChainingSchemaCachingRDFSInferencer --enable-jfr --enable-jfr-cpu-times --param dataset=cache 2>&1)"
 JFR_CPU_STATUS=$?
 set -e
 
@@ -89,8 +115,25 @@ if [[ ${JFR_CPU_STATUS} -ne 0 ]]; then
         exit ${JFR_CPU_STATUS}
 fi
 
-if [[ "${JFR_CPU_OUTPUT}" != *"-XX:FlightRecorderOptions=enableThreadCpuTime=true\\,enableProcessCpuTime=true"* ]]; then
+if [[ "${JFR_CPU_OUTPUT}" != *"enableThreadCpuTime=true"* ]] || [[ "${JFR_CPU_OUTPUT}" != *"enableProcessCpuTime=true"* ]]; then
         echo "Expected CPU time options to be appended when requested" >&2
+        exit 1
+fi
+
+set +e
+INSUFFICIENT_PARAMS_OUTPUT="$(bash "${SCRIPT}" --dry-run --module testsuites/benchmark --class org.eclipse.rdf4j.benchmark.QueryOrderBenchmark --method selectAll --enable-jfr --param limit=10 2>&1)"
+INSUFFICIENT_PARAMS_STATUS=$?
+set -e
+
+echo "${INSUFFICIENT_PARAMS_OUTPUT}"
+
+if [[ ${INSUFFICIENT_PARAMS_STATUS} -eq 0 ]]; then
+        echo "Expected insufficient param overrides to fail when profiling" >&2
+        exit 1
+fi
+
+if [[ "${INSUFFICIENT_PARAMS_OUTPUT}" != *"declares 3 @Param"* ]]; then
+        echo "Expected error to mention the benchmark's parameter count" >&2
         exit 1
 fi
 


### PR DESCRIPTION
## Summary
- extend the JMH benchmark runner to support @Param overrides, explicit JFR modes, Java command selection, and automatic CPU time options when applicable
- generate tuned JFR settings files for CPU-only or allocation/lock profiling and post-process recordings with helpful reports
- verify benchmark source files to ensure @Param overrides cover all parameters when profiling

## Testing
- bash testsuites/benchmark/test-run-single-benchmark.sh

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924de4f0b8c832eb731206fd2762d29)