### PR TITLE
Add javadoc missing version redirect

### DIFF
--- a/site/static/404.html
+++ b/site/static/404.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Page not found | RDF4J</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    :root {
+      color-scheme: light dark;
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      line-height: 1.5;
+    }
+    body {
+      margin: 2rem auto;
+      max-width: 48rem;
+      padding: 0 1.5rem;
+    }
+    h1 {
+      font-size: 2rem;
+      margin-bottom: 0.5rem;
+    }
+    p {
+      margin-top: 0;
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Page not found</h1>
+    <p>We could not find the page you were looking for.</p>
+    <p>If you followed a link to a specific Javadoc version, we will try to forward you to the closest available version automatically.</p>
+  </main>
+  <script type="module">
+    import { attemptJavadocRedirect } from '/js/javadoc-redirect.js';
+
+    attemptJavadocRedirect();
+  </script>
+</body>
+</html>

--- a/site/static/js/javadoc-redirect.js
+++ b/site/static/js/javadoc-redirect.js
@@ -1,0 +1,149 @@
+function parseSemver(version) {
+  if (typeof version !== 'string') {
+    return null;
+  }
+
+  const parts = version.match(/\d+/g);
+  if (!parts || parts.length === 0) {
+    return null;
+  }
+
+  return parts.map((part) => Number.parseInt(part, 10));
+}
+
+function compareParts(aParts, bParts) {
+  const maxLength = Math.max(aParts.length, bParts.length);
+  for (let i = 0; i < maxLength; i += 1) {
+    const a = aParts[i] ?? 0;
+    const b = bParts[i] ?? 0;
+    if (a !== b) {
+      return a - b;
+    }
+  }
+  return 0;
+}
+
+function compareSemver(a, b) {
+  const parsedA = parseSemver(a);
+  const parsedB = parseSemver(b);
+
+  if (!parsedA || !parsedB) {
+    return 0;
+  }
+
+  return compareParts(parsedA, parsedB);
+}
+
+function findClosestVersion(requestedVersion, availableVersions) {
+  const requestedParts = parseSemver(requestedVersion);
+  if (!requestedParts) {
+    return null;
+  }
+
+  const parsedVersions = availableVersions
+    .map((version) => ({ version, parts: parseSemver(version) }))
+    .filter((entry) => entry.parts)
+    .sort((a, b) => compareParts(a.parts, b.parts));
+
+  let lower = null;
+  for (const entry of parsedVersions) {
+    const comparison = compareParts(entry.parts, requestedParts);
+    if (comparison === 0) {
+      return entry.version;
+    }
+    if (comparison > 0) {
+      return entry.version;
+    }
+    lower = entry.version;
+  }
+
+  return lower;
+}
+
+function isJavadocPath(pathname) {
+  return typeof pathname === 'string' && pathname.startsWith('/javadoc/');
+}
+
+export function findRedirectPath(pathname, availableVersions) {
+  if (!isJavadocPath(pathname)) {
+    return null;
+  }
+
+  const segments = pathname.split('/');
+  // ['', 'javadoc', '<version>', ...]
+  const requestedVersion = segments[2];
+  if (!requestedVersion) {
+    return null;
+  }
+
+  const targetVersion = findClosestVersion(requestedVersion, availableVersions ?? []);
+  if (!targetVersion || targetVersion === requestedVersion) {
+    return null;
+  }
+
+  const nextSegments = segments.slice();
+  nextSegments[2] = targetVersion;
+
+  return nextSegments.join('/') || '/';
+}
+
+export function extractVersions(manifestEntries) {
+  if (!Array.isArray(manifestEntries)) {
+    return [];
+  }
+
+  return manifestEntries
+    .map((entry) => (typeof entry === 'string' ? entry : entry?.name))
+    .filter((value) => typeof value === 'string')
+    .filter((value) => parseSemver(value));
+}
+
+export async function attemptJavadocRedirect(manifestUrl = '/javadoc/manifest.json') {
+  if (typeof window === 'undefined' || typeof window.location === 'undefined') {
+    return null;
+  }
+
+  const { pathname, search, hash } = window.location;
+  if (!isJavadocPath(pathname)) {
+    return null;
+  }
+
+  let versions = [];
+  try {
+    const response = await fetch(manifestUrl, { cache: 'no-store' });
+    if (!response.ok) {
+      throw new Error(`Unexpected response ${response.status}`);
+    }
+    const manifest = await response.json();
+    versions = extractVersions(manifest);
+  } catch (error) {
+    console.warn('Unable to load javadoc manifest for redirect:', error);
+    return null;
+  }
+
+  const targetPath = findRedirectPath(pathname, versions);
+  if (!targetPath) {
+    return null;
+  }
+
+  const nextUrl = new URL(window.location.href);
+  nextUrl.pathname = targetPath;
+  nextUrl.search = search;
+  nextUrl.hash = hash;
+  window.location.replace(nextUrl.toString());
+  return nextUrl.toString();
+}
+
+if (typeof window !== 'undefined') {
+  window.JavadocRedirect = {
+    attemptJavadocRedirect,
+    extractVersions,
+    findRedirectPath,
+  };
+}
+
+export default {
+  attemptJavadocRedirect,
+  extractVersions,
+  findRedirectPath,
+};

--- a/site/static/js/javadoc-redirect.test.js
+++ b/site/static/js/javadoc-redirect.test.js
@@ -1,0 +1,25 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { findRedirectPath } from './javadoc-redirect.js';
+
+const versions = ['5.1.0', '5.1.2', '5.2.0', '4.3.16'];
+
+test('redirects to the next patch version when available', () => {
+  const result = findRedirectPath('/javadoc/5.1.1/org/example/Foo.html', versions);
+  assert.equal(result, '/javadoc/5.1.2/org/example/Foo.html');
+});
+
+test('redirects to the next minor or major version when patch is missing', () => {
+  const result = findRedirectPath('/javadoc/5.1.2/org/example/Foo.html', ['5.1.0', '5.2.0']);
+  assert.equal(result, '/javadoc/5.2.0/org/example/Foo.html');
+});
+
+test('falls back to the highest available lower version when no newer version exists', () => {
+  const result = findRedirectPath('/javadoc/9.0.0/org/example/Foo.html', versions);
+  assert.equal(result, '/javadoc/5.2.0/org/example/Foo.html');
+});
+
+test('ignores non-semver entries when calculating redirects', () => {
+  const result = findRedirectPath('/javadoc/5.1.1/org/example/Foo.html', ['latest', '5.2.0']);
+  assert.equal(result, '/javadoc/5.2.0/org/example/Foo.html');
+});


### PR DESCRIPTION
## Summary
- add a client-side helper that redirects missing javadoc requests to the nearest available version
- introduce a site 404 page that triggers the redirect logic for missing javadoc links

## Testing
- node --test site/static/js/javadoc-redirect.test.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693bde0282a8832ebd9c4a5014021001)