### PR TITLE
Deprecate Solr integration for removal

### DIFF
--- a/core/sail/solr/src/main/java/org/eclipse/rdf4j/sail/solr/SolrClientFactory.java
+++ b/core/sail/solr/src/main/java/org/eclipse/rdf4j/sail/solr/SolrClientFactory.java
@@ -12,6 +12,10 @@ package org.eclipse.rdf4j.sail.solr;
 
 import org.apache.solr.client.solrj.SolrClient;
 
+/**
+ * @deprecated since 5.3.0 and scheduled for removal alongside the Solr Sail integration.
+ */
+@Deprecated(forRemoval = true, since = "5.3.0")
 public interface SolrClientFactory {
 
 	SolrClient create(String spec);

--- a/core/sail/solr/src/main/java/org/eclipse/rdf4j/sail/solr/SolrIndex.java
+++ b/core/sail/solr/src/main/java/org/eclipse/rdf4j/sail/solr/SolrIndex.java
@@ -58,8 +58,11 @@ import com.google.common.base.Functions;
 import com.google.common.collect.Iterables;
 
 /**
+ * @deprecated since 5.3.0 and scheduled for removal. Use alternative search integrations instead, such as the Lucene or
+ *             Elasticsearch Sail implementations.
  * @see LuceneSail
  */
+@Deprecated(forRemoval = true, since = "5.3.0")
 public class SolrIndex extends AbstractSearchIndex {
 
 	public static final String SERVER_KEY = "server";

--- a/core/sail/solr/src/main/java/org/eclipse/rdf4j/sail/solr/client/cloud/package-info.java
+++ b/core/sail/solr/src/main/java/org/eclipse/rdf4j/sail/solr/client/cloud/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * CloudSolrServer client support.
+ *
+ * @deprecated since 5.3.0 and scheduled for removal alongside the Solr Sail integration.
+ */
+@Deprecated(forRemoval = true, since = "5.3.0")
+package org.eclipse.rdf4j.sail.solr.client.cloud;

--- a/core/sail/solr/src/main/java/org/eclipse/rdf4j/sail/solr/client/embedded/package-info.java
+++ b/core/sail/solr/src/main/java/org/eclipse/rdf4j/sail/solr/client/embedded/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Embedded Solr client support.
+ *
+ * @deprecated since 5.3.0 and scheduled for removal alongside the Solr Sail integration.
+ */
+@Deprecated(forRemoval = true, since = "5.3.0")
+package org.eclipse.rdf4j.sail.solr.client.embedded;

--- a/core/sail/solr/src/main/java/org/eclipse/rdf4j/sail/solr/client/http/package-info.java
+++ b/core/sail/solr/src/main/java/org/eclipse/rdf4j/sail/solr/client/http/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * HTTP Solr client support.
+ *
+ * @deprecated since 5.3.0 and scheduled for removal alongside the Solr Sail integration.
+ */
+@Deprecated(forRemoval = true, since = "5.3.0")
+package org.eclipse.rdf4j.sail.solr.client.http;

--- a/core/sail/solr/src/main/java/org/eclipse/rdf4j/sail/solr/client/package-info.java
+++ b/core/sail/solr/src/main/java/org/eclipse/rdf4j/sail/solr/client/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Solr client utilities.
+ *
+ * @deprecated since 5.3.0 and scheduled for removal alongside the Solr Sail integration.
+ */
+@Deprecated(forRemoval = true, since = "5.3.0")
+package org.eclipse.rdf4j.sail.solr.client;

--- a/core/sail/solr/src/main/java/org/eclipse/rdf4j/sail/solr/config/SolrSailConfig.java
+++ b/core/sail/solr/src/main/java/org/eclipse/rdf4j/sail/solr/config/SolrSailConfig.java
@@ -13,6 +13,11 @@ package org.eclipse.rdf4j.sail.solr.config;
 import org.eclipse.rdf4j.sail.config.SailImplConfig;
 import org.eclipse.rdf4j.sail.lucene.config.AbstractLuceneSailConfig;
 
+/**
+ * @deprecated since 5.3.0 and scheduled for removal. Use alternative search integrations instead, such as the Lucene or
+ *             Elasticsearch Sail implementations.
+ */
+@Deprecated(forRemoval = true, since = "5.3.0")
 public class SolrSailConfig extends AbstractLuceneSailConfig {
 
 	/*--------------*

--- a/core/sail/solr/src/main/java/org/eclipse/rdf4j/sail/solr/config/SolrSailFactory.java
+++ b/core/sail/solr/src/main/java/org/eclipse/rdf4j/sail/solr/config/SolrSailFactory.java
@@ -20,7 +20,11 @@ import org.eclipse.rdf4j.sail.solr.SolrIndex;
 
 /**
  * A {@link SailFactory} that creates {@link LuceneSail}s based on RDF configuration data.
+ *
+ * @deprecated since 5.3.0 and scheduled for removal. Use alternative search integrations instead, such as the Lucene or
+ *             Elasticsearch Sail implementations.
  */
+@Deprecated(forRemoval = true, since = "5.3.0")
 public class SolrSailFactory implements SailFactory {
 
 	/**

--- a/core/sail/solr/src/main/java/org/eclipse/rdf4j/sail/solr/config/package-info.java
+++ b/core/sail/solr/src/main/java/org/eclipse/rdf4j/sail/solr/config/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Configuration support for the Solr Sail.
+ *
+ * @deprecated since 5.3.0 and scheduled for removal alongside the Solr Sail integration.
+ */
+@Deprecated(forRemoval = true, since = "5.3.0")
+package org.eclipse.rdf4j.sail.solr.config;

--- a/core/sail/solr/src/main/java/org/eclipse/rdf4j/sail/solr/package-info.java
+++ b/core/sail/solr/src/main/java/org/eclipse/rdf4j/sail/solr/package-info.java
@@ -2,7 +2,7 @@
  * Solr-based search integration.
  *
  * @deprecated since 5.3.0 and scheduled for removal. Use alternative search integrations instead, such as the Lucene or
- *     Elasticsearch Sail implementations.
+ *             Elasticsearch Sail implementations.
  */
 @Deprecated(forRemoval = true, since = "5.3.0")
 package org.eclipse.rdf4j.sail.solr;

--- a/core/sail/solr/src/main/java/org/eclipse/rdf4j/sail/solr/package-info.java
+++ b/core/sail/solr/src/main/java/org/eclipse/rdf4j/sail/solr/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Solr-based search integration.
+ *
+ * @deprecated since 5.3.0 and scheduled for removal. Use alternative search integrations instead, such as the Lucene or
+ *     Elasticsearch Sail implementations.
+ */
+@Deprecated(forRemoval = true, since = "5.3.0")
+package org.eclipse.rdf4j.sail.solr;

--- a/site/content/documentation/programming/geosparql.md
+++ b/site/content/documentation/programming/geosparql.md
@@ -72,7 +72,7 @@ RDF4J supports the following RCC8 functions: `geof:rcc8eq`, `geof:rcc8dc`, `geof
 
 ### Improved performance through Lucene
 
-Although RDF4J supports GeoSPARQL querying on any type of store, the Lucene SAIL and its derivates (the SolrSail and the ElasticSearchSail) have built-in optimizations that make geospatial querying on large datasets more efficient. By default, the Lucene SAIL only spatially indexes `http://www.opengis.net/ont/geosparql#asWKT fields`. This can be changed using the `LuceneSail.WKT_FIELDS` parameter.
+Although RDF4J supports GeoSPARQL querying on any type of store, the Lucene SAIL and its derivates (the SolrSail and the ElasticSearchSail) have built-in optimizations that make geospatial querying on large datasets more efficient. The SolrSail is **deprecated for removal** as of RDF4J 5.3.0, so prefer the remaining backends for new deployments. By default, the Lucene SAIL only spatially indexes `http://www.opengis.net/ont/geosparql#asWKT fields`. This can be changed using the `LuceneSail.WKT_FIELDS` parameter.
 
 ## Reading and writing WKT Literals
 

--- a/site/content/documentation/programming/lucene.md
+++ b/site/content/documentation/programming/lucene.md
@@ -184,6 +184,8 @@ The LuceneSail can currently be used with three SearchIndex implementations:
 | ElasticSearch     | `org.eclipse.rdf4j.sail.elasticsearch.ElasticsearchIndex` | `rdf4j-sail-elasticsearch`            | no                      |
 | Apache Solr       | `org.eclipse.rdf4j.sail.solr.SolrIndex`                   | `rdf4j-sail-solr`                     | no                      |
 
+The Solr-based integration is **deprecated for removal** as of RDF4J 5.3.0. Prefer one of the other search backends for new projects and plan migrations away from `rdf4j-sail-solr`.
+
 Each SearchIndex implementation can easily be extended if you need to add extra features or store/access data with a different schema.
 
 The following example uses a local Solr instance running on the default port 8983. Make sure that both the Apache httpcore and commons-logging jars are in the classpath, and that the Solr core uses an appropriate schema (an example can be found in RDF4J’s embedded solr source code on GitHub).


### PR DESCRIPTION
## Summary
- mark the Solr Sail module and its configuration/client packages as deprecated for removal
- document Solr deprecation in search and GeoSPARQL programming guides

## Testing
- mvn -pl core/sail/solr -DskipITs test *(fails: missing rdf4j-sail-lucene-api dependency in local reactor)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f5d21961c832e8ec0655133c26e76)