### PR TITLE
GH-0000 Implement leapfrog triejoin for memory store

### DIFF
--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/MemorySailStore.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/MemorySailStore.java
@@ -931,7 +931,7 @@ class MemorySailStore implements SailStore {
 	/**
 	 * @author James Leigh
 	 */
-	private final class MemorySailDataset implements SailDataset {
+final class MemorySailDataset implements SailDataset {
 
 		private final boolean explicit;
 

--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/MemorySailStore.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/MemorySailStore.java
@@ -931,7 +931,7 @@ class MemorySailStore implements SailStore {
 	/**
 	 * @author James Leigh
 	 */
-final class MemorySailDataset implements SailDataset {
+	final class MemorySailDataset implements SailDataset {
 
 		private final boolean explicit;
 

--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/MemoryStore.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/MemoryStore.java
@@ -23,6 +23,7 @@ import org.eclipse.rdf4j.query.algebra.evaluation.EvaluationStrategyFactory;
 import org.eclipse.rdf4j.query.algebra.evaluation.federation.FederatedServiceResolver;
 import org.eclipse.rdf4j.query.algebra.evaluation.federation.FederatedServiceResolverClient;
 import org.eclipse.rdf4j.query.algebra.evaluation.impl.DefaultEvaluationStrategyFactory;
+import org.eclipse.rdf4j.sail.memory.evaluation.MemoryEvaluationStrategyFactory;
 import org.eclipse.rdf4j.repository.sparql.federation.SPARQLServiceResolver;
 import org.eclipse.rdf4j.sail.NotifyingSailConnection;
 import org.eclipse.rdf4j.sail.SailChangedEvent;
@@ -206,14 +207,14 @@ public class MemoryStore extends AbstractNotifyingSail implements FederatedServi
 	/**
 	 * @return Returns the {@link EvaluationStrategy}.
 	 */
-	public synchronized EvaluationStrategyFactory getEvaluationStrategyFactory() {
-		if (evalStratFactory == null) {
-			evalStratFactory = new DefaultEvaluationStrategyFactory(getFederatedServiceResolver());
-		}
-		evalStratFactory.setQuerySolutionCacheThreshold(getIterationCacheSyncThreshold());
-		evalStratFactory.setTrackResultSize(isTrackResultSize());
-		return evalStratFactory;
-	}
+public synchronized EvaluationStrategyFactory getEvaluationStrategyFactory() {
+if (evalStratFactory == null) {
+evalStratFactory = new MemoryEvaluationStrategyFactory(getFederatedServiceResolver());
+}
+evalStratFactory.setQuerySolutionCacheThreshold(getIterationCacheSyncThreshold());
+evalStratFactory.setTrackResultSize(isTrackResultSize());
+return evalStratFactory;
+}
 
 	/**
 	 * Sets the {@link EvaluationStrategy} to use.

--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/MemoryStore.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/MemoryStore.java
@@ -23,7 +23,6 @@ import org.eclipse.rdf4j.query.algebra.evaluation.EvaluationStrategyFactory;
 import org.eclipse.rdf4j.query.algebra.evaluation.federation.FederatedServiceResolver;
 import org.eclipse.rdf4j.query.algebra.evaluation.federation.FederatedServiceResolverClient;
 import org.eclipse.rdf4j.query.algebra.evaluation.impl.DefaultEvaluationStrategyFactory;
-import org.eclipse.rdf4j.sail.memory.evaluation.MemoryEvaluationStrategyFactory;
 import org.eclipse.rdf4j.repository.sparql.federation.SPARQLServiceResolver;
 import org.eclipse.rdf4j.sail.NotifyingSailConnection;
 import org.eclipse.rdf4j.sail.SailChangedEvent;
@@ -33,6 +32,7 @@ import org.eclipse.rdf4j.sail.base.SailSink;
 import org.eclipse.rdf4j.sail.base.SailStore;
 import org.eclipse.rdf4j.sail.helpers.AbstractNotifyingSail;
 import org.eclipse.rdf4j.sail.helpers.DirectoryLockManager;
+import org.eclipse.rdf4j.sail.memory.evaluation.MemoryEvaluationStrategyFactory;
 import org.eclipse.rdf4j.sail.memory.model.MemValueFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -207,14 +207,14 @@ public class MemoryStore extends AbstractNotifyingSail implements FederatedServi
 	/**
 	 * @return Returns the {@link EvaluationStrategy}.
 	 */
-public synchronized EvaluationStrategyFactory getEvaluationStrategyFactory() {
-if (evalStratFactory == null) {
-evalStratFactory = new MemoryEvaluationStrategyFactory(getFederatedServiceResolver());
-}
-evalStratFactory.setQuerySolutionCacheThreshold(getIterationCacheSyncThreshold());
-evalStratFactory.setTrackResultSize(isTrackResultSize());
-return evalStratFactory;
-}
+	public synchronized EvaluationStrategyFactory getEvaluationStrategyFactory() {
+		if (evalStratFactory == null) {
+			evalStratFactory = new MemoryEvaluationStrategyFactory(getFederatedServiceResolver());
+		}
+		evalStratFactory.setQuerySolutionCacheThreshold(getIterationCacheSyncThreshold());
+		evalStratFactory.setTrackResultSize(isTrackResultSize());
+		return evalStratFactory;
+	}
 
 	/**
 	 * Sets the {@link EvaluationStrategy} to use.

--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/MemoryStoreConnection.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/MemoryStoreConnection.java
@@ -42,7 +42,7 @@ import org.slf4j.LoggerFactory;
  */
 public class MemoryStoreConnection extends SailSourceConnection implements ThreadSafetyAware {
 
-private static final Logger logger = LoggerFactory.getLogger(MemoryStoreConnection.class);
+	private static final Logger logger = LoggerFactory.getLogger(MemoryStoreConnection.class);
 
 	/*-----------*
 	 * Variables *
@@ -93,60 +93,60 @@ private static final Logger logger = LoggerFactory.getLogger(MemoryStoreConnecti
 		sailChangedEvent = new DefaultSailChangedEvent(sail);
 	}
 
-@Override
-protected void addStatementInternal(Resource subj, IRI pred, Value obj, Resource... contexts) throws SailException {
+	@Override
+	protected void addStatementInternal(Resource subj, IRI pred, Value obj, Resource... contexts) throws SailException {
 // assume the triple is not yet present in the triple store
-sailChangedEvent.setStatementsAdded(true);
-}
+		sailChangedEvent.setStatementsAdded(true);
+	}
 
-@Override
-protected CloseableIteration<? extends BindingSet> evaluateInternal(TupleExpr tupleExpr, Dataset dataset,
-BindingSet bindings, boolean includeInferred) throws SailException {
+	@Override
+	protected CloseableIteration<? extends BindingSet> evaluateInternal(TupleExpr tupleExpr, Dataset dataset,
+			BindingSet bindings, boolean includeInferred) throws SailException {
 
-logger.trace("Incoming query model:\n{}", tupleExpr);
+		logger.trace("Incoming query model:\n{}", tupleExpr);
 
-if (!(tupleExpr instanceof QueryRoot)) {
+		if (!(tupleExpr instanceof QueryRoot)) {
 // Add a dummy root node to the tuple expressions to allow the optimizers to modify the actual root node
-tupleExpr = new QueryRoot(tupleExpr);
-}
+			tupleExpr = new QueryRoot(tupleExpr);
+		}
 
-SailSource branch = null;
-MemorySailStore.MemorySailDataset rdfDataset = null;
-CloseableIteration<BindingSet> iteration = null;
-boolean allGood = false;
-try {
-branch = branch(IncludeInferred.fromBoolean(includeInferred));
-rdfDataset = (MemorySailStore.MemorySailDataset) branch.dataset(getIsolationLevel());
+		SailSource branch = null;
+		MemorySailStore.MemorySailDataset rdfDataset = null;
+		CloseableIteration<BindingSet> iteration = null;
+		boolean allGood = false;
+		try {
+			branch = branch(IncludeInferred.fromBoolean(includeInferred));
+			rdfDataset = (MemorySailStore.MemorySailDataset) branch.dataset(getIsolationLevel());
 
-MemoryTripleSourceWrapper tripleSource = new MemoryTripleSourceWrapper(rdfDataset, getValueFactory());
-EvaluationStrategy strategy = getEvaluationStrategy(dataset, tripleSource);
-if (isTrackResultSize()) {
-strategy.setTrackResultSize(true);
-}
+			MemoryTripleSourceWrapper tripleSource = new MemoryTripleSourceWrapper(rdfDataset, getValueFactory());
+			EvaluationStrategy strategy = getEvaluationStrategy(dataset, tripleSource);
+			if (isTrackResultSize()) {
+				strategy.setTrackResultSize(true);
+			}
 
-tupleExpr = strategy.optimize(tupleExpr, sail.getSailStore().getEvaluationStatistics(), bindings);
-logger.trace("Optimized query model:\n{}", tupleExpr);
-QueryEvaluationStep qes = strategy.precompile(tupleExpr);
-iteration = qes.evaluate(EmptyBindingSet.getInstance());
-iteration = interlock(iteration, rdfDataset, branch);
-allGood = true;
-return iteration;
-} catch (QueryEvaluationException e) {
-throw new SailException(e);
-} finally {
-if (!allGood) {
-if (iteration != null) {
-iteration.close();
-}
-if (rdfDataset != null) {
-rdfDataset.close();
-}
-if (branch != null) {
-branch.close();
-}
-}
-}
-}
+			tupleExpr = strategy.optimize(tupleExpr, sail.getSailStore().getEvaluationStatistics(), bindings);
+			logger.trace("Optimized query model:\n{}", tupleExpr);
+			QueryEvaluationStep qes = strategy.precompile(tupleExpr);
+			iteration = qes.evaluate(EmptyBindingSet.getInstance());
+			iteration = interlock(iteration, rdfDataset, branch);
+			allGood = true;
+			return iteration;
+		} catch (QueryEvaluationException e) {
+			throw new SailException(e);
+		} finally {
+			if (!allGood) {
+				if (iteration != null) {
+					iteration.close();
+				}
+				if (rdfDataset != null) {
+					rdfDataset.close();
+				}
+				if (branch != null) {
+					branch.close();
+				}
+			}
+		}
+	}
 
 	@Override
 	public boolean addInferredStatement(Resource subj, IRI pred, Value obj, Resource... contexts) throws SailException {

--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/MemoryStoreConnection.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/MemoryStoreConnection.java
@@ -11,15 +11,28 @@
 
 package org.eclipse.rdf4j.sail.memory;
 
+import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.common.transaction.IsolationLevels;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.Dataset;
+import org.eclipse.rdf4j.query.QueryEvaluationException;
+import org.eclipse.rdf4j.query.algebra.QueryRoot;
+import org.eclipse.rdf4j.query.algebra.TupleExpr;
+import org.eclipse.rdf4j.query.algebra.evaluation.EvaluationStrategy;
+import org.eclipse.rdf4j.query.algebra.evaluation.QueryEvaluationStep;
+import org.eclipse.rdf4j.query.impl.EmptyBindingSet;
 import org.eclipse.rdf4j.sail.SailException;
 import org.eclipse.rdf4j.sail.SailReadOnlyException;
+import org.eclipse.rdf4j.sail.base.SailSource;
 import org.eclipse.rdf4j.sail.base.SailSourceConnection;
 import org.eclipse.rdf4j.sail.features.ThreadSafetyAware;
 import org.eclipse.rdf4j.sail.helpers.DefaultSailChangedEvent;
+import org.eclipse.rdf4j.sail.memory.evaluation.MemoryTripleSourceWrapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Implementation of a Sail Connection for memory stores.
@@ -28,6 +41,8 @@ import org.eclipse.rdf4j.sail.helpers.DefaultSailChangedEvent;
  * @author jeen
  */
 public class MemoryStoreConnection extends SailSourceConnection implements ThreadSafetyAware {
+
+private static final Logger logger = LoggerFactory.getLogger(MemoryStoreConnection.class);
 
 	/*-----------*
 	 * Variables *
@@ -78,11 +93,60 @@ public class MemoryStoreConnection extends SailSourceConnection implements Threa
 		sailChangedEvent = new DefaultSailChangedEvent(sail);
 	}
 
-	@Override
-	protected void addStatementInternal(Resource subj, IRI pred, Value obj, Resource... contexts) throws SailException {
-		// assume the triple is not yet present in the triple store
-		sailChangedEvent.setStatementsAdded(true);
-	}
+@Override
+protected void addStatementInternal(Resource subj, IRI pred, Value obj, Resource... contexts) throws SailException {
+// assume the triple is not yet present in the triple store
+sailChangedEvent.setStatementsAdded(true);
+}
+
+@Override
+protected CloseableIteration<? extends BindingSet> evaluateInternal(TupleExpr tupleExpr, Dataset dataset,
+BindingSet bindings, boolean includeInferred) throws SailException {
+
+logger.trace("Incoming query model:\n{}", tupleExpr);
+
+if (!(tupleExpr instanceof QueryRoot)) {
+// Add a dummy root node to the tuple expressions to allow the optimizers to modify the actual root node
+tupleExpr = new QueryRoot(tupleExpr);
+}
+
+SailSource branch = null;
+MemorySailStore.MemorySailDataset rdfDataset = null;
+CloseableIteration<BindingSet> iteration = null;
+boolean allGood = false;
+try {
+branch = branch(IncludeInferred.fromBoolean(includeInferred));
+rdfDataset = (MemorySailStore.MemorySailDataset) branch.dataset(getIsolationLevel());
+
+MemoryTripleSourceWrapper tripleSource = new MemoryTripleSourceWrapper(rdfDataset, getValueFactory());
+EvaluationStrategy strategy = getEvaluationStrategy(dataset, tripleSource);
+if (isTrackResultSize()) {
+strategy.setTrackResultSize(true);
+}
+
+tupleExpr = strategy.optimize(tupleExpr, sail.getSailStore().getEvaluationStatistics(), bindings);
+logger.trace("Optimized query model:\n{}", tupleExpr);
+QueryEvaluationStep qes = strategy.precompile(tupleExpr);
+iteration = qes.evaluate(EmptyBindingSet.getInstance());
+iteration = interlock(iteration, rdfDataset, branch);
+allGood = true;
+return iteration;
+} catch (QueryEvaluationException e) {
+throw new SailException(e);
+} finally {
+if (!allGood) {
+if (iteration != null) {
+iteration.close();
+}
+if (rdfDataset != null) {
+rdfDataset.close();
+}
+if (branch != null) {
+branch.close();
+}
+}
+}
+}
 
 	@Override
 	public boolean addInferredStatement(Resource subj, IRI pred, Value obj, Resource... contexts) throws SailException {

--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/evaluation/MemoryEvaluationStrategy.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/evaluation/MemoryEvaluationStrategy.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ ******************************************************************************/
+package org.eclipse.rdf4j.sail.memory.evaluation;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.rdf4j.common.iteration.CloseableIteration;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.Dataset;
+import org.eclipse.rdf4j.query.QueryEvaluationException;
+import org.eclipse.rdf4j.query.algebra.Join;
+import org.eclipse.rdf4j.query.algebra.StatementPattern;
+import org.eclipse.rdf4j.query.algebra.TupleExpr;
+import org.eclipse.rdf4j.query.algebra.evaluation.EvaluationStrategy;
+import org.eclipse.rdf4j.query.algebra.evaluation.QueryEvaluationStep;
+import org.eclipse.rdf4j.query.algebra.evaluation.QueryEvaluationStep.DelayedEvaluation;
+import org.eclipse.rdf4j.query.algebra.evaluation.TripleSource;
+import org.eclipse.rdf4j.query.algebra.evaluation.federation.FederatedServiceResolver;
+import org.eclipse.rdf4j.query.algebra.evaluation.impl.DefaultEvaluationStrategy;
+import org.eclipse.rdf4j.query.algebra.evaluation.impl.QueryEvaluationContext;
+import org.eclipse.rdf4j.query.algebra.evaluation.impl.evaluationsteps.EvaluationStatistics;
+import org.eclipse.rdf4j.sail.memory.MemorySailStore.MemorySailDataset;
+
+public class MemoryEvaluationStrategy extends DefaultEvaluationStrategy {
+
+public MemoryEvaluationStrategy(TripleSource tripleSource, Dataset dataset,
+FederatedServiceResolver serviceResolver, long iterationCacheSyncTreshold,
+EvaluationStatistics evaluationStatistics, boolean trackResultSize) {
+super(tripleSource, dataset, serviceResolver, iterationCacheSyncTreshold, evaluationStatistics,
+trackResultSize);
+}
+
+@Override
+protected QueryEvaluationStep prepare(Join node, QueryEvaluationContext context) throws QueryEvaluationException {
+if (tripleSource instanceof MemoryTripleSourceWrapper) {
+MemoryTripleSourceWrapper memoryTripleSource = (MemoryTripleSourceWrapper) tripleSource;
+List<StatementPattern> statementPatterns = new ArrayList<>();
+if (collectStatementPatterns(node, statementPatterns)) {
+node.setAlgorithm("LeapfrogTrieJoin");
+return prepareWorstCaseJoin(statementPatterns, memoryTripleSource.getDataset(), context);
+}
+}
+
+return super.prepare(node, context);
+}
+
+private QueryEvaluationStep prepareWorstCaseJoin(List<StatementPattern> statementPatterns,
+MemorySailDataset dataset, QueryEvaluationContext context) {
+return new DelayedEvaluation(bindings -> worstCaseJoin(statementPatterns, dataset, context, bindings), context);
+}
+
+private CloseableIteration<BindingSet> worstCaseJoin(List<StatementPattern> statementPatterns,
+MemorySailDataset dataset, QueryEvaluationContext context, BindingSet bindings) {
+return new MemoryWorstCaseJoinIteration(statementPatterns, dataset, context, bindings);
+}
+
+private boolean collectStatementPatterns(TupleExpr node, List<StatementPattern> statementPatterns) {
+if (node instanceof StatementPattern) {
+statementPatterns.add((StatementPattern) node);
+return true;
+} else if (node instanceof Join) {
+Join join = (Join) node;
+return collectStatementPatterns(join.getLeftArg(), statementPatterns)
+&& collectStatementPatterns(join.getRightArg(), statementPatterns);
+}
+return false;
+}
+}

--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/evaluation/MemoryEvaluationStrategy.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/evaluation/MemoryEvaluationStrategy.java
@@ -32,46 +32,46 @@ import org.eclipse.rdf4j.sail.memory.MemorySailStore.MemorySailDataset;
 
 public class MemoryEvaluationStrategy extends DefaultEvaluationStrategy {
 
-public MemoryEvaluationStrategy(TripleSource tripleSource, Dataset dataset,
-FederatedServiceResolver serviceResolver, long iterationCacheSyncTreshold,
-EvaluationStatistics evaluationStatistics, boolean trackResultSize) {
-super(tripleSource, dataset, serviceResolver, iterationCacheSyncTreshold, evaluationStatistics,
-trackResultSize);
-}
+	public MemoryEvaluationStrategy(TripleSource tripleSource, Dataset dataset,
+			FederatedServiceResolver serviceResolver, long iterationCacheSyncTreshold,
+			EvaluationStatistics evaluationStatistics, boolean trackResultSize) {
+		super(tripleSource, dataset, serviceResolver, iterationCacheSyncTreshold, evaluationStatistics,
+				trackResultSize);
+	}
 
-@Override
-protected QueryEvaluationStep prepare(Join node, QueryEvaluationContext context) throws QueryEvaluationException {
-if (tripleSource instanceof MemoryTripleSourceWrapper) {
-MemoryTripleSourceWrapper memoryTripleSource = (MemoryTripleSourceWrapper) tripleSource;
-List<StatementPattern> statementPatterns = new ArrayList<>();
-if (collectStatementPatterns(node, statementPatterns)) {
-node.setAlgorithm("LeapfrogTrieJoin");
-return prepareWorstCaseJoin(statementPatterns, memoryTripleSource.getDataset(), context);
-}
-}
+	@Override
+	protected QueryEvaluationStep prepare(Join node, QueryEvaluationContext context) throws QueryEvaluationException {
+		if (tripleSource instanceof MemoryTripleSourceWrapper) {
+			MemoryTripleSourceWrapper memoryTripleSource = (MemoryTripleSourceWrapper) tripleSource;
+			List<StatementPattern> statementPatterns = new ArrayList<>();
+			if (collectStatementPatterns(node, statementPatterns)) {
+				node.setAlgorithm("LeapfrogTrieJoin");
+				return prepareWorstCaseJoin(statementPatterns, memoryTripleSource.getDataset(), context);
+			}
+		}
 
-return super.prepare(node, context);
-}
+		return super.prepare(node, context);
+	}
 
-private QueryEvaluationStep prepareWorstCaseJoin(List<StatementPattern> statementPatterns,
-MemorySailDataset dataset, QueryEvaluationContext context) {
-return new DelayedEvaluation(bindings -> worstCaseJoin(statementPatterns, dataset, context, bindings), context);
-}
+	private QueryEvaluationStep prepareWorstCaseJoin(List<StatementPattern> statementPatterns,
+			MemorySailDataset dataset, QueryEvaluationContext context) {
+		return new DelayedEvaluation(bindings -> worstCaseJoin(statementPatterns, dataset, context, bindings), context);
+	}
 
-private CloseableIteration<BindingSet> worstCaseJoin(List<StatementPattern> statementPatterns,
-MemorySailDataset dataset, QueryEvaluationContext context, BindingSet bindings) {
-return new MemoryWorstCaseJoinIteration(statementPatterns, dataset, context, bindings);
-}
+	private CloseableIteration<BindingSet> worstCaseJoin(List<StatementPattern> statementPatterns,
+			MemorySailDataset dataset, QueryEvaluationContext context, BindingSet bindings) {
+		return new MemoryWorstCaseJoinIteration(statementPatterns, dataset, context, bindings);
+	}
 
-private boolean collectStatementPatterns(TupleExpr node, List<StatementPattern> statementPatterns) {
-if (node instanceof StatementPattern) {
-statementPatterns.add((StatementPattern) node);
-return true;
-} else if (node instanceof Join) {
-Join join = (Join) node;
-return collectStatementPatterns(join.getLeftArg(), statementPatterns)
-&& collectStatementPatterns(join.getRightArg(), statementPatterns);
-}
-return false;
-}
+	private boolean collectStatementPatterns(TupleExpr node, List<StatementPattern> statementPatterns) {
+		if (node instanceof StatementPattern) {
+			statementPatterns.add((StatementPattern) node);
+			return true;
+		} else if (node instanceof Join) {
+			Join join = (Join) node;
+			return collectStatementPatterns(join.getLeftArg(), statementPatterns)
+					&& collectStatementPatterns(join.getRightArg(), statementPatterns);
+		}
+		return false;
+	}
 }

--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/evaluation/MemoryEvaluationStrategyFactory.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/evaluation/MemoryEvaluationStrategyFactory.java
@@ -23,40 +23,40 @@ import org.eclipse.rdf4j.query.algebra.evaluation.impl.AbstractEvaluationStrateg
 import org.eclipse.rdf4j.query.algebra.evaluation.impl.evaluationsteps.EvaluationStatistics;
 
 public class MemoryEvaluationStrategyFactory extends AbstractEvaluationStrategyFactory
-                implements FederatedServiceResolverClient {
+		implements FederatedServiceResolverClient {
 
-private FederatedServiceResolver serviceResolver;
-protected Supplier<CollectionFactory> collectionFactorySupplier = DefaultCollectionFactory::new;
+	private FederatedServiceResolver serviceResolver;
+	protected Supplier<CollectionFactory> collectionFactorySupplier = DefaultCollectionFactory::new;
 
-public MemoryEvaluationStrategyFactory() {
-}
+	public MemoryEvaluationStrategyFactory() {
+	}
 
-public MemoryEvaluationStrategyFactory(FederatedServiceResolver resolver) {
-this.serviceResolver = resolver;
-}
+	public MemoryEvaluationStrategyFactory(FederatedServiceResolver resolver) {
+		this.serviceResolver = resolver;
+	}
 
-@Override
-public void setFederatedServiceResolver(FederatedServiceResolver resolver) {
-this.serviceResolver = resolver;
-}
+	@Override
+	public void setFederatedServiceResolver(FederatedServiceResolver resolver) {
+		this.serviceResolver = resolver;
+	}
 
-@Override
-public FederatedServiceResolver getFederatedServiceResolver() {
-return serviceResolver;
-}
+	@Override
+	public FederatedServiceResolver getFederatedServiceResolver() {
+		return serviceResolver;
+	}
 
-@Override
-public void setCollectionFactory(Supplier<CollectionFactory> collectionFactory) {
-this.collectionFactorySupplier = collectionFactory;
-}
+	@Override
+	public void setCollectionFactory(Supplier<CollectionFactory> collectionFactory) {
+		this.collectionFactorySupplier = collectionFactory;
+	}
 
-@Override
-public EvaluationStrategy createEvaluationStrategy(Dataset dataset, TripleSource tripleSource,
-EvaluationStatistics evaluationStatistics) {
-MemoryEvaluationStrategy strategy = new MemoryEvaluationStrategy(tripleSource, dataset, serviceResolver,
-getQuerySolutionCacheThreshold(), evaluationStatistics, isTrackResultSize());
-getOptimizerPipeline().ifPresent(strategy::setOptimizerPipeline);
-strategy.setCollectionFactory(collectionFactorySupplier);
-return strategy;
-}
+	@Override
+	public EvaluationStrategy createEvaluationStrategy(Dataset dataset, TripleSource tripleSource,
+			EvaluationStatistics evaluationStatistics) {
+		MemoryEvaluationStrategy strategy = new MemoryEvaluationStrategy(tripleSource, dataset, serviceResolver,
+				getQuerySolutionCacheThreshold(), evaluationStatistics, isTrackResultSize());
+		getOptimizerPipeline().ifPresent(strategy::setOptimizerPipeline);
+		strategy.setCollectionFactory(collectionFactorySupplier);
+		return strategy;
+	}
 }

--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/evaluation/MemoryEvaluationStrategyFactory.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/evaluation/MemoryEvaluationStrategyFactory.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ ******************************************************************************/
+package org.eclipse.rdf4j.sail.memory.evaluation;
+
+import java.util.function.Supplier;
+
+import org.eclipse.rdf4j.collection.factory.api.CollectionFactory;
+import org.eclipse.rdf4j.collection.factory.impl.DefaultCollectionFactory;
+import org.eclipse.rdf4j.query.Dataset;
+import org.eclipse.rdf4j.query.algebra.evaluation.EvaluationStrategy;
+import org.eclipse.rdf4j.query.algebra.evaluation.TripleSource;
+import org.eclipse.rdf4j.query.algebra.evaluation.federation.FederatedServiceResolver;
+import org.eclipse.rdf4j.query.algebra.evaluation.federation.FederatedServiceResolverClient;
+import org.eclipse.rdf4j.query.algebra.evaluation.impl.AbstractEvaluationStrategyFactory;
+import org.eclipse.rdf4j.query.algebra.evaluation.impl.evaluationsteps.EvaluationStatistics;
+
+public class MemoryEvaluationStrategyFactory extends AbstractEvaluationStrategyFactory
+                implements FederatedServiceResolverClient {
+
+private FederatedServiceResolver serviceResolver;
+protected Supplier<CollectionFactory> collectionFactorySupplier = DefaultCollectionFactory::new;
+
+public MemoryEvaluationStrategyFactory() {
+}
+
+public MemoryEvaluationStrategyFactory(FederatedServiceResolver resolver) {
+this.serviceResolver = resolver;
+}
+
+@Override
+public void setFederatedServiceResolver(FederatedServiceResolver resolver) {
+this.serviceResolver = resolver;
+}
+
+@Override
+public FederatedServiceResolver getFederatedServiceResolver() {
+return serviceResolver;
+}
+
+@Override
+public void setCollectionFactory(Supplier<CollectionFactory> collectionFactory) {
+this.collectionFactorySupplier = collectionFactory;
+}
+
+@Override
+public EvaluationStrategy createEvaluationStrategy(Dataset dataset, TripleSource tripleSource,
+EvaluationStatistics evaluationStatistics) {
+MemoryEvaluationStrategy strategy = new MemoryEvaluationStrategy(tripleSource, dataset, serviceResolver,
+getQuerySolutionCacheThreshold(), evaluationStatistics, isTrackResultSize());
+getOptimizerPipeline().ifPresent(strategy::setOptimizerPipeline);
+strategy.setCollectionFactory(collectionFactorySupplier);
+return strategy;
+}
+}

--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/evaluation/MemoryTripleSourceWrapper.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/evaluation/MemoryTripleSourceWrapper.java
@@ -23,20 +23,21 @@ import org.eclipse.rdf4j.sail.memory.MemorySailStore.MemorySailDataset;
 
 public class MemoryTripleSourceWrapper extends SailDatasetTripleSource {
 
-private final MemorySailDataset dataset;
+	private final MemorySailDataset dataset;
 
-public MemoryTripleSourceWrapper(MemorySailDataset dataset, ValueFactory valueFactory) {
-super(valueFactory, dataset);
-this.dataset = dataset;
-}
+	public MemoryTripleSourceWrapper(MemorySailDataset dataset, ValueFactory valueFactory) {
+		super(valueFactory, dataset);
+		this.dataset = dataset;
+	}
 
-public MemorySailDataset getDataset() {
-return dataset;
-}
+	public MemorySailDataset getDataset() {
+		return dataset;
+	}
 
-@Override
-public CloseableIteration<? extends Statement> getStatements(StatementOrder order, Resource subj, IRI pred, Value obj,
-Resource... contexts) throws QueryEvaluationException {
-return super.getStatements(order, subj, pred, obj, contexts);
-}
+	@Override
+	public CloseableIteration<? extends Statement> getStatements(StatementOrder order, Resource subj, IRI pred,
+			Value obj,
+			Resource... contexts) throws QueryEvaluationException {
+		return super.getStatements(order, subj, pred, obj, contexts);
+	}
 }

--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/evaluation/MemoryTripleSourceWrapper.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/evaluation/MemoryTripleSourceWrapper.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ ******************************************************************************/
+package org.eclipse.rdf4j.sail.memory.evaluation;
+
+import org.eclipse.rdf4j.common.iteration.CloseableIteration;
+import org.eclipse.rdf4j.common.order.StatementOrder;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.query.QueryEvaluationException;
+import org.eclipse.rdf4j.sail.base.SailDatasetTripleSource;
+import org.eclipse.rdf4j.sail.memory.MemorySailStore.MemorySailDataset;
+
+public class MemoryTripleSourceWrapper extends SailDatasetTripleSource {
+
+private final MemorySailDataset dataset;
+
+public MemoryTripleSourceWrapper(MemorySailDataset dataset, ValueFactory valueFactory) {
+super(valueFactory, dataset);
+this.dataset = dataset;
+}
+
+public MemorySailDataset getDataset() {
+return dataset;
+}
+
+@Override
+public CloseableIteration<? extends Statement> getStatements(StatementOrder order, Resource subj, IRI pred, Value obj,
+Resource... contexts) throws QueryEvaluationException {
+return super.getStatements(order, subj, pred, obj, contexts);
+}
+}

--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/evaluation/MemoryWorstCaseJoinIteration.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/evaluation/MemoryWorstCaseJoinIteration.java
@@ -39,209 +39,214 @@ import org.eclipse.rdf4j.sail.memory.model.MemStatement;
 
 class MemoryWorstCaseJoinIteration extends LookAheadIteration<BindingSet> {
 
-private final List<StatementPattern> statementPatterns;
-private final MemorySailDataset dataset;
-private final QueryEvaluationContext context;
-private final BindingSet baseBindings;
-private Iterator<BindingSet> materializedResults;
+	private final List<StatementPattern> statementPatterns;
+	private final MemorySailDataset dataset;
+	private final QueryEvaluationContext context;
+	private final BindingSet baseBindings;
+	private Iterator<BindingSet> materializedResults;
 
-MemoryWorstCaseJoinIteration(List<StatementPattern> statementPatterns, MemorySailDataset dataset,
-QueryEvaluationContext context, BindingSet bindings) {
-this.statementPatterns = statementPatterns;
-this.dataset = dataset;
-this.context = context;
-this.baseBindings = bindings;
-}
+	MemoryWorstCaseJoinIteration(List<StatementPattern> statementPatterns, MemorySailDataset dataset,
+			QueryEvaluationContext context, BindingSet bindings) {
+		this.statementPatterns = statementPatterns;
+		this.dataset = dataset;
+		this.context = context;
+		this.baseBindings = bindings;
+	}
 
-@Override
-protected BindingSet getNextElement() throws QueryEvaluationException {
-if (materializedResults == null) {
-materializeResults();
-}
-if (materializedResults.hasNext()) {
-return materializedResults.next();
-}
-return null;
-}
+	@Override
+	protected BindingSet getNextElement() throws QueryEvaluationException {
+		if (materializedResults == null) {
+			materializeResults();
+		}
+		if (materializedResults.hasNext()) {
+			return materializedResults.next();
+		}
+		return null;
+	}
 
-private void materializeResults() throws QueryEvaluationException {
-Set<String> variableOrder = collectVariableOrder();
-List<BindingSet> results = new ArrayList<>();
+	private void materializeResults() throws QueryEvaluationException {
+		Set<String> variableOrder = collectVariableOrder();
+		List<BindingSet> results = new ArrayList<>();
 
-MutableBindingSet seed = new QueryBindingSet();
-for (Binding binding : baseBindings) {
-seed.addBinding(binding);
-}
+		MutableBindingSet seed = new QueryBindingSet();
+		for (Binding binding : baseBindings) {
+			seed.addBinding(binding);
+		}
 
-recurse(new ArrayList<>(variableOrder), 0, seed, results);
-materializedResults = results.iterator();
-}
+		recurse(new ArrayList<>(variableOrder), 0, seed, results);
+		materializedResults = results.iterator();
+	}
 
-private Set<String> collectVariableOrder() {
-Map<String, Integer> counts = new HashMap<>();
-for (StatementPattern pattern : statementPatterns) {
-collect(pattern.getSubjectVar(), counts);
-collect(pattern.getPredicateVar(), counts);
-collect(pattern.getObjectVar(), counts);
-collect(pattern.getContextVar(), counts);
-}
-Set<String> order = new LinkedHashSet<>();
-counts.entrySet().stream().sorted(Map.Entry.<String, Integer>comparingByValue().reversed())
-.forEach(e -> order.add(e.getKey()));
-return order;
-}
+	private Set<String> collectVariableOrder() {
+		Map<String, Integer> counts = new HashMap<>();
+		for (StatementPattern pattern : statementPatterns) {
+			collect(pattern.getSubjectVar(), counts);
+			collect(pattern.getPredicateVar(), counts);
+			collect(pattern.getObjectVar(), counts);
+			collect(pattern.getContextVar(), counts);
+		}
+		Set<String> order = new LinkedHashSet<>();
+		counts.entrySet()
+				.stream()
+				.sorted(Map.Entry.<String, Integer>comparingByValue().reversed())
+				.forEach(e -> order.add(e.getKey()));
+		return order;
+	}
 
-private void collect(Var var, Map<String, Integer> counts) {
-if (var != null && !var.hasValue()) {
-counts.merge(var.getName(), 1, Integer::sum);
-}
-}
+	private void collect(Var var, Map<String, Integer> counts) {
+		if (var != null && !var.hasValue()) {
+			counts.merge(var.getName(), 1, Integer::sum);
+		}
+	}
 
-private void recurse(List<String> variableOrder, int idx, MutableBindingSet currentBindings,
-Collection<BindingSet> sink) throws QueryEvaluationException {
-if (idx >= variableOrder.size()) {
-if (patternsSatisfied(currentBindings)) {
-sink.add(new QueryBindingSet(currentBindings));
-}
-return;
-}
+	private void recurse(List<String> variableOrder, int idx, MutableBindingSet currentBindings,
+			Collection<BindingSet> sink) throws QueryEvaluationException {
+		if (idx >= variableOrder.size()) {
+			if (patternsSatisfied(currentBindings)) {
+				sink.add(new QueryBindingSet(currentBindings));
+			}
+			return;
+		}
 
-String varName = variableOrder.get(idx);
-if (currentBindings.hasBinding(varName)) {
-recurse(variableOrder, idx + 1, currentBindings, sink);
-return;
-}
+		String varName = variableOrder.get(idx);
+		if (currentBindings.hasBinding(varName)) {
+			recurse(variableOrder, idx + 1, currentBindings, sink);
+			return;
+		}
 
-Set<Value> candidates = intersectCandidates(varName, currentBindings);
-for (Value candidate : candidates) {
-MutableBindingSet next = new QueryBindingSet(currentBindings);
-next.addBinding(varName, candidate);
-recurse(variableOrder, idx + 1, next, sink);
-}
-}
+		Set<Value> candidates = intersectCandidates(varName, currentBindings);
+		for (Value candidate : candidates) {
+			MutableBindingSet next = new QueryBindingSet(currentBindings);
+			next.addBinding(varName, candidate);
+			recurse(variableOrder, idx + 1, next, sink);
+		}
+	}
 
-private boolean patternsSatisfied(MutableBindingSet bindings) throws QueryEvaluationException {
-for (StatementPattern pattern : statementPatterns) {
-if (!hasMatchingStatement(pattern, bindings)) {
-return false;
-}
-}
-return true;
-}
+	private boolean patternsSatisfied(MutableBindingSet bindings) throws QueryEvaluationException {
+		for (StatementPattern pattern : statementPatterns) {
+			if (!hasMatchingStatement(pattern, bindings)) {
+				return false;
+			}
+		}
+		return true;
+	}
 
-private Set<Value> intersectCandidates(String varName, BindingSet bindings) throws QueryEvaluationException {
-Set<Value> intersection = null;
-for (StatementPattern pattern : statementPatterns) {
-if (!usesVariable(pattern, varName)) {
-continue;
-}
+	private Set<Value> intersectCandidates(String varName, BindingSet bindings) throws QueryEvaluationException {
+		Set<Value> intersection = null;
+		for (StatementPattern pattern : statementPatterns) {
+			if (!usesVariable(pattern, varName)) {
+				continue;
+			}
 
-Set<Value> values = collectValues(pattern, varName, bindings);
-if (intersection == null) {
-intersection = values;
-} else {
-intersection.retainAll(values);
-}
+			Set<Value> values = collectValues(pattern, varName, bindings);
+			if (intersection == null) {
+				intersection = values;
+			} else {
+				intersection.retainAll(values);
+			}
 
-if (intersection.isEmpty()) {
-return Collections.emptySet();
-}
-}
+			if (intersection.isEmpty()) {
+				return Collections.emptySet();
+			}
+		}
 
-return intersection != null ? intersection : Collections.emptySet();
-}
+		return intersection != null ? intersection : Collections.emptySet();
+	}
 
-private boolean usesVariable(StatementPattern pattern, String varName) {
-return varName.equals(optionalName(pattern.getSubjectVar())) || varName.equals(optionalName(pattern.getPredicateVar()))
-|| varName.equals(optionalName(pattern.getObjectVar())) || varName.equals(optionalName(pattern.getContextVar()));
-}
+	private boolean usesVariable(StatementPattern pattern, String varName) {
+		return varName.equals(optionalName(pattern.getSubjectVar()))
+				|| varName.equals(optionalName(pattern.getPredicateVar()))
+				|| varName.equals(optionalName(pattern.getObjectVar()))
+				|| varName.equals(optionalName(pattern.getContextVar()));
+	}
 
-private String optionalName(Var var) {
-return var == null ? null : var.getName();
-}
+	private String optionalName(Var var) {
+		return var == null ? null : var.getName();
+	}
 
-private Set<Value> collectValues(StatementPattern pattern, String targetVar, BindingSet bindings)
-throws QueryEvaluationException {
-Set<Value> values = new HashSet<>();
+	private Set<Value> collectValues(StatementPattern pattern, String targetVar, BindingSet bindings)
+			throws QueryEvaluationException {
+		Set<Value> values = new HashSet<>();
 
-Resource subject = resourceValue(pattern.getSubjectVar(), bindings);
-IRI predicate = iriValue(pattern.getPredicateVar(), bindings);
-Value object = value(pattern.getObjectVar(), bindings);
-Resource[] contexts = computeContexts(pattern.getContextVar(), bindings);
-if (contexts == null) {
-return Collections.emptySet();
-}
+		Resource subject = resourceValue(pattern.getSubjectVar(), bindings);
+		IRI predicate = iriValue(pattern.getPredicateVar(), bindings);
+		Value object = value(pattern.getObjectVar(), bindings);
+		Resource[] contexts = computeContexts(pattern.getContextVar(), bindings);
+		if (contexts == null) {
+			return Collections.emptySet();
+		}
 
-try (CloseableIteration<MemStatement> stmts = dataset.getStatements(subject, predicate, object, contexts)) {
-while (stmts.hasNext()) {
-MemStatement st = stmts.next();
-if (targetVar.equals(optionalName(pattern.getSubjectVar()))) {
-values.add(st.getSubject());
-} else if (targetVar.equals(optionalName(pattern.getPredicateVar()))) {
-values.add(st.getPredicate());
-} else if (targetVar.equals(optionalName(pattern.getObjectVar()))) {
-values.add(st.getObject());
-} else if (targetVar.equals(optionalName(pattern.getContextVar()))) {
-values.add(st.getContext());
-}
-}
-} catch (QueryEvaluationException e) {
-throw e;
-} catch (Exception e) {
-throw new QueryEvaluationException(e);
-}
+		try (CloseableIteration<MemStatement> stmts = dataset.getStatements(subject, predicate, object, contexts)) {
+			while (stmts.hasNext()) {
+				MemStatement st = stmts.next();
+				if (targetVar.equals(optionalName(pattern.getSubjectVar()))) {
+					values.add(st.getSubject());
+				} else if (targetVar.equals(optionalName(pattern.getPredicateVar()))) {
+					values.add(st.getPredicate());
+				} else if (targetVar.equals(optionalName(pattern.getObjectVar()))) {
+					values.add(st.getObject());
+				} else if (targetVar.equals(optionalName(pattern.getContextVar()))) {
+					values.add(st.getContext());
+				}
+			}
+		} catch (QueryEvaluationException e) {
+			throw e;
+		} catch (Exception e) {
+			throw new QueryEvaluationException(e);
+		}
 
-return values;
-}
+		return values;
+	}
 
-private boolean hasMatchingStatement(StatementPattern pattern, BindingSet bindings) throws QueryEvaluationException {
-Resource subject = resourceValue(pattern.getSubjectVar(), bindings);
-IRI predicate = iriValue(pattern.getPredicateVar(), bindings);
-Value object = value(pattern.getObjectVar(), bindings);
-Resource[] contexts = computeContexts(pattern.getContextVar(), bindings);
-if (contexts == null) {
-return false;
-}
+	private boolean hasMatchingStatement(StatementPattern pattern, BindingSet bindings)
+			throws QueryEvaluationException {
+		Resource subject = resourceValue(pattern.getSubjectVar(), bindings);
+		IRI predicate = iriValue(pattern.getPredicateVar(), bindings);
+		Value object = value(pattern.getObjectVar(), bindings);
+		Resource[] contexts = computeContexts(pattern.getContextVar(), bindings);
+		if (contexts == null) {
+			return false;
+		}
 
-try (CloseableIteration<MemStatement> stmts = dataset.getStatements(subject, predicate, object, contexts)) {
-return stmts.hasNext();
-} catch (QueryEvaluationException e) {
-throw e;
-} catch (Exception e) {
-throw new QueryEvaluationException(e);
-}
-}
+		try (CloseableIteration<MemStatement> stmts = dataset.getStatements(subject, predicate, object, contexts)) {
+			return stmts.hasNext();
+		} catch (QueryEvaluationException e) {
+			throw e;
+		} catch (Exception e) {
+			throw new QueryEvaluationException(e);
+		}
+	}
 
-private Resource[] computeContexts(Var contextVar, BindingSet bindings) {
-if (contextVar == null || (!contextVar.hasValue() && !bindings.hasBinding(contextVar.getName()))) {
-return new Resource[0];
-}
+	private Resource[] computeContexts(Var contextVar, BindingSet bindings) {
+		if (contextVar == null || (!contextVar.hasValue() && !bindings.hasBinding(contextVar.getName()))) {
+			return new Resource[0];
+		}
 
-Value ctxValue = contextVar.hasValue() ? contextVar.getValue() : bindings.getValue(contextVar.getName());
-if (ctxValue instanceof Resource) {
-return new Resource[] { (Resource) ctxValue };
-}
-return null;
-}
+		Value ctxValue = contextVar.hasValue() ? contextVar.getValue() : bindings.getValue(contextVar.getName());
+		if (ctxValue instanceof Resource) {
+			return new Resource[] { (Resource) ctxValue };
+		}
+		return null;
+	}
 
-private Resource resourceValue(Var var, BindingSet bindings) {
-Value v = value(var, bindings);
-return v instanceof Resource ? (Resource) v : null;
-}
+	private Resource resourceValue(Var var, BindingSet bindings) {
+		Value v = value(var, bindings);
+		return v instanceof Resource ? (Resource) v : null;
+	}
 
-private IRI iriValue(Var var, BindingSet bindings) {
-Value v = value(var, bindings);
-return v instanceof IRI ? (IRI) v : null;
-}
+	private IRI iriValue(Var var, BindingSet bindings) {
+		Value v = value(var, bindings);
+		return v instanceof IRI ? (IRI) v : null;
+	}
 
-private Value value(Var var, BindingSet bindings) {
-if (var == null) {
-return null;
-}
-if (var.hasValue()) {
-return var.getValue();
-}
-Binding existing = bindings.getBinding(var.getName());
-return existing != null ? existing.getValue() : null;
-}
+	private Value value(Var var, BindingSet bindings) {
+		if (var == null) {
+			return null;
+		}
+		if (var.hasValue()) {
+			return var.getValue();
+		}
+		Binding existing = bindings.getBinding(var.getName());
+		return existing != null ? existing.getValue() : null;
+	}
 }

--- a/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/evaluation/MemoryWorstCaseJoinIteration.java
+++ b/core/sail/memory/src/main/java/org/eclipse/rdf4j/sail/memory/evaluation/MemoryWorstCaseJoinIteration.java
@@ -1,0 +1,247 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ ******************************************************************************/
+package org.eclipse.rdf4j.sail.memory.evaluation;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.rdf4j.common.iteration.CloseableIteration;
+import org.eclipse.rdf4j.common.iteration.LookAheadIteration;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.query.Binding;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.MutableBindingSet;
+import org.eclipse.rdf4j.query.QueryEvaluationException;
+import org.eclipse.rdf4j.query.algebra.StatementPattern;
+import org.eclipse.rdf4j.query.algebra.Var;
+import org.eclipse.rdf4j.query.algebra.evaluation.impl.QueryBindingSet;
+import org.eclipse.rdf4j.query.algebra.evaluation.impl.QueryEvaluationContext;
+import org.eclipse.rdf4j.sail.memory.MemorySailStore.MemorySailDataset;
+import org.eclipse.rdf4j.sail.memory.model.MemStatement;
+
+class MemoryWorstCaseJoinIteration extends LookAheadIteration<BindingSet> {
+
+private final List<StatementPattern> statementPatterns;
+private final MemorySailDataset dataset;
+private final QueryEvaluationContext context;
+private final BindingSet baseBindings;
+private Iterator<BindingSet> materializedResults;
+
+MemoryWorstCaseJoinIteration(List<StatementPattern> statementPatterns, MemorySailDataset dataset,
+QueryEvaluationContext context, BindingSet bindings) {
+this.statementPatterns = statementPatterns;
+this.dataset = dataset;
+this.context = context;
+this.baseBindings = bindings;
+}
+
+@Override
+protected BindingSet getNextElement() throws QueryEvaluationException {
+if (materializedResults == null) {
+materializeResults();
+}
+if (materializedResults.hasNext()) {
+return materializedResults.next();
+}
+return null;
+}
+
+private void materializeResults() throws QueryEvaluationException {
+Set<String> variableOrder = collectVariableOrder();
+List<BindingSet> results = new ArrayList<>();
+
+MutableBindingSet seed = new QueryBindingSet();
+for (Binding binding : baseBindings) {
+seed.addBinding(binding);
+}
+
+recurse(new ArrayList<>(variableOrder), 0, seed, results);
+materializedResults = results.iterator();
+}
+
+private Set<String> collectVariableOrder() {
+Map<String, Integer> counts = new HashMap<>();
+for (StatementPattern pattern : statementPatterns) {
+collect(pattern.getSubjectVar(), counts);
+collect(pattern.getPredicateVar(), counts);
+collect(pattern.getObjectVar(), counts);
+collect(pattern.getContextVar(), counts);
+}
+Set<String> order = new LinkedHashSet<>();
+counts.entrySet().stream().sorted(Map.Entry.<String, Integer>comparingByValue().reversed())
+.forEach(e -> order.add(e.getKey()));
+return order;
+}
+
+private void collect(Var var, Map<String, Integer> counts) {
+if (var != null && !var.hasValue()) {
+counts.merge(var.getName(), 1, Integer::sum);
+}
+}
+
+private void recurse(List<String> variableOrder, int idx, MutableBindingSet currentBindings,
+Collection<BindingSet> sink) throws QueryEvaluationException {
+if (idx >= variableOrder.size()) {
+if (patternsSatisfied(currentBindings)) {
+sink.add(new QueryBindingSet(currentBindings));
+}
+return;
+}
+
+String varName = variableOrder.get(idx);
+if (currentBindings.hasBinding(varName)) {
+recurse(variableOrder, idx + 1, currentBindings, sink);
+return;
+}
+
+Set<Value> candidates = intersectCandidates(varName, currentBindings);
+for (Value candidate : candidates) {
+MutableBindingSet next = new QueryBindingSet(currentBindings);
+next.addBinding(varName, candidate);
+recurse(variableOrder, idx + 1, next, sink);
+}
+}
+
+private boolean patternsSatisfied(MutableBindingSet bindings) throws QueryEvaluationException {
+for (StatementPattern pattern : statementPatterns) {
+if (!hasMatchingStatement(pattern, bindings)) {
+return false;
+}
+}
+return true;
+}
+
+private Set<Value> intersectCandidates(String varName, BindingSet bindings) throws QueryEvaluationException {
+Set<Value> intersection = null;
+for (StatementPattern pattern : statementPatterns) {
+if (!usesVariable(pattern, varName)) {
+continue;
+}
+
+Set<Value> values = collectValues(pattern, varName, bindings);
+if (intersection == null) {
+intersection = values;
+} else {
+intersection.retainAll(values);
+}
+
+if (intersection.isEmpty()) {
+return Collections.emptySet();
+}
+}
+
+return intersection != null ? intersection : Collections.emptySet();
+}
+
+private boolean usesVariable(StatementPattern pattern, String varName) {
+return varName.equals(optionalName(pattern.getSubjectVar())) || varName.equals(optionalName(pattern.getPredicateVar()))
+|| varName.equals(optionalName(pattern.getObjectVar())) || varName.equals(optionalName(pattern.getContextVar()));
+}
+
+private String optionalName(Var var) {
+return var == null ? null : var.getName();
+}
+
+private Set<Value> collectValues(StatementPattern pattern, String targetVar, BindingSet bindings)
+throws QueryEvaluationException {
+Set<Value> values = new HashSet<>();
+
+Resource subject = resourceValue(pattern.getSubjectVar(), bindings);
+IRI predicate = iriValue(pattern.getPredicateVar(), bindings);
+Value object = value(pattern.getObjectVar(), bindings);
+Resource[] contexts = computeContexts(pattern.getContextVar(), bindings);
+if (contexts == null) {
+return Collections.emptySet();
+}
+
+try (CloseableIteration<MemStatement> stmts = dataset.getStatements(subject, predicate, object, contexts)) {
+while (stmts.hasNext()) {
+MemStatement st = stmts.next();
+if (targetVar.equals(optionalName(pattern.getSubjectVar()))) {
+values.add(st.getSubject());
+} else if (targetVar.equals(optionalName(pattern.getPredicateVar()))) {
+values.add(st.getPredicate());
+} else if (targetVar.equals(optionalName(pattern.getObjectVar()))) {
+values.add(st.getObject());
+} else if (targetVar.equals(optionalName(pattern.getContextVar()))) {
+values.add(st.getContext());
+}
+}
+} catch (QueryEvaluationException e) {
+throw e;
+} catch (Exception e) {
+throw new QueryEvaluationException(e);
+}
+
+return values;
+}
+
+private boolean hasMatchingStatement(StatementPattern pattern, BindingSet bindings) throws QueryEvaluationException {
+Resource subject = resourceValue(pattern.getSubjectVar(), bindings);
+IRI predicate = iriValue(pattern.getPredicateVar(), bindings);
+Value object = value(pattern.getObjectVar(), bindings);
+Resource[] contexts = computeContexts(pattern.getContextVar(), bindings);
+if (contexts == null) {
+return false;
+}
+
+try (CloseableIteration<MemStatement> stmts = dataset.getStatements(subject, predicate, object, contexts)) {
+return stmts.hasNext();
+} catch (QueryEvaluationException e) {
+throw e;
+} catch (Exception e) {
+throw new QueryEvaluationException(e);
+}
+}
+
+private Resource[] computeContexts(Var contextVar, BindingSet bindings) {
+if (contextVar == null || (!contextVar.hasValue() && !bindings.hasBinding(contextVar.getName()))) {
+return new Resource[0];
+}
+
+Value ctxValue = contextVar.hasValue() ? contextVar.getValue() : bindings.getValue(contextVar.getName());
+if (ctxValue instanceof Resource) {
+return new Resource[] { (Resource) ctxValue };
+}
+return null;
+}
+
+private Resource resourceValue(Var var, BindingSet bindings) {
+Value v = value(var, bindings);
+return v instanceof Resource ? (Resource) v : null;
+}
+
+private IRI iriValue(Var var, BindingSet bindings) {
+Value v = value(var, bindings);
+return v instanceof IRI ? (IRI) v : null;
+}
+
+private Value value(Var var, BindingSet bindings) {
+if (var == null) {
+return null;
+}
+if (var.hasValue()) {
+return var.getValue();
+}
+Binding existing = bindings.getBinding(var.getName());
+return existing != null ? existing.getValue() : null;
+}
+}

--- a/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/MemoryWorstCaseJoinTest.java
+++ b/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/MemoryWorstCaseJoinTest.java
@@ -29,35 +29,38 @@ import org.junit.jupiter.api.Test;
 
 public class MemoryWorstCaseJoinTest {
 
-private final ValueFactory vf = SimpleValueFactory.getInstance();
+	private final ValueFactory vf = SimpleValueFactory.getInstance();
 
-@Test
-public void leapfrogTrieJoinIsUsed() {
-MemoryStore store = new MemoryStore();
-try (SailRepository repository = new SailRepository(store)) {
-repository.init();
-try (RepositoryConnection connection = repository.getConnection()) {
-IRI friend = vf.createIRI("http://example.com/friend");
-IRI type = vf.createIRI("http://example.com/type");
-IRI person = vf.createIRI("http://example.com/Person");
-connection.add(vf.createIRI("http://example.com/alice"), type, person);
-connection.add(vf.createIRI("http://example.com/bob"), type, person);
-connection.add(vf.createIRI("http://example.com/alice"), friend, vf.createIRI("http://example.com/bob"));
-connection.add(vf.createIRI("http://example.com/alice"), friend, vf.createIRI("http://example.com/charlie"));
-connection.add(vf.createIRI("http://example.com/bob"), friend, vf.createIRI("http://example.com/alice"));
+	@Test
+	public void leapfrogTrieJoinIsUsed() {
+		MemoryStore store = new MemoryStore();
+		try (SailRepository repository = new SailRepository(store)) {
+			repository.init();
+			try (RepositoryConnection connection = repository.getConnection()) {
+				IRI friend = vf.createIRI("http://example.com/friend");
+				IRI type = vf.createIRI("http://example.com/type");
+				IRI person = vf.createIRI("http://example.com/Person");
+				connection.add(vf.createIRI("http://example.com/alice"), type, person);
+				connection.add(vf.createIRI("http://example.com/bob"), type, person);
+				connection.add(vf.createIRI("http://example.com/alice"), friend,
+						vf.createIRI("http://example.com/bob"));
+				connection.add(vf.createIRI("http://example.com/alice"), friend,
+						vf.createIRI("http://example.com/charlie"));
+				connection.add(vf.createIRI("http://example.com/bob"), friend,
+						vf.createIRI("http://example.com/alice"));
 
-Query query = connection.prepareTupleQuery("SELECT ?s ?o WHERE { ?s <" + type + "> <" + person
-+ "> . ?s <" + friend + "> ?o . }");
-Explanation explanation = query.explain(Explanation.Level.Executed);
-assertThat(explanation.toString()).contains("LeapfrogTrieJoin");
+				Query query = connection.prepareTupleQuery("SELECT ?s ?o WHERE { ?s <" + type + "> <" + person
+						+ "> . ?s <" + friend + "> ?o . }");
+				Explanation explanation = query.explain(Explanation.Level.Executed);
+				assertThat(explanation.toString()).contains("LeapfrogTrieJoin");
 
-List<BindingSet> results = new ArrayList<>();
-try (TupleQueryResult result = SailHelper.evaluateTupleQuery(connection, query)) {
-result.forEachRemaining(results::add);
-}
+				List<BindingSet> results = new ArrayList<>();
+				try (TupleQueryResult result = SailHelper.evaluateTupleQuery(connection, query)) {
+					result.forEachRemaining(results::add);
+				}
 
-assertThat(results).hasSize(3);
-}
-}
-}
+				assertThat(results).hasSize(3);
+			}
+		}
+	}
 }

--- a/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/MemoryWorstCaseJoinTest.java
+++ b/core/sail/memory/src/test/java/org/eclipse/rdf4j/sail/memory/MemoryWorstCaseJoinTest.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2024 Eclipse RDF4J contributors.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ ******************************************************************************/
+package org.eclipse.rdf4j.sail.memory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.Query;
+import org.eclipse.rdf4j.query.TupleQueryResult;
+import org.eclipse.rdf4j.query.explanation.Explanation;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.testsuite.sail.SailHelper;
+import org.junit.jupiter.api.Test;
+
+public class MemoryWorstCaseJoinTest {
+
+private final ValueFactory vf = SimpleValueFactory.getInstance();
+
+@Test
+public void leapfrogTrieJoinIsUsed() {
+MemoryStore store = new MemoryStore();
+try (SailRepository repository = new SailRepository(store)) {
+repository.init();
+try (RepositoryConnection connection = repository.getConnection()) {
+IRI friend = vf.createIRI("http://example.com/friend");
+IRI type = vf.createIRI("http://example.com/type");
+IRI person = vf.createIRI("http://example.com/Person");
+connection.add(vf.createIRI("http://example.com/alice"), type, person);
+connection.add(vf.createIRI("http://example.com/bob"), type, person);
+connection.add(vf.createIRI("http://example.com/alice"), friend, vf.createIRI("http://example.com/bob"));
+connection.add(vf.createIRI("http://example.com/alice"), friend, vf.createIRI("http://example.com/charlie"));
+connection.add(vf.createIRI("http://example.com/bob"), friend, vf.createIRI("http://example.com/alice"));
+
+Query query = connection.prepareTupleQuery("SELECT ?s ?o WHERE { ?s <" + type + "> <" + person
++ "> . ?s <" + friend + "> ?o . }");
+Explanation explanation = query.explain(Explanation.Level.Executed);
+assertThat(explanation.toString()).contains("LeapfrogTrieJoin");
+
+List<BindingSet> results = new ArrayList<>();
+try (TupleQueryResult result = SailHelper.evaluateTupleQuery(connection, query)) {
+result.forEachRemaining(results::add);
+}
+
+assertThat(results).hasSize(3);
+}
+}
+}
+}

--- a/testsuites/benchmark/src/main/java/org/eclipse/rdf4j/benchmark/MemoryWorstCaseJoinBenchmark.java
+++ b/testsuites/benchmark/src/main/java/org/eclipse/rdf4j/benchmark/MemoryWorstCaseJoinBenchmark.java
@@ -1,0 +1,134 @@
+package org.eclipse.rdf4j.benchmark;
+
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.query.TupleQuery;
+import org.eclipse.rdf4j.query.TupleQueryResult;
+import org.eclipse.rdf4j.query.algebra.evaluation.impl.DefaultEvaluationStrategyFactory;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
+import org.eclipse.rdf4j.sail.memory.MemoryStore;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+@State(Scope.Benchmark)
+@BenchmarkMode({ Mode.AverageTime })
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 3)
+@Measurement(iterations = 5)
+@Fork(value = 1, jvmArgs = { "-Xms2G", "-Xmx2G" })
+public class MemoryWorstCaseJoinBenchmark {
+
+	public enum Strategy {
+		LEAPFROG,
+		DEFAULT
+	}
+
+	@Param({ "LEAPFROG", "DEFAULT" })
+	public String strategy;
+
+	private SailRepository repository;
+
+	private ValueFactory valueFactory;
+
+	private IRI p1;
+
+	private IRI p2;
+
+	private IRI p3;
+
+	private String triangleQuery;
+
+	private int expectedCount;
+
+	@Setup
+	public void setUp() {
+		repository = new SailRepository(createStore());
+		repository.init();
+		valueFactory = SimpleValueFactory.getInstance();
+		p1 = valueFactory.createIRI("urn:p1");
+		p2 = valueFactory.createIRI("urn:p2");
+		p3 = valueFactory.createIRI("urn:p3");
+		triangleQuery = "SELECT ?a ?b ?c WHERE { ?a <urn:p1> ?b . ?a <urn:p2> ?c . ?b <urn:p3> ?c . }";
+		loadDataset();
+	}
+
+	@TearDown
+	public void tearDown() {
+		if (repository != null) {
+			repository.shutDown();
+		}
+	}
+
+	@Benchmark
+	public int triangleQuery() {
+		try (SailRepositoryConnection connection = repository.getConnection()) {
+			TupleQuery query = connection.prepareTupleQuery(triangleQuery);
+			try (TupleQueryResult result = query.evaluate()) {
+				int count = 0;
+				while (result.hasNext()) {
+					result.next();
+					count++;
+				}
+				if (count != expectedCount) {
+					throw new IllegalStateException("Expected " + expectedCount + " results but got " + count);
+				}
+				return count;
+			}
+		}
+	}
+
+	private MemoryStore createStore() {
+		MemoryStore store = new MemoryStore();
+		if (Strategy.DEFAULT.name().equals(strategy)) {
+			store.setEvaluationStrategyFactory(new DefaultEvaluationStrategyFactory());
+		}
+		return store;
+	}
+
+	private void loadDataset() {
+		try (SailRepositoryConnection connection = repository.getConnection()) {
+			connection.begin();
+
+			int subjects = 25;
+			int fanout = 20;
+			expectedCount = subjects * fanout * fanout;
+
+			for (int a = 0; a < subjects; a++) {
+				Resource subject = valueFactory.createIRI("urn:a" + a);
+				for (int b = 0; b < fanout; b++) {
+					Resource bNode = valueFactory.createIRI("urn:b" + b);
+					connection.add(subject, p1, bNode);
+				}
+				for (int c = 0; c < fanout; c++) {
+					Resource cNode = valueFactory.createIRI("urn:c" + c);
+					connection.add(subject, p2, cNode);
+				}
+			}
+
+			for (int b = 0; b < fanout; b++) {
+				Resource bNode = valueFactory.createIRI("urn:b" + b);
+				for (int c = 0; c < fanout; c++) {
+					Resource cNode = valueFactory.createIRI("urn:c" + c);
+					connection.add(bNode, p3, cNode);
+				}
+			}
+
+			connection.commit();
+		}
+	}
+}

--- a/testsuites/benchmark/src/test/java/org/eclipse/rdf4j/benchmark/MemoryWorstCaseJoinBenchmarkTest.java
+++ b/testsuites/benchmark/src/test/java/org/eclipse/rdf4j/benchmark/MemoryWorstCaseJoinBenchmarkTest.java
@@ -1,0 +1,30 @@
+package org.eclipse.rdf4j.benchmark;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class MemoryWorstCaseJoinBenchmarkTest {
+
+	private MemoryWorstCaseJoinBenchmark benchmark;
+
+	@BeforeEach
+	void setUp() {
+		benchmark = new MemoryWorstCaseJoinBenchmark();
+		benchmark.strategy = MemoryWorstCaseJoinBenchmark.Strategy.LEAPFROG.name();
+		benchmark.setUp();
+	}
+
+	@AfterEach
+	void tearDown() {
+		benchmark.tearDown();
+	}
+
+	@Test
+	void triangleQueryProducesResults() {
+		int count = benchmark.triangleQuery();
+		assertTrue(count > 0, "triangle query should produce results");
+	}
+}


### PR DESCRIPTION
## Summary
- add memory-specific evaluation strategy factory and triejoin-based worst case join iteration
- integrate memory connections with custom triple source to expose datasets for leapfrog triejoin
- cover leapfrog triejoin selection with a dedicated MemoryStore test

## Testing
- mvn -pl core/sail/memory -Dtest=MemoryWorstCaseJoinTest test (fails: missing SNAPSHOT artifacts when resolving project dependencies)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939f27f0268832e9664ad9d915d2e32)