### PR TITLE
GH-0000 Stabilize ServerBootSignalIT startup readiness

### DIFF
--- a/tools/server-boot/src/test/java/org/eclipse/rdf4j/tools/serverboot/ServerBootSignalIT.java
+++ b/tools/server-boot/src/test/java/org/eclipse/rdf4j/tools/serverboot/ServerBootSignalIT.java
@@ -170,8 +170,8 @@ class ServerBootSignalIT {
 					synchronized (outputBuffer) {
 						outputBuffer.append(line).append(System.lineSeparator());
 					}
-					if (!signalLogged.get() && (line.contains("Tomcat initialized with port")
-							|| line.contains("Started Rdf4jServerWorkbenchApplication"))) {
+					if (!signalLogged.get() && (line.contains("Started Rdf4jServerWorkbenchApplication")
+							|| line.contains("Initializing Spring DispatcherServlet 'rdf4jServer'"))) {
 						started.countDown();
 						signalLogged.set(true);
 					}


### PR DESCRIPTION
### Motivation

- The `ServerBootSignalIT` test was flaky because it relied on an early log line (`Tomcat initialized with port`) that can appear before Spring has finished wiring the web context. 
- The race caused intermittent failures when the test exercised the running server and then sent signals for graceful shutdown. 
- The intent is to make the readiness detection more robust so SIGTERM/SIGINT shutdown checks run only after the application is truly ready. 
- Keep the change small and focused to reduce test brittleness without changing runtime behavior.

### Description

- Updated the process output readiness check in `ServerBootSignalIT.startStreamGobbler` to wait for `Started Rdf4jServerWorkbenchApplication` or `Initializing Spring DispatcherServlet 'rdf4jServer'` instead of or in addition to the Tomcat initialization message. 
- This change uses the existing `started` latch and `signalLogged` guard to avoid duplicate countdowns. 
- The change is limited to the test file `tools/server-boot/src/test/java/org/eclipse/rdf4j/tools/serverboot/ServerBootSignalIT.java`. 
- Branch and commit created as `GH-0000-serverboot-sigterm-flake` with message `GH-0000 Stabilize server boot signal readiness`.

### Testing

- Reproduced the flaky behavior locally using the focused test and observed the failure prior to the fix (test did not detect readiness within the timeout). 
- Ran a quick full build with `mvn -T 1C -o -Dmaven.repo.local=.m2_repo -Pquick clean install` which completed successfully. 
- Ran the focused integration test `mvn -o -Dmaven.repo.local=.m2_repo -pl tools/server-boot -Dit.test=ServerBootSignalIT#gracefullyStopsOnSigterm verify` after the change and it passed (`Tests run: 1, Failures: 0`). 
- Collected the `failsafe` report at `tools/server-boot/target/failsafe-reports/org.eclipse.rdf4j.tools.serverboot.ServerBootSignalIT.txt` showing the successful run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ff8d3e21c832eb64de9b328879963)