### PR TITLE
Add retry to ValueStoreWalSearchTest

### DIFF
--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/wal/ValueStoreWalSearchTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/wal/ValueStoreWalSearchTest.java
@@ -66,9 +66,15 @@ class ValueStoreWalSearchTest {
 		Integer[] ids = dict.keySet().toArray(Integer[]::new);
 		Integer pickId = ids[new Random().nextInt(ids.length)];
 
-		ValueStoreWalSearch search = ValueStoreWalSearch.open(cfgRead);
-		Value found = search.findValueById(pickId);
-		assertThat(found).as("ValueStoreWalSearch should find value by id").isNotNull();
+                ValueStoreWalSearch search = ValueStoreWalSearch.open(cfgRead);
+                Value found = null;
+                for (int attempt = 0; attempt < 10 && found == null; attempt++) {
+                        found = search.findValueById(pickId);
+                        if (found == null) {
+                                Thread.sleep(100);
+                        }
+                }
+                assertThat(found).as("ValueStoreWalSearch should find value by id").isNotNull();
 
 		// Cross-check against ValueStore
 		try (ValueStore vs = new ValueStore(dataDir, false)) {

--- a/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/wal/ValueStoreWalSearchTest.java
+++ b/core/sail/nativerdf/src/test/java/org/eclipse/rdf4j/sail/nativerdf/wal/ValueStoreWalSearchTest.java
@@ -66,15 +66,15 @@ class ValueStoreWalSearchTest {
 		Integer[] ids = dict.keySet().toArray(Integer[]::new);
 		Integer pickId = ids[new Random().nextInt(ids.length)];
 
-                ValueStoreWalSearch search = ValueStoreWalSearch.open(cfgRead);
-                Value found = null;
-                for (int attempt = 0; attempt < 10 && found == null; attempt++) {
-                        found = search.findValueById(pickId);
-                        if (found == null) {
-                                Thread.sleep(100);
-                        }
-                }
-                assertThat(found).as("ValueStoreWalSearch should find value by id").isNotNull();
+		ValueStoreWalSearch search = ValueStoreWalSearch.open(cfgRead);
+		Value found = null;
+		for (int attempt = 0; attempt < 10 && found == null; attempt++) {
+			found = search.findValueById(pickId);
+			if (found == null) {
+				Thread.sleep(100);
+			}
+		}
+		assertThat(found).as("ValueStoreWalSearch should find value by id").isNotNull();
 
 		// Cross-check against ValueStore
 		try (ValueStore vs = new ValueStore(dataDir, false)) {


### PR DESCRIPTION
## Summary
- add a retry loop when ValueStoreWalSearch returns null to make the test more resilient

## Testing
- not run (per request)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693860b6898c832e9698aa3e750a508c)