### PR TITLE
GH-0000 Pool LMDB cursors across store components

### DIFF
--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbContextIdIterator.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbContextIdIterator.java
@@ -41,6 +41,7 @@ class LmdbContextIdIterator implements Closeable {
 	private long txnRefVersion;
 
 	private final long txn;
+	private final long env;
 
 	private final int dbi;
 
@@ -62,13 +63,14 @@ class LmdbContextIdIterator implements Closeable {
 
 	private final Thread ownerThread = Thread.currentThread();
 
-	LmdbContextIdIterator(int dbi, Txn txnRef) throws IOException {
+	LmdbContextIdIterator(int dbi, Txn txnRef, long env) throws IOException {
 		this.pool = Pool.get();
 		this.keyData = pool.getVal();
 		this.valueData = pool.getVal();
 
 		this.dbi = dbi;
 		this.txnRef = txnRef;
+		this.env = env;
 		this.txnLockManager = txnRef.lockManager();
 
 		long readStamp;
@@ -82,7 +84,7 @@ class LmdbContextIdIterator implements Closeable {
 			this.txn = txnRef.get();
 
 			try (MemoryStack stack = MemoryStack.stackPush()) {
-				cursor = pool.getCursor(stack, txn, dbi);
+				cursor = pool.getCursor(stack, env, txn, dbi);
 			}
 		} finally {
 			txnLockManager.unlockRead(readStamp);
@@ -166,7 +168,7 @@ class LmdbContextIdIterator implements Closeable {
 			}
 			try {
 				if (!closed) {
-					pool.freeCursor(cursor, dbi);
+					pool.freeCursor(cursor, dbi, env);
 					pool.free(keyData);
 					pool.free(valueData);
 					if (minKeyBuf != null) {

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbContextIdIterator.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbContextIdIterator.java
@@ -15,9 +15,7 @@ import static org.lwjgl.util.lmdb.LMDB.MDB_NEXT;
 import static org.lwjgl.util.lmdb.LMDB.MDB_SET;
 import static org.lwjgl.util.lmdb.LMDB.MDB_SET_RANGE;
 import static org.lwjgl.util.lmdb.LMDB.MDB_SUCCESS;
-import static org.lwjgl.util.lmdb.LMDB.mdb_cursor_close;
 import static org.lwjgl.util.lmdb.LMDB.mdb_cursor_get;
-import static org.lwjgl.util.lmdb.LMDB.mdb_cursor_open;
 import static org.lwjgl.util.lmdb.LMDB.mdb_cursor_renew;
 
 import java.io.Closeable;
@@ -27,7 +25,6 @@ import java.nio.ByteBuffer;
 import org.eclipse.rdf4j.common.concurrent.locks.StampedLongAdderLockManager;
 import org.eclipse.rdf4j.sail.SailException;
 import org.eclipse.rdf4j.sail.lmdb.TxnManager.Txn;
-import org.lwjgl.PointerBuffer;
 import org.lwjgl.system.MemoryStack;
 import org.lwjgl.util.lmdb.MDBVal;
 
@@ -85,9 +82,7 @@ class LmdbContextIdIterator implements Closeable {
 			this.txn = txnRef.get();
 
 			try (MemoryStack stack = MemoryStack.stackPush()) {
-				PointerBuffer pp = stack.mallocPointer(1);
-				E(mdb_cursor_open(txn, dbi, pp));
-				cursor = pp.get(0);
+				cursor = pool.getCursor(stack, txn, dbi);
 			}
 		} finally {
 			txnLockManager.unlockRead(readStamp);
@@ -171,7 +166,7 @@ class LmdbContextIdIterator implements Closeable {
 			}
 			try {
 				if (!closed) {
-					mdb_cursor_close(cursor);
+					pool.freeCursor(cursor, dbi);
 					pool.free(keyData);
 					pool.free(valueData);
 					if (minKeyBuf != null) {

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbRecordIterator.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbRecordIterator.java
@@ -17,9 +17,7 @@ import static org.lwjgl.util.lmdb.LMDB.MDB_SET;
 import static org.lwjgl.util.lmdb.LMDB.MDB_SET_RANGE;
 import static org.lwjgl.util.lmdb.LMDB.MDB_SUCCESS;
 import static org.lwjgl.util.lmdb.LMDB.mdb_cmp;
-import static org.lwjgl.util.lmdb.LMDB.mdb_cursor_close;
 import static org.lwjgl.util.lmdb.LMDB.mdb_cursor_get;
-import static org.lwjgl.util.lmdb.LMDB.mdb_cursor_open;
 import static org.lwjgl.util.lmdb.LMDB.mdb_cursor_renew;
 
 import java.io.IOException;
@@ -30,7 +28,6 @@ import org.eclipse.rdf4j.sail.SailException;
 import org.eclipse.rdf4j.sail.lmdb.TripleStore.TripleIndex;
 import org.eclipse.rdf4j.sail.lmdb.TxnManager.Txn;
 import org.eclipse.rdf4j.sail.lmdb.util.GroupMatcher;
-import org.lwjgl.PointerBuffer;
 import org.lwjgl.system.MemoryStack;
 import org.lwjgl.util.lmdb.MDBVal;
 import org.slf4j.Logger;
@@ -130,9 +127,7 @@ class LmdbRecordIterator implements RecordIterator {
 			this.txn = txnRef.get();
 
 			try (MemoryStack stack = MemoryStack.stackPush()) {
-				PointerBuffer pp = stack.mallocPointer(1);
-				E(mdb_cursor_open(txn, dbi, pp));
-				cursor = pp.get(0);
+				cursor = pool.getCursor(stack, txn, dbi);
 			}
 		} finally {
 			txnLockManager.unlockRead(readStamp);
@@ -242,7 +237,7 @@ class LmdbRecordIterator implements RecordIterator {
 			}
 			try {
 				if (!closed) {
-					mdb_cursor_close(cursor);
+					pool.freeCursor(cursor, dbi);
 					pool.free(keyData);
 					pool.free(valueData);
 					if (minKeyBuf != null) {

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbRecordIterator.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbRecordIterator.java
@@ -59,6 +59,7 @@ class LmdbRecordIterator implements RecordIterator {
 	private long txnRefVersion;
 
 	private final long txn;
+	private final long env;
 
 	private final int dbi;
 
@@ -84,7 +85,7 @@ class LmdbRecordIterator implements RecordIterator {
 	private final Thread ownerThread = Thread.currentThread();
 
 	LmdbRecordIterator(TripleIndex index, boolean rangeSearch, long subj, long pred, long obj,
-			long context, boolean explicit, Txn txnRef) throws IOException {
+			long context, boolean explicit, Txn txnRef, long env) throws IOException {
 		this.subj = subj;
 		this.pred = pred;
 		this.obj = obj;
@@ -114,6 +115,7 @@ class LmdbRecordIterator implements RecordIterator {
 
 		this.dbi = index.getDB(explicit);
 		this.txnRef = txnRef;
+		this.env = env;
 		this.txnLockManager = txnRef.lockManager();
 
 		long readStamp;
@@ -127,7 +129,7 @@ class LmdbRecordIterator implements RecordIterator {
 			this.txn = txnRef.get();
 
 			try (MemoryStack stack = MemoryStack.stackPush()) {
-				cursor = pool.getCursor(stack, txn, dbi);
+				cursor = pool.getCursor(stack, env, txn, dbi);
 			}
 		} finally {
 			txnLockManager.unlockRead(readStamp);
@@ -237,7 +239,7 @@ class LmdbRecordIterator implements RecordIterator {
 			}
 			try {
 				if (!closed) {
-					pool.freeCursor(cursor, dbi);
+					pool.freeCursor(cursor, dbi, env);
 					pool.free(keyData);
 					pool.free(valueData);
 					if (minKeyBuf != null) {

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/PersistentSet.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/PersistentSet.java
@@ -205,7 +205,7 @@ class PersistentSet<T extends Serializable> extends AbstractSet<T> {
 					this.txnRefVersion = txnRef.version();
 
 					try (MemoryStack stack = MemoryStack.stackPush()) {
-						cursor = pool.getCursor(stack, txnRef.get(), dbi);
+						cursor = pool.getCursor(stack, factory.env, txnRef.get(), dbi);
 					}
 				} finally {
 					txnLockManager.unlockRead(readStamp);
@@ -279,7 +279,7 @@ class PersistentSet<T extends Serializable> extends AbstractSet<T> {
 					throw new SailException(e);
 				}
 				try {
-					pool.freeCursor(cursor, dbi);
+					pool.freeCursor(cursor, dbi, factory.env);
 					txnRef.close();
 					txnRef = null;
 				} finally {

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/PersistentSet.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/PersistentSet.java
@@ -18,9 +18,7 @@ import static org.lwjgl.util.lmdb.LMDB.MDB_NOOVERWRITE;
 import static org.lwjgl.util.lmdb.LMDB.MDB_SET;
 import static org.lwjgl.util.lmdb.LMDB.MDB_SET_RANGE;
 import static org.lwjgl.util.lmdb.LMDB.MDB_SUCCESS;
-import static org.lwjgl.util.lmdb.LMDB.mdb_cursor_close;
 import static org.lwjgl.util.lmdb.LMDB.mdb_cursor_get;
-import static org.lwjgl.util.lmdb.LMDB.mdb_cursor_open;
 import static org.lwjgl.util.lmdb.LMDB.mdb_cursor_renew;
 import static org.lwjgl.util.lmdb.LMDB.mdb_del;
 import static org.lwjgl.util.lmdb.LMDB.mdb_drop;
@@ -43,7 +41,6 @@ import java.util.NoSuchElementException;
 import org.eclipse.rdf4j.common.concurrent.locks.StampedLongAdderLockManager;
 import org.eclipse.rdf4j.sail.SailException;
 import org.eclipse.rdf4j.sail.lmdb.TxnManager.Txn;
-import org.lwjgl.PointerBuffer;
 import org.lwjgl.system.MemoryStack;
 import org.lwjgl.util.lmdb.MDBVal;
 import org.slf4j.Logger;
@@ -188,6 +185,7 @@ class PersistentSet<T extends Serializable> extends AbstractSet<T> {
 
 		private final MDBVal keyData = MDBVal.malloc();
 		private final MDBVal valueData = MDBVal.malloc();
+		private final Pool pool = Pool.get();
 		private final long cursor;
 
 		private final StampedLongAdderLockManager txnLockManager;
@@ -207,9 +205,7 @@ class PersistentSet<T extends Serializable> extends AbstractSet<T> {
 					this.txnRefVersion = txnRef.version();
 
 					try (MemoryStack stack = MemoryStack.stackPush()) {
-						PointerBuffer pp = stack.mallocPointer(1);
-						E(mdb_cursor_open(txnRef.get(), dbi, pp));
-						cursor = pp.get(0);
+						cursor = pool.getCursor(stack, txnRef.get(), dbi);
 					}
 				} finally {
 					txnLockManager.unlockRead(readStamp);
@@ -283,7 +279,7 @@ class PersistentSet<T extends Serializable> extends AbstractSet<T> {
 					throw new SailException(e);
 				}
 				try {
-					mdb_cursor_close(cursor);
+					pool.freeCursor(cursor, dbi);
 					txnRef.close();
 					txnRef = null;
 				} finally {

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/Pool.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/Pool.java
@@ -10,13 +10,21 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.lmdb;
 
+import static org.eclipse.rdf4j.sail.lmdb.LmdbUtil.E;
+import static org.lwjgl.util.lmdb.LMDB.mdb_cursor_close;
+import static org.lwjgl.util.lmdb.LMDB.mdb_cursor_open;
+import static org.lwjgl.util.lmdb.LMDB.mdb_cursor_renew;
+
+import java.io.IOException;
 import java.nio.ByteBuffer;
 
+import org.lwjgl.PointerBuffer;
+import org.lwjgl.system.MemoryStack;
 import org.lwjgl.system.MemoryUtil;
 import org.lwjgl.util.lmdb.MDBVal;
 
 /**
- * A simple pool for {@link MDBVal}, {@link ByteBuffer} and {@link Statistics} instances.
+ * A simple pool for {@link MDBVal}, {@link ByteBuffer}, {@link Statistics} and LMDB cursors.
  */
 class Pool {
 	// thread-local pool instance
@@ -25,9 +33,12 @@ class Pool {
 	private final MDBVal[] valPool = new MDBVal[1024];
 	private final ByteBuffer[] keyPool = new ByteBuffer[1024];
 	private final Statistics[] statisticsPool = new Statistics[512];
+	private final long[] cursorPool = new long[256];
+	private final int[] cursorDbiPool = new int[256];
 	private int valPoolIndex = -1;
 	private int keyPoolIndex = -1;
 	private int statisticsPoolIndex = -1;
+	private int cursorPoolIndex = -1;
 
 	final MDBVal getVal() {
 		if (valPoolIndex >= 0) {
@@ -74,12 +85,44 @@ class Pool {
 		}
 	}
 
+	final long getCursor(MemoryStack stack, long txn, int dbi) throws IOException {
+		for (int i = cursorPoolIndex; i >= 0; i--) {
+			if (cursorDbiPool[i] == dbi) {
+				long cursor = cursorPool[i];
+				cursorPool[i] = cursorPool[cursorPoolIndex];
+				cursorDbiPool[i] = cursorDbiPool[cursorPoolIndex];
+				cursorPoolIndex--;
+				E(mdb_cursor_renew(txn, cursor));
+				return cursor;
+			}
+		}
+
+		PointerBuffer pp = stack.mallocPointer(1);
+		E(mdb_cursor_open(txn, dbi, pp));
+		return pp.get(0);
+	}
+
+	final void freeCursor(long cursor, int dbi) {
+		if (cursor == 0) {
+			return;
+		}
+		if (cursorPoolIndex < cursorPool.length - 1) {
+			cursorPool[++cursorPoolIndex] = cursor;
+			cursorDbiPool[cursorPoolIndex] = dbi;
+		} else {
+			mdb_cursor_close(cursor);
+		}
+	}
+
 	final void close() {
 		while (valPoolIndex >= 0) {
 			valPool[valPoolIndex--].close();
 		}
 		while (keyPoolIndex >= 0) {
 			MemoryUtil.memFree(keyPool[keyPoolIndex--]);
+		}
+		while (cursorPoolIndex >= 0) {
+			mdb_cursor_close(cursorPool[cursorPoolIndex--]);
 		}
 	}
 

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/Pool.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/Pool.java
@@ -36,6 +36,7 @@ class Pool {
 	private final Statistics[] statisticsPool = new Statistics[512];
 	private final long[] cursorPool = new long[256];
 	private final int[] cursorDbiPool = new int[256];
+	private final long[] cursorEnvPool = new long[256];
 	private int valPoolIndex = -1;
 	private int keyPoolIndex = -1;
 	private int statisticsPoolIndex = -1;
@@ -86,12 +87,22 @@ class Pool {
 		}
 	}
 
-	final long getCursor(MemoryStack stack, long txn, int dbi) throws IOException {
+	final long getCursor(MemoryStack stack, long env, long txn, int dbi) throws IOException {
 		for (int i = cursorPoolIndex; i >= 0; i--) {
+			if (cursorEnvPool[i] != env) {
+				mdb_cursor_close(cursorPool[i]);
+				cursorPool[i] = cursorPool[cursorPoolIndex];
+				cursorDbiPool[i] = cursorDbiPool[cursorPoolIndex];
+				cursorEnvPool[i] = cursorEnvPool[cursorPoolIndex];
+				cursorPoolIndex--;
+				continue;
+			}
+
 			if (cursorDbiPool[i] == dbi) {
 				long cursor = cursorPool[i];
 				cursorPool[i] = cursorPool[cursorPoolIndex];
 				cursorDbiPool[i] = cursorDbiPool[cursorPoolIndex];
+				cursorEnvPool[i] = cursorEnvPool[cursorPoolIndex];
 				cursorPoolIndex--;
 
 				int rc = mdb_cursor_renew(txn, cursor);
@@ -108,13 +119,14 @@ class Pool {
 		return pp.get(0);
 	}
 
-	final void freeCursor(long cursor, int dbi) {
+	final void freeCursor(long cursor, int dbi, long env) {
 		if (cursor == 0) {
 			return;
 		}
 		if (cursorPoolIndex < cursorPool.length - 1) {
 			cursorPool[++cursorPoolIndex] = cursor;
 			cursorDbiPool[cursorPoolIndex] = dbi;
+			cursorEnvPool[cursorPoolIndex] = env;
 		} else {
 			mdb_cursor_close(cursor);
 		}

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/Pool.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/Pool.java
@@ -11,6 +11,7 @@
 package org.eclipse.rdf4j.sail.lmdb;
 
 import static org.eclipse.rdf4j.sail.lmdb.LmdbUtil.E;
+import static org.lwjgl.util.lmdb.LMDB.MDB_SUCCESS;
 import static org.lwjgl.util.lmdb.LMDB.mdb_cursor_close;
 import static org.lwjgl.util.lmdb.LMDB.mdb_cursor_open;
 import static org.lwjgl.util.lmdb.LMDB.mdb_cursor_renew;
@@ -92,8 +93,13 @@ class Pool {
 				cursorPool[i] = cursorPool[cursorPoolIndex];
 				cursorDbiPool[i] = cursorDbiPool[cursorPoolIndex];
 				cursorPoolIndex--;
-				E(mdb_cursor_renew(txn, cursor));
-				return cursor;
+
+				int rc = mdb_cursor_renew(txn, cursor);
+				if (rc == MDB_SUCCESS) {
+					return cursor;
+				}
+
+				mdb_cursor_close(cursor);
 			}
 		}
 

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/TripleStore.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/TripleStore.java
@@ -397,7 +397,7 @@ class TripleStore implements Closeable {
 						RecordIterator[] sourceIter = { null };
 						try {
 							sourceIter[0] = new LmdbRecordIterator(sourceIndex, false, -1, -1, -1, -1,
-									explicit, txnManager.createTxn(txn));
+									explicit, txnManager.createTxn(txn), env);
 
 							RecordIterator it = sourceIter[0];
 							long[] quad;
@@ -487,7 +487,7 @@ class TripleStore implements Closeable {
 	 * @throws IOException
 	 */
 	public LmdbContextIdIterator getContexts(Txn txn) throws IOException {
-		return new LmdbContextIdIterator(this.contextsDbi, txn);
+		return new LmdbContextIdIterator(this.contextsDbi, txn, env);
 	}
 
 	/**
@@ -525,7 +525,7 @@ class TripleStore implements Closeable {
 
 	private RecordIterator getTriplesUsingIndex(Txn txn, long subj, long pred, long obj, long context,
 			boolean explicit, TripleIndex index, boolean rangeSearch) throws IOException {
-		return new LmdbRecordIterator(index, rangeSearch, subj, pred, obj, context, explicit, txn);
+		return new LmdbRecordIterator(index, rangeSearch, subj, pred, obj, context, explicit, txn, env);
 	}
 
 	/**
@@ -598,7 +598,7 @@ class TripleStore implements Closeable {
 
 					long cursor = 0;
 					try {
-						cursor = pool.getCursor(stack, txn, dbi);
+						cursor = pool.getCursor(stack, env, txn, dbi);
 
 						if (fullScan) {
 							long[] quad = new long[4];
@@ -660,7 +660,7 @@ class TripleStore implements Closeable {
 							}
 						}
 					} finally {
-						pool.freeCursor(cursor, dbi);
+						pool.freeCursor(cursor, dbi, env);
 					}
 				}
 			}
@@ -715,7 +715,7 @@ class TripleStore implements Closeable {
 					long cursor = 0;
 
 					try {
-						cursor = pool.getCursor(stack, txn, dbi);
+						cursor = pool.getCursor(stack, env, txn, dbi);
 
 						// set cursor to min key
 						keyData.mv_data(keyBuf);
@@ -819,7 +819,7 @@ class TripleStore implements Closeable {
 							}
 						}
 					} finally {
-						pool.freeCursor(cursor, dbi);
+						pool.freeCursor(cursor, dbi, env);
 					}
 				}
 				return cardinality;

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/TripleStore.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/TripleStore.java
@@ -31,9 +31,7 @@ import static org.lwjgl.util.lmdb.LMDB.MDB_PREV;
 import static org.lwjgl.util.lmdb.LMDB.MDB_SET_RANGE;
 import static org.lwjgl.util.lmdb.LMDB.MDB_SUCCESS;
 import static org.lwjgl.util.lmdb.LMDB.mdb_cmp;
-import static org.lwjgl.util.lmdb.LMDB.mdb_cursor_close;
 import static org.lwjgl.util.lmdb.LMDB.mdb_cursor_get;
-import static org.lwjgl.util.lmdb.LMDB.mdb_cursor_open;
 import static org.lwjgl.util.lmdb.LMDB.mdb_dbi_close;
 import static org.lwjgl.util.lmdb.LMDB.mdb_dbi_open;
 import static org.lwjgl.util.lmdb.LMDB.mdb_del;
@@ -567,7 +565,7 @@ class TripleStore implements Closeable {
 
 			MDBVal valueData = MDBVal.mallocStack(stack);
 
-			PointerBuffer pp = stack.mallocPointer(1);
+			Pool pool = Pool.get();
 
 			// test contexts list if it contains the id
 			for (Iterator<Long> it = ids.iterator(); it.hasNext();) {
@@ -600,8 +598,7 @@ class TripleStore implements Closeable {
 
 					long cursor = 0;
 					try {
-						E(mdb_cursor_open(txn, dbi, pp));
-						cursor = pp.get(0);
+						cursor = pool.getCursor(stack, txn, dbi);
 
 						if (fullScan) {
 							long[] quad = new long[4];
@@ -663,9 +660,7 @@ class TripleStore implements Closeable {
 							}
 						}
 					} finally {
-						if (cursor != 0) {
-							mdb_cursor_close(cursor);
-						}
+						pool.freeCursor(cursor, dbi);
 					}
 				}
 			}
@@ -701,8 +696,6 @@ class TripleStore implements Closeable {
 				maxKeyBuf.flip();
 				maxKey.mv_data(maxKeyBuf);
 
-				PointerBuffer pp = stack.mallocPointer(1);
-
 				MDBVal keyData = MDBVal.mallocStack(stack);
 				ByteBuffer keyBuf = stack.malloc(TripleStore.MAX_KEY_LENGTH);
 				MDBVal valueData = MDBVal.mallocStack(stack);
@@ -722,8 +715,7 @@ class TripleStore implements Closeable {
 					long cursor = 0;
 
 					try {
-						E(mdb_cursor_open(txn, dbi, pp));
-						cursor = pp.get(0);
+						cursor = pool.getCursor(stack, txn, dbi);
 
 						// set cursor to min key
 						keyData.mv_data(keyBuf);
@@ -827,9 +819,7 @@ class TripleStore implements Closeable {
 							}
 						}
 					} finally {
-						if (cursor != 0) {
-							mdb_cursor_close(cursor);
-						}
+						pool.freeCursor(cursor, dbi);
 					}
 				}
 				return cardinality;

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/TxnRecordCache.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/TxnRecordCache.java
@@ -189,7 +189,7 @@ final class TxnRecordCache {
 				E(mdb_txn_begin(env, NULL, MDB_RDONLY, pp));
 				txn = pp.get(0);
 
-				cursor = pool.getCursor(stack, txn, dbi);
+				cursor = pool.getCursor(stack, env, txn, dbi);
 			}
 		}
 
@@ -210,7 +210,7 @@ final class TxnRecordCache {
 			if (txn != 0) {
 				keyData.close();
 				valueData.close();
-				Pool.get().freeCursor(cursor, dbi);
+				Pool.get().freeCursor(cursor, dbi, env);
 				mdb_txn_abort(txn);
 				txn = 0;
 			}

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/TxnRecordCache.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/TxnRecordCache.java
@@ -22,9 +22,7 @@ import static org.lwjgl.util.lmdb.LMDB.MDB_NOSYNC;
 import static org.lwjgl.util.lmdb.LMDB.MDB_NOTLS;
 import static org.lwjgl.util.lmdb.LMDB.MDB_RDONLY;
 import static org.lwjgl.util.lmdb.LMDB.MDB_SUCCESS;
-import static org.lwjgl.util.lmdb.LMDB.mdb_cursor_close;
 import static org.lwjgl.util.lmdb.LMDB.mdb_cursor_get;
-import static org.lwjgl.util.lmdb.LMDB.mdb_cursor_open;
 import static org.lwjgl.util.lmdb.LMDB.mdb_del;
 import static org.lwjgl.util.lmdb.LMDB.mdb_env_close;
 import static org.lwjgl.util.lmdb.LMDB.mdb_env_create;
@@ -184,14 +182,14 @@ final class TxnRecordCache {
 
 		protected RecordCacheIterator(int dbi) throws IOException {
 			this.dbi = dbi;
+			Pool pool = Pool.get();
 			try (MemoryStack stack = MemoryStack.stackPush()) {
 				PointerBuffer pp = stack.mallocPointer(1);
 
 				E(mdb_txn_begin(env, NULL, MDB_RDONLY, pp));
 				txn = pp.get(0);
 
-				E(mdb_cursor_open(txn, dbi, pp));
-				cursor = pp.get(0);
+				cursor = pool.getCursor(stack, txn, dbi);
 			}
 		}
 
@@ -212,7 +210,7 @@ final class TxnRecordCache {
 			if (txn != 0) {
 				keyData.close();
 				valueData.close();
-				mdb_cursor_close(cursor);
+				Pool.get().freeCursor(cursor, dbi);
 				mdb_txn_abort(txn);
 				txn = 0;
 			}

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/ValueStore.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/ValueStore.java
@@ -240,7 +240,7 @@ class ValueStore extends AbstractValueFactory {
 			for (int lookupDbi : new int[] { dbi, freeDbi }) {
 				long cursor = 0;
 				try {
-					cursor = pool.getCursor(stack, txn, lookupDbi);
+					cursor = pool.getCursor(stack, env, txn, lookupDbi);
 
 					MDBVal keyData = MDBVal.calloc(stack);
 					// set cursor after max ID
@@ -259,7 +259,7 @@ class ValueStore extends AbstractValueFactory {
 						nextId = Math.max(nextId, (data2id(keyData.mv_data()) >> 2) + 1);
 					}
 				} finally {
-					pool.freeCursor(cursor, lookupDbi);
+					pool.freeCursor(cursor, lookupDbi, env);
 				}
 			}
 			return null;
@@ -275,7 +275,7 @@ class ValueStore extends AbstractValueFactory {
 			long cursor = 0;
 
 			try {
-				cursor = pool.getCursor(stack, txn, dbi);
+				cursor = pool.getCursor(stack, env, txn, dbi);
 
 				MDBVal keyData = MDBVal.calloc(stack);
 				// set cursor to min key
@@ -292,7 +292,7 @@ class ValueStore extends AbstractValueFactory {
 					rc = mdb_cursor_get(cursor, keyData, valueData, MDB_NEXT);
 				}
 			} finally {
-				pool.freeCursor(cursor, dbi);
+				pool.freeCursor(cursor, dbi, env);
 			}
 			return null;
 		});
@@ -383,7 +383,7 @@ class ValueStore extends AbstractValueFactory {
 				Pool pool = Pool.get();
 				long cursor = 0;
 				try {
-					cursor = pool.getCursor(stack, txn, freeDbi);
+					cursor = pool.getCursor(stack, env, txn, freeDbi);
 
 					MDBVal keyData = MDBVal.calloc(stack);
 					MDBVal valueData = MDBVal.calloc(stack);
@@ -397,7 +397,7 @@ class ValueStore extends AbstractValueFactory {
 					freeIdsAvailable = mdb_cursor_get(cursor, keyData, valueData, MDB_NEXT) == MDB_SUCCESS;
 					return null;
 				} finally {
-					pool.freeCursor(cursor, freeDbi);
+					pool.freeCursor(cursor, freeDbi, env);
 				}
 			});
 			if (reusedId != null) {
@@ -770,7 +770,7 @@ class ValueStore extends AbstractValueFactory {
 				Pool pool = Pool.get();
 				long cursor = 0;
 				try {
-					cursor = pool.getCursor(stack, txn, dbi);
+					cursor = pool.getCursor(stack, env, txn, dbi);
 
 					// iterate all entries for hash value
 					if (mdb_cursor_get(cursor, hashVal, dataVal, MDB_SET_RANGE) == MDB_SUCCESS) {
@@ -791,7 +791,7 @@ class ValueStore extends AbstractValueFactory {
 						} while (mdb_cursor_get(cursor, hashVal, dataVal, MDB_NEXT) == MDB_SUCCESS);
 					}
 				} finally {
-					pool.freeCursor(cursor, dbi);
+					pool.freeCursor(cursor, dbi, env);
 				}
 
 				if (!create) {
@@ -1073,8 +1073,8 @@ class ValueStore extends AbstractValueFactory {
 							hashVal.mv_data(hashBb);
 
 							if (valuesCursor == 0) {
-								// initialize cursor
-								valuesCursor = pool.getCursor(stack, txn, dbi);
+// initialize cursor
+								valuesCursor = pool.getCursor(stack, env, txn, dbi);
 							}
 
 							if (mdb_cursor_get(valuesCursor, hashVal, dataVal, MDB_SET_RANGE) == MDB_SUCCESS) {
@@ -1114,7 +1114,7 @@ class ValueStore extends AbstractValueFactory {
 				}
 			}
 		} finally {
-			pool.freeCursor(valuesCursor, dbi);
+			pool.freeCursor(valuesCursor, dbi, env);
 		}
 	}
 
@@ -1130,7 +1130,7 @@ class ValueStore extends AbstractValueFactory {
 		Pool pool = Pool.get();
 		long unusedIdsCursor = 0;
 		try {
-			unusedIdsCursor = pool.getCursor(stack, txn, unusedDbi);
+			unusedIdsCursor = pool.getCursor(stack, env, txn, unusedDbi);
 
 			if (revisionIds == null) {
 				// marker to delete all IDs
@@ -1163,7 +1163,7 @@ class ValueStore extends AbstractValueFactory {
 				}
 			}
 		} finally {
-			pool.freeCursor(unusedIdsCursor, unusedDbi);
+			pool.freeCursor(unusedIdsCursor, unusedDbi, env);
 		}
 		this.freeIdsAvailable |= freeIds;
 	}

--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/ValueStore.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/ValueStore.java
@@ -26,10 +26,8 @@ import static org.lwjgl.util.lmdb.LMDB.MDB_RDONLY;
 import static org.lwjgl.util.lmdb.LMDB.MDB_RESERVE;
 import static org.lwjgl.util.lmdb.LMDB.MDB_SET_RANGE;
 import static org.lwjgl.util.lmdb.LMDB.MDB_SUCCESS;
-import static org.lwjgl.util.lmdb.LMDB.mdb_cursor_close;
 import static org.lwjgl.util.lmdb.LMDB.mdb_cursor_del;
 import static org.lwjgl.util.lmdb.LMDB.mdb_cursor_get;
-import static org.lwjgl.util.lmdb.LMDB.mdb_cursor_open;
 import static org.lwjgl.util.lmdb.LMDB.mdb_del;
 import static org.lwjgl.util.lmdb.LMDB.mdb_env_close;
 import static org.lwjgl.util.lmdb.LMDB.mdb_env_create;
@@ -237,13 +235,12 @@ class ValueStore extends AbstractValueFactory {
 
 		// read maximum id from store
 		readTransaction(env, (stack, txn) -> {
-			long cursor = 0;
-			PointerBuffer pp = stack.mallocPointer(1);
+			Pool pool = Pool.get();
 
 			for (int lookupDbi : new int[] { dbi, freeDbi }) {
+				long cursor = 0;
 				try {
-					E(mdb_cursor_open(txn, lookupDbi, pp));
-					cursor = pp.get(0);
+					cursor = pool.getCursor(stack, txn, lookupDbi);
 
 					MDBVal keyData = MDBVal.calloc(stack);
 					// set cursor after max ID
@@ -262,9 +259,7 @@ class ValueStore extends AbstractValueFactory {
 						nextId = Math.max(nextId, (data2id(keyData.mv_data()) >> 2) + 1);
 					}
 				} finally {
-					if (cursor != 0) {
-						mdb_cursor_close(cursor);
-					}
+					pool.freeCursor(cursor, lookupDbi);
 				}
 			}
 			return null;
@@ -276,12 +271,11 @@ class ValueStore extends AbstractValueFactory {
 
 	private void logValues() throws IOException {
 		readTransaction(env, (stack, txn) -> {
+			Pool pool = Pool.get();
 			long cursor = 0;
-			PointerBuffer pp = stack.mallocPointer(1);
 
 			try {
-				E(mdb_cursor_open(txn, dbi, pp));
-				cursor = pp.get(0);
+				cursor = pool.getCursor(stack, txn, dbi);
 
 				MDBVal keyData = MDBVal.calloc(stack);
 				// set cursor to min key
@@ -298,9 +292,7 @@ class ValueStore extends AbstractValueFactory {
 					rc = mdb_cursor_get(cursor, keyData, valueData, MDB_NEXT);
 				}
 			} finally {
-				if (cursor != 0) {
-					mdb_cursor_close(cursor);
-				}
+				pool.freeCursor(cursor, dbi);
 			}
 			return null;
 		});
@@ -388,11 +380,10 @@ class ValueStore extends AbstractValueFactory {
 		if (freeIdsAvailable) {
 			// next id from store
 			Long reusedId = writeTransaction((stack, txn) -> {
+				Pool pool = Pool.get();
 				long cursor = 0;
 				try {
-					PointerBuffer pp = stack.mallocPointer(1);
-					E(mdb_cursor_open(txn, freeDbi, pp));
-					cursor = pp.get(0);
+					cursor = pool.getCursor(stack, txn, freeDbi);
 
 					MDBVal keyData = MDBVal.calloc(stack);
 					MDBVal valueData = MDBVal.calloc(stack);
@@ -406,9 +397,7 @@ class ValueStore extends AbstractValueFactory {
 					freeIdsAvailable = mdb_cursor_get(cursor, keyData, valueData, MDB_NEXT) == MDB_SUCCESS;
 					return null;
 				} finally {
-					if (cursor != 0) {
-						mdb_cursor_close(cursor);
-					}
+					pool.freeCursor(cursor, freeDbi);
 				}
 			});
 			if (reusedId != null) {
@@ -778,11 +767,10 @@ class ValueStore extends AbstractValueFactory {
 				hashBb.put(0, HASHID_KEY);
 				hashVal.mv_data(hashBb);
 
+				Pool pool = Pool.get();
 				long cursor = 0;
 				try {
-					PointerBuffer pp = stack.mallocPointer(1);
-					E(mdb_cursor_open(txn, dbi, pp));
-					cursor = pp.get(0);
+					cursor = pool.getCursor(stack, txn, dbi);
 
 					// iterate all entries for hash value
 					if (mdb_cursor_get(cursor, hashVal, dataVal, MDB_SET_RANGE) == MDB_SUCCESS) {
@@ -803,9 +791,7 @@ class ValueStore extends AbstractValueFactory {
 						} while (mdb_cursor_get(cursor, hashVal, dataVal, MDB_NEXT) == MDB_SUCCESS);
 					}
 				} finally {
-					if (cursor != 0) {
-						mdb_cursor_close(cursor);
-					}
+					pool.freeCursor(cursor, dbi);
 				}
 
 				if (!create) {
@@ -1039,6 +1025,7 @@ class ValueStore extends AbstractValueFactory {
 
 		ByteBuffer refIdBb = idBuffer(stack);
 
+		Pool pool = Pool.get();
 		long valuesCursor = 0;
 		try {
 			for (Long id : ids) {
@@ -1087,9 +1074,7 @@ class ValueStore extends AbstractValueFactory {
 
 							if (valuesCursor == 0) {
 								// initialize cursor
-								PointerBuffer pp = stack.mallocPointer(1);
-								E(mdb_cursor_open(txn, dbi, pp));
-								valuesCursor = pp.get(0);
+								valuesCursor = pool.getCursor(stack, txn, dbi);
 							}
 
 							if (mdb_cursor_get(valuesCursor, hashVal, dataVal, MDB_SET_RANGE) == MDB_SUCCESS) {
@@ -1129,9 +1114,7 @@ class ValueStore extends AbstractValueFactory {
 				}
 			}
 		} finally {
-			if (valuesCursor != 0) {
-				mdb_cursor_close(valuesCursor);
-			}
+			pool.freeCursor(valuesCursor, dbi);
 		}
 	}
 
@@ -1144,11 +1127,10 @@ class ValueStore extends AbstractValueFactory {
 		ByteBuffer revIdBb = stack.malloc(1 + Long.BYTES + 2 + Long.BYTES);
 
 		boolean freeIds = false;
+		Pool pool = Pool.get();
 		long unusedIdsCursor = 0;
 		try {
-			PointerBuffer pp = stack.mallocPointer(1);
-			E(mdb_cursor_open(txn, unusedDbi, pp));
-			unusedIdsCursor = pp.get(0);
+			unusedIdsCursor = pool.getCursor(stack, txn, unusedDbi);
 
 			if (revisionIds == null) {
 				// marker to delete all IDs
@@ -1181,9 +1163,7 @@ class ValueStore extends AbstractValueFactory {
 				}
 			}
 		} finally {
-			if (unusedIdsCursor != 0) {
-				mdb_cursor_close(unusedIdsCursor);
-			}
+			pool.freeCursor(unusedIdsCursor, unusedDbi);
 		}
 		this.freeIdsAvailable |= freeIds;
 	}

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/PoolCursorTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/PoolCursorTest.java
@@ -12,6 +12,7 @@ package org.eclipse.rdf4j.sail.lmdb;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.lwjgl.system.MemoryUtil.NULL;
 import static org.lwjgl.util.lmdb.LMDB.MDB_CREATE;
 import static org.lwjgl.util.lmdb.LMDB.MDB_FIRST;
@@ -30,6 +31,7 @@ import static org.lwjgl.util.lmdb.LMDB.mdb_txn_abort;
 import static org.lwjgl.util.lmdb.LMDB.mdb_txn_begin;
 
 import java.io.File;
+import java.lang.reflect.Field;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -71,11 +73,11 @@ class PoolCursorTest {
 				LmdbUtil.E(mdb_txn_begin(env, NULL, MDB_RDONLY, txnPointer));
 				long txn = txnPointer.get(0);
 
-				firstCursor = pool.getCursor(stack, txn, dbi);
+				firstCursor = pool.getCursor(stack, env, txn, dbi);
 				MDBVal key = MDBVal.calloc(stack);
 				MDBVal value = MDBVal.calloc(stack);
 				assertEquals(MDB_SUCCESS, mdb_cursor_get(firstCursor, key, value, MDB_FIRST));
-				pool.freeCursor(firstCursor, dbi);
+				pool.freeCursor(firstCursor, dbi, env);
 				mdb_txn_abort(txn);
 			}
 
@@ -84,12 +86,12 @@ class PoolCursorTest {
 				LmdbUtil.E(mdb_txn_begin(env, NULL, MDB_RDONLY, txnPointer));
 				long txn = txnPointer.get(0);
 
-				long secondCursor = pool.getCursor(stack, txn, dbi);
+				long secondCursor = pool.getCursor(stack, env, txn, dbi);
 				MDBVal key = MDBVal.calloc(stack);
 				MDBVal value = MDBVal.calloc(stack);
 				assertEquals(firstCursor, secondCursor);
 				assertEquals(MDB_SUCCESS, mdb_cursor_get(secondCursor, key, value, MDB_FIRST));
-				pool.freeCursor(secondCursor, dbi);
+				pool.freeCursor(secondCursor, dbi, env);
 				mdb_txn_abort(txn);
 			}
 		} finally {
@@ -129,8 +131,8 @@ class PoolCursorTest {
 				LmdbUtil.E(mdb_txn_begin(env, NULL, MDB_RDONLY, txnPointer));
 				long txn = txnPointer.get(0);
 
-				long readCursor = pool.getCursor(stack, txn, dbi);
-				pool.freeCursor(readCursor, dbi);
+				long readCursor = pool.getCursor(stack, env, txn, dbi);
+				pool.freeCursor(readCursor, dbi, env);
 				mdb_txn_abort(txn);
 			}
 
@@ -139,16 +141,102 @@ class PoolCursorTest {
 				LmdbUtil.E(mdb_txn_begin(env, NULL, 0, txnPointer));
 				long txn = txnPointer.get(0);
 
-				long writeCursor = assertDoesNotThrow(() -> pool.getCursor(stack, txn, dbi));
+				long writeCursor = assertDoesNotThrow(() -> pool.getCursor(stack, env, txn, dbi));
 
 				MDBVal key = MDBVal.calloc(stack);
 				MDBVal value = MDBVal.calloc(stack);
 				assertEquals(MDB_SUCCESS, mdb_cursor_get(writeCursor, key, value, MDB_FIRST));
-				pool.freeCursor(writeCursor, dbi);
+				pool.freeCursor(writeCursor, dbi, env);
 				mdb_txn_abort(txn);
 			}
 		} finally {
 			mdb_env_close(env);
+			Pool.release();
+		}
+	}
+
+	@Test
+	void doesNotReuseCursorsAcrossEnvironments(@TempDir File dataDir) throws Exception {
+		File mainDir = new File(dataDir, "main");
+		File cacheDir = new File(dataDir, "cache");
+		mainDir.mkdir();
+		cacheDir.mkdir();
+
+		long mainEnv;
+		long cacheEnv;
+		try (MemoryStack stack = MemoryStack.stackPush()) {
+			PointerBuffer envPointer = stack.mallocPointer(1);
+			LmdbUtil.E(mdb_env_create(envPointer));
+			mainEnv = envPointer.get(0);
+
+			LmdbUtil.E(mdb_env_create(envPointer));
+			cacheEnv = envPointer.get(0);
+		}
+
+		try {
+			LmdbUtil.E(mdb_env_set_maxdbs(mainEnv, 1));
+			LmdbUtil.E(mdb_env_set_maxdbs(cacheEnv, 1));
+			LmdbUtil.E(mdb_env_open(mainEnv, mainDir.getAbsolutePath(), MDB_NOSYNC | MDB_NOMETASYNC | MDB_NOTLS, 0664));
+			LmdbUtil.E(
+					mdb_env_open(cacheEnv, cacheDir.getAbsolutePath(), MDB_NOSYNC | MDB_NOMETASYNC | MDB_NOTLS, 0664));
+
+			int mainDbi = LmdbUtil.openDatabase(mainEnv, null, MDB_CREATE, null);
+			int cacheDbi = LmdbUtil.openDatabase(cacheEnv, null, MDB_CREATE, null);
+
+			LmdbUtil.transaction(mainEnv, (stack, txn) -> {
+				MDBVal key = MDBVal.calloc(stack);
+				key.mv_data(stack.bytes((byte) 1));
+				MDBVal value = MDBVal.calloc(stack);
+				value.mv_data(stack.bytes((byte) 1));
+				mdb_put(txn, mainDbi, key, value, 0);
+				return null;
+			});
+
+			Pool pool = Pool.get();
+			long cachedCursor;
+			Field cursorPoolField = Pool.class.getDeclaredField("cursorPool");
+			cursorPoolField.setAccessible(true);
+			Field cursorEnvPoolField = Pool.class.getDeclaredField("cursorEnvPool");
+			cursorEnvPoolField.setAccessible(true);
+			Field cursorPoolIndexField = Pool.class.getDeclaredField("cursorPoolIndex");
+			cursorPoolIndexField.setAccessible(true);
+
+			try (MemoryStack stack = MemoryStack.stackPush()) {
+				PointerBuffer txnPointer = stack.mallocPointer(1);
+				LmdbUtil.E(mdb_txn_begin(cacheEnv, NULL, MDB_RDONLY, txnPointer));
+				long txn = txnPointer.get(0);
+
+				cachedCursor = pool.getCursor(stack, cacheEnv, txn, cacheDbi);
+				pool.freeCursor(cachedCursor, cacheDbi, cacheEnv);
+				mdb_txn_abort(txn);
+			}
+
+			int poolIndexBefore = cursorPoolIndexField.getInt(pool);
+			long[] cursorPool = (long[]) cursorPoolField.get(pool);
+			assertEquals(cachedCursor, cursorPool[poolIndexBefore]);
+
+			mdb_env_close(cacheEnv);
+
+			try (MemoryStack stack = MemoryStack.stackPush()) {
+				PointerBuffer txnPointer = stack.mallocPointer(1);
+				LmdbUtil.E(mdb_txn_begin(mainEnv, NULL, MDB_RDONLY, txnPointer));
+				long txn = txnPointer.get(0);
+
+				long cursor = assertDoesNotThrow(() -> pool.getCursor(stack, mainEnv, txn, mainDbi));
+				MDBVal key = MDBVal.calloc(stack);
+				MDBVal value = MDBVal.calloc(stack);
+				assertEquals(MDB_SUCCESS, mdb_cursor_get(cursor, key, value, MDB_FIRST));
+				pool.freeCursor(cursor, mainDbi, mainEnv);
+				mdb_txn_abort(txn);
+			}
+
+			int poolIndexAfter = cursorPoolIndexField.getInt(pool);
+			assertEquals(poolIndexBefore, poolIndexAfter);
+			assertEquals(cachedCursor, cursorPool[poolIndexAfter]);
+			long[] cursorEnvPool = (long[]) cursorEnvPoolField.get(pool);
+			assertEquals(mainEnv, cursorEnvPool[poolIndexAfter]);
+		} finally {
+			mdb_env_close(mainEnv);
 			Pool.release();
 		}
 	}

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/PoolCursorTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/PoolCursorTest.java
@@ -1,0 +1,99 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *******************************************************************************/
+package org.eclipse.rdf4j.sail.lmdb;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.lwjgl.system.MemoryUtil.NULL;
+import static org.lwjgl.util.lmdb.LMDB.MDB_CREATE;
+import static org.lwjgl.util.lmdb.LMDB.MDB_FIRST;
+import static org.lwjgl.util.lmdb.LMDB.MDB_NOMETASYNC;
+import static org.lwjgl.util.lmdb.LMDB.MDB_NOSYNC;
+import static org.lwjgl.util.lmdb.LMDB.MDB_NOTLS;
+import static org.lwjgl.util.lmdb.LMDB.MDB_RDONLY;
+import static org.lwjgl.util.lmdb.LMDB.MDB_SUCCESS;
+import static org.lwjgl.util.lmdb.LMDB.mdb_cursor_get;
+import static org.lwjgl.util.lmdb.LMDB.mdb_env_close;
+import static org.lwjgl.util.lmdb.LMDB.mdb_env_create;
+import static org.lwjgl.util.lmdb.LMDB.mdb_env_open;
+import static org.lwjgl.util.lmdb.LMDB.mdb_env_set_maxdbs;
+import static org.lwjgl.util.lmdb.LMDB.mdb_put;
+import static org.lwjgl.util.lmdb.LMDB.mdb_txn_abort;
+import static org.lwjgl.util.lmdb.LMDB.mdb_txn_begin;
+
+import java.io.File;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.lwjgl.PointerBuffer;
+import org.lwjgl.system.MemoryStack;
+import org.lwjgl.util.lmdb.MDBVal;
+
+class PoolCursorTest {
+
+	@Test
+	void reusesCursors(@TempDir File dataDir) throws Exception {
+		long env;
+		try (MemoryStack stack = MemoryStack.stackPush()) {
+			PointerBuffer envPointer = stack.mallocPointer(1);
+			LmdbUtil.E(mdb_env_create(envPointer));
+			env = envPointer.get(0);
+		}
+
+		try {
+			LmdbUtil.E(mdb_env_set_maxdbs(env, 1));
+			LmdbUtil.E(mdb_env_open(env, dataDir.getAbsolutePath(), MDB_NOSYNC | MDB_NOMETASYNC | MDB_NOTLS, 0664));
+
+			int dbi = LmdbUtil.openDatabase(env, null, MDB_CREATE, null);
+
+			LmdbUtil.transaction(env, (stack, txn) -> {
+				MDBVal key = MDBVal.calloc(stack);
+				key.mv_data(stack.bytes((byte) 1));
+				MDBVal value = MDBVal.calloc(stack);
+				value.mv_data(stack.bytes((byte) 1));
+				mdb_put(txn, dbi, key, value, 0);
+				return null;
+			});
+
+			Pool pool = Pool.get();
+			long firstCursor;
+
+			try (MemoryStack stack = MemoryStack.stackPush()) {
+				PointerBuffer txnPointer = stack.mallocPointer(1);
+				LmdbUtil.E(mdb_txn_begin(env, NULL, MDB_RDONLY, txnPointer));
+				long txn = txnPointer.get(0);
+
+				firstCursor = pool.getCursor(stack, txn, dbi);
+				MDBVal key = MDBVal.calloc(stack);
+				MDBVal value = MDBVal.calloc(stack);
+				assertEquals(MDB_SUCCESS, mdb_cursor_get(firstCursor, key, value, MDB_FIRST));
+				pool.freeCursor(firstCursor, dbi);
+				mdb_txn_abort(txn);
+			}
+
+			try (MemoryStack stack = MemoryStack.stackPush()) {
+				PointerBuffer txnPointer = stack.mallocPointer(1);
+				LmdbUtil.E(mdb_txn_begin(env, NULL, MDB_RDONLY, txnPointer));
+				long txn = txnPointer.get(0);
+
+				long secondCursor = pool.getCursor(stack, txn, dbi);
+				MDBVal key = MDBVal.calloc(stack);
+				MDBVal value = MDBVal.calloc(stack);
+				assertEquals(firstCursor, secondCursor);
+				assertEquals(MDB_SUCCESS, mdb_cursor_get(secondCursor, key, value, MDB_FIRST));
+				pool.freeCursor(secondCursor, dbi);
+				mdb_txn_abort(txn);
+			}
+		} finally {
+			mdb_env_close(env);
+			Pool.release();
+		}
+	}
+}

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/PoolCursorTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/PoolCursorTest.java
@@ -232,8 +232,8 @@ class PoolCursorTest {
 
 			int poolIndexAfter = cursorPoolIndexField.getInt(pool);
 			assertEquals(poolIndexBefore, poolIndexAfter);
-			assertEquals(cachedCursor, cursorPool[poolIndexAfter]);
 			long[] cursorEnvPool = (long[]) cursorEnvPoolField.get(pool);
+			assertNotEquals(0L, cursorPool[poolIndexAfter]);
 			assertEquals(mainEnv, cursorEnvPool[poolIndexAfter]);
 		} finally {
 			mdb_env_close(mainEnv);

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/PoolCursorTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/PoolCursorTest.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package org.eclipse.rdf4j.sail.lmdb;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.lwjgl.system.MemoryUtil.NULL;
 import static org.lwjgl.util.lmdb.LMDB.MDB_CREATE;
@@ -89,6 +90,61 @@ class PoolCursorTest {
 				assertEquals(firstCursor, secondCursor);
 				assertEquals(MDB_SUCCESS, mdb_cursor_get(secondCursor, key, value, MDB_FIRST));
 				pool.freeCursor(secondCursor, dbi);
+				mdb_txn_abort(txn);
+			}
+		} finally {
+			mdb_env_close(env);
+			Pool.release();
+		}
+	}
+
+	@Test
+	void opensNewCursorForWriteTxn(@TempDir File dataDir) throws Exception {
+		long env;
+		try (MemoryStack stack = MemoryStack.stackPush()) {
+			PointerBuffer envPointer = stack.mallocPointer(1);
+			LmdbUtil.E(mdb_env_create(envPointer));
+			env = envPointer.get(0);
+		}
+
+		try {
+			LmdbUtil.E(mdb_env_set_maxdbs(env, 1));
+			LmdbUtil.E(mdb_env_open(env, dataDir.getAbsolutePath(), MDB_NOSYNC | MDB_NOMETASYNC | MDB_NOTLS, 0664));
+
+			int dbi = LmdbUtil.openDatabase(env, null, MDB_CREATE, null);
+
+			LmdbUtil.transaction(env, (stack, txn) -> {
+				MDBVal key = MDBVal.calloc(stack);
+				key.mv_data(stack.bytes((byte) 1));
+				MDBVal value = MDBVal.calloc(stack);
+				value.mv_data(stack.bytes((byte) 1));
+				mdb_put(txn, dbi, key, value, 0);
+				return null;
+			});
+
+			Pool pool = Pool.get();
+
+			try (MemoryStack stack = MemoryStack.stackPush()) {
+				PointerBuffer txnPointer = stack.mallocPointer(1);
+				LmdbUtil.E(mdb_txn_begin(env, NULL, MDB_RDONLY, txnPointer));
+				long txn = txnPointer.get(0);
+
+				long readCursor = pool.getCursor(stack, txn, dbi);
+				pool.freeCursor(readCursor, dbi);
+				mdb_txn_abort(txn);
+			}
+
+			try (MemoryStack stack = MemoryStack.stackPush()) {
+				PointerBuffer txnPointer = stack.mallocPointer(1);
+				LmdbUtil.E(mdb_txn_begin(env, NULL, 0, txnPointer));
+				long txn = txnPointer.get(0);
+
+				long writeCursor = assertDoesNotThrow(() -> pool.getCursor(stack, txn, dbi));
+
+				MDBVal key = MDBVal.calloc(stack);
+				MDBVal value = MDBVal.calloc(stack);
+				assertEquals(MDB_SUCCESS, mdb_cursor_get(writeCursor, key, value, MDB_FIRST));
+				pool.freeCursor(writeCursor, dbi);
 				mdb_txn_abort(txn);
 			}
 		} finally {


### PR DESCRIPTION
## Summary
- add cursor pooling support in Pool with lifecycle management
- update LMDB iterators and stores to acquire cursors from the pool and return them for reuse
- add PoolCursorTest to verify pooled cursors are reused between transactions

## Testing
- mvn -pl core/sail/lmdb -Dtest=PoolCursorTest test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935de8dd088832eb241e623960078ab)