### PR TITLE
GH-0000 Add bulk-load failure guidance

### DIFF
--- a/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbBulkLoader.java
+++ b/core/sail/lmdb/src/main/java/org/eclipse/rdf4j/sail/lmdb/LmdbBulkLoader.java
@@ -103,7 +103,7 @@ class LmdbBulkLoader {
 			}
 			success = true;
 		} catch (IOException | RDFParseException | RDFHandlerException e) {
-			throw new SailException("Bulk load failed", e);
+			throw new SailException("Bulk load failed; delete the indexes before retrying", e);
 		} finally {
 			if (success && workDir != null) {
 				try {

--- a/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbBulkLoadTest.java
+++ b/core/sail/lmdb/src/test/java/org/eclipse/rdf4j/sail/lmdb/LmdbBulkLoadTest.java
@@ -12,6 +12,8 @@
 package org.eclipse.rdf4j.sail.lmdb;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -24,6 +26,7 @@ import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.sail.SailConnection;
+import org.eclipse.rdf4j.sail.SailException;
 import org.eclipse.rdf4j.sail.lmdb.config.LmdbStoreConfig;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -59,6 +62,23 @@ class LmdbBulkLoadTest {
 				assertEquals(2, countStatements(conn.getStatements(null, p1, null, false)));
 				assertEquals(2, countStatements(conn.getStatements(null, null, null, false, ctx1)));
 			}
+		} finally {
+			store.shutDown();
+		}
+	}
+
+	@Test
+	void bulkLoadFailureMentionsIndexCleanup() throws Exception {
+		Path dataFile = dataDir.resolve("broken.nq");
+		Files.writeString(dataFile, "<urn:s1> <urn:p1> <urn:o1>", StandardCharsets.UTF_8);
+
+		LmdbStore store = new LmdbStore(dataDir.toFile(), new LmdbStoreConfig("spoc,posc,cspo"));
+		store.init();
+		try {
+			SailException exception = assertThrows(SailException.class,
+					() -> store.bulkLoad(dataFile, RDFFormat.NQUADS));
+			assertTrue(exception.getMessage().contains("delete the indexes"),
+					"Expected guidance to delete the indexes after failure");
 		} finally {
 			store.shutDown();
 		}


### PR DESCRIPTION
### Motivation
- Ensure LMDB bulk-load failures provide actionable recovery instructions when indexes may be partially populated.
- Prevent user confusion by surfacing guidance to remove indexes before retrying a failed bulk-load.
- Add a regression test that explicitly verifies the failure message contains cleanup guidance.

### Description
- Change exception message in `LmdbBulkLoader.bulkLoad` to include: "Bulk load failed; delete the indexes before retrying".
- Add `LmdbBulkLoadTest#bulkLoadFailureMentionsIndexCleanup` which reproduces a bulk-load error and asserts the thrown `SailException` message contains the index-cleanup guidance.
- Add required test imports and a minimal broken N-Quads fixture to trigger the failure.

### Testing
- Ran full quick build with `mvn -T 1C -o -Dmaven.repo.local=.m2_repo -Pquick clean install`, which completed successfully.
- Ran the focused module test before the fix using `mvn -pl core/sail/lmdb -Dtest=LmdbBulkLoadTest#bulkLoadFailureMentionsIndexCleanup verify`, which failed as expected (pre-fix failure evidence collected).
- Re-ran the focused module test after the change with the same `mvn ... verify`, and the test passed indicating the guidance is present.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694edf3e93c8832e8bef4fbce2219b1d)