### PR TITLE
Expose SHACL Sail options in Workbench UI and repository templates

### DIFF
--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-shacl.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-shacl.ttl
@@ -11,6 +11,21 @@
         config:rep.type "openrdf:SailRepository" ;
         config:sail.impl [
             config:sail.type "rdf4j:ShaclSail" ;
+            config:shacl.parallelValidation {%Parallel validation|true|false%} ;
+            config:shacl.logValidationPlans {%Log validation plans|true|false%} ;
+            config:shacl.logValidationViolations {%Log validation violations|true|false%} ;
+            config:shacl.validationEnabled {%Validation enabled|true|false%} ;
+            config:shacl.cacheSelectNodes {%Cache select nodes|true|false%} ;
+            config:shacl.globalLogValidationExecution {%Global log validation execution|true|false%} ;
+            config:shacl.rdfsSubClassReasoning {%RDFS subclass reasoning|true|false%} ;
+            config:shacl.performanceLogging {%Performance logging|true|false%} ;
+            config:shacl.serializableValidation {%Serializable validation|true|false%} ;
+            config:shacl.eclipseRdf4jShaclExtensions {%Eclipse RDF4J SHACL extensions|true|false%} ;
+            config:shacl.dashDataShapes {%DASH data shapes|true|false%} ;
+            config:shacl.validationResultsLimitTotal {%Validation results limit total|1000000%} ;
+            config:shacl.validationResultsLimitPerConstraint {%Validation results limit per constraint|1000%} ;
+            config:shacl.transactionalValidationLimit {%Transactional validation limit|500000%} ;
+            config:shacl.shapesGraph {%Shapes graphs|<http://rdf4j.org/schema/rdf4j#SHACLShapeGraph>%} ;
             config:delegate [
                 config:sail.type "openrdf:MemoryStore" ;
                 config:iterationCacheSyncThreshold "{%Query Iteration Cache size|10000%}";

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-shacl.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/memory-shacl.ttl
@@ -12,16 +12,16 @@
         config:sail.impl [
             config:sail.type "rdf4j:ShaclSail" ;
             config:shacl.parallelValidation {%Parallel validation|true|false%} ;
-            config:shacl.logValidationPlans {%Log validation plans|true|false%} ;
-            config:shacl.logValidationViolations {%Log validation violations|true|false%} ;
+            config:shacl.logValidationPlans {%Log validation plans|false|true%} ;
+            config:shacl.logValidationViolations {%Log validation violations|false|true%} ;
             config:shacl.validationEnabled {%Validation enabled|true|false%} ;
             config:shacl.cacheSelectNodes {%Cache select nodes|true|false%} ;
-            config:shacl.globalLogValidationExecution {%Global log validation execution|true|false%} ;
+            config:shacl.globalLogValidationExecution {%Global log validation execution|false|true%} ;
             config:shacl.rdfsSubClassReasoning {%RDFS subclass reasoning|true|false%} ;
-            config:shacl.performanceLogging {%Performance logging|true|false%} ;
+            config:shacl.performanceLogging {%Performance logging|false|true%} ;
             config:shacl.serializableValidation {%Serializable validation|true|false%} ;
-            config:shacl.eclipseRdf4jShaclExtensions {%Eclipse RDF4J SHACL extensions|true|false%} ;
-            config:shacl.dashDataShapes {%DASH data shapes|true|false%} ;
+            config:shacl.eclipseRdf4jShaclExtensions {%Eclipse RDF4J SHACL extensions|false|true%} ;
+            config:shacl.dashDataShapes {%DASH data shapes|false|true%} ;
             config:shacl.validationResultsLimitTotal {%Validation results limit total|1000000%} ;
             config:shacl.validationResultsLimitPerConstraint {%Validation results limit per constraint|1000%} ;
             config:shacl.transactionalValidationLimit {%Transactional validation limit|500000%} ;

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native-shacl.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native-shacl.ttl
@@ -13,16 +13,16 @@
         config:sail.impl [
             config:sail.type "rdf4j:ShaclSail" ;
             config:shacl.parallelValidation {%Parallel validation|true|false%} ;
-            config:shacl.logValidationPlans {%Log validation plans|true|false%} ;
-            config:shacl.logValidationViolations {%Log validation violations|true|false%} ;
+            config:shacl.logValidationPlans {%Log validation plans|false|true%} ;
+            config:shacl.logValidationViolations {%Log validation violations|false|true%} ;
             config:shacl.validationEnabled {%Validation enabled|true|false%} ;
             config:shacl.cacheSelectNodes {%Cache select nodes|true|false%} ;
-            config:shacl.globalLogValidationExecution {%Global log validation execution|true|false%} ;
+            config:shacl.globalLogValidationExecution {%Global log validation execution|false|true%} ;
             config:shacl.rdfsSubClassReasoning {%RDFS subclass reasoning|true|false%} ;
-            config:shacl.performanceLogging {%Performance logging|true|false%} ;
+            config:shacl.performanceLogging {%Performance logging|false|true%} ;
             config:shacl.serializableValidation {%Serializable validation|true|false%} ;
-            config:shacl.eclipseRdf4jShaclExtensions {%Eclipse RDF4J SHACL extensions|true|false%} ;
-            config:shacl.dashDataShapes {%DASH data shapes|true|false%} ;
+            config:shacl.eclipseRdf4jShaclExtensions {%Eclipse RDF4J SHACL extensions|false|true%} ;
+            config:shacl.dashDataShapes {%DASH data shapes|false|true%} ;
             config:shacl.validationResultsLimitTotal {%Validation results limit total|1000000%} ;
             config:shacl.validationResultsLimitPerConstraint {%Validation results limit per constraint|1000%} ;
             config:shacl.transactionalValidationLimit {%Transactional validation limit|500000%} ;

--- a/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native-shacl.ttl
+++ b/core/repository/api/src/main/resources/org/eclipse/rdf4j/repository/config/native-shacl.ttl
@@ -12,6 +12,21 @@
         config:rep.type "openrdf:SailRepository" ;
         config:sail.impl [
             config:sail.type "rdf4j:ShaclSail" ;
+            config:shacl.parallelValidation {%Parallel validation|true|false%} ;
+            config:shacl.logValidationPlans {%Log validation plans|true|false%} ;
+            config:shacl.logValidationViolations {%Log validation violations|true|false%} ;
+            config:shacl.validationEnabled {%Validation enabled|true|false%} ;
+            config:shacl.cacheSelectNodes {%Cache select nodes|true|false%} ;
+            config:shacl.globalLogValidationExecution {%Global log validation execution|true|false%} ;
+            config:shacl.rdfsSubClassReasoning {%RDFS subclass reasoning|true|false%} ;
+            config:shacl.performanceLogging {%Performance logging|true|false%} ;
+            config:shacl.serializableValidation {%Serializable validation|true|false%} ;
+            config:shacl.eclipseRdf4jShaclExtensions {%Eclipse RDF4J SHACL extensions|true|false%} ;
+            config:shacl.dashDataShapes {%DASH data shapes|true|false%} ;
+            config:shacl.validationResultsLimitTotal {%Validation results limit total|1000000%} ;
+            config:shacl.validationResultsLimitPerConstraint {%Validation results limit per constraint|1000%} ;
+            config:shacl.transactionalValidationLimit {%Transactional validation limit|500000%} ;
+            config:shacl.shapesGraph {%Shapes graphs|<http://rdf4j.org/schema/rdf4j#SHACLShapeGraph>%} ;
             config:delegate [
                 config:sail.type "openrdf:NativeStore" ;
                 config:sail.iterationCacheSyncThreshold "{%Query Iteration Cache size|10000%}";

--- a/tools/workbench/src/main/webapp/transformations/create-memory-shacl.xsl
+++ b/tools/workbench/src/main/webapp/transformations/create-memory-shacl.xsl
@@ -87,6 +87,163 @@
 						<td></td>
 					</tr>
 					<tr>
+						<th>Parallel validation</th>
+						<td>
+							<input type="radio" name="Parallel validation" value="true"
+								checked="true" />
+							<xsl:value-of select="$true.label" />
+							<input type="radio" name="Parallel validation" value="false" />
+							<xsl:value-of select="$false.label" />
+						</td>
+						<td></td>
+					</tr>
+					<tr>
+						<th>Log validation plans</th>
+						<td>
+							<input type="radio" name="Log validation plans" value="true" />
+							<xsl:value-of select="$true.label" />
+							<input type="radio" name="Log validation plans" value="false"
+								checked="true" />
+							<xsl:value-of select="$false.label" />
+						</td>
+						<td></td>
+					</tr>
+					<tr>
+						<th>Log validation violations</th>
+						<td>
+							<input type="radio" name="Log validation violations" value="true" />
+							<xsl:value-of select="$true.label" />
+							<input type="radio" name="Log validation violations" value="false"
+								checked="true" />
+							<xsl:value-of select="$false.label" />
+						</td>
+						<td></td>
+					</tr>
+					<tr>
+						<th>Validation enabled</th>
+						<td>
+							<input type="radio" name="Validation enabled" value="true"
+								checked="true" />
+							<xsl:value-of select="$true.label" />
+							<input type="radio" name="Validation enabled" value="false" />
+							<xsl:value-of select="$false.label" />
+						</td>
+						<td></td>
+					</tr>
+					<tr>
+						<th>Cache select nodes</th>
+						<td>
+							<input type="radio" name="Cache select nodes" value="true"
+								checked="true" />
+							<xsl:value-of select="$true.label" />
+							<input type="radio" name="Cache select nodes" value="false" />
+							<xsl:value-of select="$false.label" />
+						</td>
+						<td></td>
+					</tr>
+					<tr>
+						<th>Global log validation execution</th>
+						<td>
+							<input type="radio" name="Global log validation execution"
+								value="true" />
+							<xsl:value-of select="$true.label" />
+							<input type="radio" name="Global log validation execution"
+								value="false" checked="true" />
+							<xsl:value-of select="$false.label" />
+						</td>
+						<td></td>
+					</tr>
+					<tr>
+						<th>RDFS subclass reasoning</th>
+						<td>
+							<input type="radio" name="RDFS subclass reasoning" value="true"
+								checked="true" />
+							<xsl:value-of select="$true.label" />
+							<input type="radio" name="RDFS subclass reasoning" value="false" />
+							<xsl:value-of select="$false.label" />
+						</td>
+						<td></td>
+					</tr>
+					<tr>
+						<th>Performance logging</th>
+						<td>
+							<input type="radio" name="Performance logging" value="true" />
+							<xsl:value-of select="$true.label" />
+							<input type="radio" name="Performance logging" value="false"
+								checked="true" />
+							<xsl:value-of select="$false.label" />
+						</td>
+						<td></td>
+					</tr>
+					<tr>
+						<th>Serializable validation</th>
+						<td>
+							<input type="radio" name="Serializable validation" value="true"
+								checked="true" />
+							<xsl:value-of select="$true.label" />
+							<input type="radio" name="Serializable validation" value="false" />
+							<xsl:value-of select="$false.label" />
+						</td>
+						<td></td>
+					</tr>
+					<tr>
+						<th>Eclipse RDF4J SHACL extensions</th>
+						<td>
+							<input type="radio" name="Eclipse RDF4J SHACL extensions"
+								value="true" />
+							<xsl:value-of select="$true.label" />
+							<input type="radio" name="Eclipse RDF4J SHACL extensions"
+								value="false" checked="true" />
+							<xsl:value-of select="$false.label" />
+						</td>
+						<td></td>
+					</tr>
+					<tr>
+						<th>DASH data shapes</th>
+						<td>
+							<input type="radio" name="DASH data shapes" value="true" />
+							<xsl:value-of select="$true.label" />
+							<input type="radio" name="DASH data shapes" value="false"
+								checked="true" />
+							<xsl:value-of select="$false.label" />
+						</td>
+						<td></td>
+					</tr>
+					<tr>
+						<th>Validation results limit total</th>
+						<td>
+							<input type="text" id="validationResultsLimitTotal"
+								name="Validation results limit total" size="10"
+								value="1000000" />
+						</td>
+						<td></td>
+					</tr>
+					<tr>
+						<th>Validation results limit per constraint</th>
+						<td>
+							<input type="text" id="validationResultsLimitPerConstraint"
+								name="Validation results limit per constraint" size="10"
+								value="1000" />
+						</td>
+						<td></td>
+					</tr>
+					<tr>
+						<th>Transactional validation limit</th>
+						<td>
+							<input type="text" id="transactionalValidationLimit"
+								name="Transactional validation limit" size="10" value="500000" />
+						</td>
+						<td></td>
+					</tr>
+					<tr>
+						<th>Shapes graphs</th>
+						<td>
+							<input type="text" id="shapesGraphs" name="Shapes graphs" size="64"
+								value="&lt;http://rdf4j.org/schema/rdf4j#SHACLShapeGraph&gt;" />
+						</td>
+						<td></td>
+					</tr>
+					<tr>
 						<td></td>
 						<td>
 							<input type="button" value="{$cancel.label}" style="float:right"

--- a/tools/workbench/src/main/webapp/transformations/create-native-shacl.xsl
+++ b/tools/workbench/src/main/webapp/transformations/create-native-shacl.xsl
@@ -73,6 +73,163 @@
 						<td></td>
 					</tr>
 					<tr>
+						<th>Parallel validation</th>
+						<td>
+							<input type="radio" name="Parallel validation" value="true"
+								checked="true" />
+							<xsl:value-of select="$true.label" />
+							<input type="radio" name="Parallel validation" value="false" />
+							<xsl:value-of select="$false.label" />
+						</td>
+						<td></td>
+					</tr>
+					<tr>
+						<th>Log validation plans</th>
+						<td>
+							<input type="radio" name="Log validation plans" value="true" />
+							<xsl:value-of select="$true.label" />
+							<input type="radio" name="Log validation plans" value="false"
+								checked="true" />
+							<xsl:value-of select="$false.label" />
+						</td>
+						<td></td>
+					</tr>
+					<tr>
+						<th>Log validation violations</th>
+						<td>
+							<input type="radio" name="Log validation violations" value="true" />
+							<xsl:value-of select="$true.label" />
+							<input type="radio" name="Log validation violations" value="false"
+								checked="true" />
+							<xsl:value-of select="$false.label" />
+						</td>
+						<td></td>
+					</tr>
+					<tr>
+						<th>Validation enabled</th>
+						<td>
+							<input type="radio" name="Validation enabled" value="true"
+								checked="true" />
+							<xsl:value-of select="$true.label" />
+							<input type="radio" name="Validation enabled" value="false" />
+							<xsl:value-of select="$false.label" />
+						</td>
+						<td></td>
+					</tr>
+					<tr>
+						<th>Cache select nodes</th>
+						<td>
+							<input type="radio" name="Cache select nodes" value="true"
+								checked="true" />
+							<xsl:value-of select="$true.label" />
+							<input type="radio" name="Cache select nodes" value="false" />
+							<xsl:value-of select="$false.label" />
+						</td>
+						<td></td>
+					</tr>
+					<tr>
+						<th>Global log validation execution</th>
+						<td>
+							<input type="radio" name="Global log validation execution"
+								value="true" />
+							<xsl:value-of select="$true.label" />
+							<input type="radio" name="Global log validation execution"
+								value="false" checked="true" />
+							<xsl:value-of select="$false.label" />
+						</td>
+						<td></td>
+					</tr>
+					<tr>
+						<th>RDFS subclass reasoning</th>
+						<td>
+							<input type="radio" name="RDFS subclass reasoning" value="true"
+								checked="true" />
+							<xsl:value-of select="$true.label" />
+							<input type="radio" name="RDFS subclass reasoning" value="false" />
+							<xsl:value-of select="$false.label" />
+						</td>
+						<td></td>
+					</tr>
+					<tr>
+						<th>Performance logging</th>
+						<td>
+							<input type="radio" name="Performance logging" value="true" />
+							<xsl:value-of select="$true.label" />
+							<input type="radio" name="Performance logging" value="false"
+								checked="true" />
+							<xsl:value-of select="$false.label" />
+						</td>
+						<td></td>
+					</tr>
+					<tr>
+						<th>Serializable validation</th>
+						<td>
+							<input type="radio" name="Serializable validation" value="true"
+								checked="true" />
+							<xsl:value-of select="$true.label" />
+							<input type="radio" name="Serializable validation" value="false" />
+							<xsl:value-of select="$false.label" />
+						</td>
+						<td></td>
+					</tr>
+					<tr>
+						<th>Eclipse RDF4J SHACL extensions</th>
+						<td>
+							<input type="radio" name="Eclipse RDF4J SHACL extensions"
+								value="true" />
+							<xsl:value-of select="$true.label" />
+							<input type="radio" name="Eclipse RDF4J SHACL extensions"
+								value="false" checked="true" />
+							<xsl:value-of select="$false.label" />
+						</td>
+						<td></td>
+					</tr>
+					<tr>
+						<th>DASH data shapes</th>
+						<td>
+							<input type="radio" name="DASH data shapes" value="true" />
+							<xsl:value-of select="$true.label" />
+							<input type="radio" name="DASH data shapes" value="false"
+								checked="true" />
+							<xsl:value-of select="$false.label" />
+						</td>
+						<td></td>
+					</tr>
+					<tr>
+						<th>Validation results limit total</th>
+						<td>
+							<input type="text" id="validationResultsLimitTotal"
+								name="Validation results limit total" size="10"
+								value="1000000" />
+						</td>
+						<td></td>
+					</tr>
+					<tr>
+						<th>Validation results limit per constraint</th>
+						<td>
+							<input type="text" id="validationResultsLimitPerConstraint"
+								name="Validation results limit per constraint" size="10"
+								value="1000" />
+						</td>
+						<td></td>
+					</tr>
+					<tr>
+						<th>Transactional validation limit</th>
+						<td>
+							<input type="text" id="transactionalValidationLimit"
+								name="Transactional validation limit" size="10" value="500000" />
+						</td>
+						<td></td>
+					</tr>
+					<tr>
+						<th>Shapes graphs</th>
+						<td>
+							<input type="text" id="shapesGraphs" name="Shapes graphs" size="64"
+								value="&lt;http://rdf4j.org/schema/rdf4j#SHACLShapeGraph&gt;" />
+						</td>
+						<td></td>
+					</tr>
+					<tr>
 						<td></td>
 						<td>
 							<input type="button" value="{$cancel.label}" style="float:right"

--- a/tools/workbench/src/test/java/org/eclipse/rdf4j/workbench/commands/CreateServletTest.java
+++ b/tools/workbench/src/test/java/org/eclipse/rdf4j/workbench/commands/CreateServletTest.java
@@ -130,6 +130,9 @@ public class CreateServletTest {
 			assertThat(nativeTemplate).contains("{%" + option + "|");
 		}
 
+		assertShaclDefaultsMatchConfig(memoryTemplate);
+		assertShaclDefaultsMatchConfig(nativeTemplate);
+
 		assertShaclInputsPresent(Paths.get("src/main/webapp/transformations/create-memory-shacl.xsl"));
 		assertShaclInputsPresent(Paths.get("src/main/webapp/transformations/create-native-shacl.xsl"));
 	}
@@ -152,6 +155,15 @@ public class CreateServletTest {
 			"Shapes graphs"
 	};
 
+	private static final String[] SHACL_FALSE_DEFAULTS = {
+			"Log validation plans",
+			"Log validation violations",
+			"Global log validation execution",
+			"Performance logging",
+			"Eclipse RDF4J SHACL extensions",
+			"DASH data shapes"
+	};
+
 	private static String readConfigTemplate(String resource) throws IOException {
 		try (InputStream input = RepositoryConfig.class.getResourceAsStream(resource)) {
 			assertThat(input).as(resource).isNotNull();
@@ -163,6 +175,12 @@ public class CreateServletTest {
 		String xsl = Files.readString(path, StandardCharsets.UTF_8);
 		for (String option : SHACL_OPTION_NAMES) {
 			assertThat(xsl).contains("name=\"" + option + "\"");
+		}
+	}
+
+	private static void assertShaclDefaultsMatchConfig(String template) {
+		for (String option : SHACL_FALSE_DEFAULTS) {
+			assertThat(template).contains("{%" + option + "|false|true%}");
 		}
 	}
 }

--- a/tools/workbench/src/test/java/org/eclipse/rdf4j/workbench/commands/CreateServletTest.java
+++ b/tools/workbench/src/test/java/org/eclipse/rdf4j/workbench/commands/CreateServletTest.java
@@ -15,7 +15,11 @@ import static org.assertj.core.api.Assertions.fail;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import org.eclipse.rdf4j.common.exception.RDF4JException;
 import org.eclipse.rdf4j.repository.config.RepositoryConfig;
@@ -113,6 +117,52 @@ public class CreateServletTest {
 			assertThat(config.getTitle()).isEqualTo("Legacy Test Repository");
 		} catch (RDF4JException | IOException e) {
 			fail(e.getMessage());
+		}
+	}
+
+	@Test
+	public void testShaclTemplatesExposeAllOptions() throws IOException {
+		String memoryTemplate = readConfigTemplate("memory-shacl.ttl");
+		String nativeTemplate = readConfigTemplate("native-shacl.ttl");
+
+		for (String option : SHACL_OPTION_NAMES) {
+			assertThat(memoryTemplate).contains("{%" + option + "|");
+			assertThat(nativeTemplate).contains("{%" + option + "|");
+		}
+
+		assertShaclInputsPresent(Paths.get("src/main/webapp/transformations/create-memory-shacl.xsl"));
+		assertShaclInputsPresent(Paths.get("src/main/webapp/transformations/create-native-shacl.xsl"));
+	}
+
+	private static final String[] SHACL_OPTION_NAMES = {
+			"Parallel validation",
+			"Log validation plans",
+			"Log validation violations",
+			"Validation enabled",
+			"Cache select nodes",
+			"Global log validation execution",
+			"RDFS subclass reasoning",
+			"Performance logging",
+			"Serializable validation",
+			"Eclipse RDF4J SHACL extensions",
+			"DASH data shapes",
+			"Validation results limit total",
+			"Validation results limit per constraint",
+			"Transactional validation limit",
+			"Shapes graphs"
+	};
+
+	private static String readConfigTemplate(String resource) throws IOException {
+		try (InputStream input = RepositoryConfig.class.getResourceAsStream(resource)) {
+			assertThat(input).as(resource).isNotNull();
+			return new String(input.readAllBytes(), StandardCharsets.UTF_8);
+		}
+	}
+
+	private static void assertShaclInputsPresent(Path path) throws IOException {
+		String xsl = Files.readString(path, StandardCharsets.UTF_8);
+		for (String option : SHACL_OPTION_NAMES) {
+			assertThat(xsl).contains("name=\"" + option + "\"");
 		}
 	}
 }


### PR DESCRIPTION
### Motivation
- Make every configurable option of `ShaclSail` available when creating a SHACL-backed repository in the Workbench so admins can set all SHACL runtime settings from the UI and from the configuration templates.

### Description
- Add SHACL configuration placeholders to the repo templates `core/repository/api/src/main/resources/.../memory-shacl.ttl` and `.../native-shacl.ttl` to accept all `ShaclSail` options (booleans, numeric limits and shapes graph). 
- Surface all SHACL options in the Workbench create forms by adding corresponding form inputs to `tools/workbench/src/main/webapp/transformations/create-memory-shacl.xsl` and `create-native-shacl.xsl` (radio inputs for boolean flags and text inputs for numeric/IRI values).
- Add a regression test `tools/workbench/src/test/java/org/eclipse/rdf4j/workbench/commands/CreateServletTest.java::testShaclTemplatesExposeAllOptions` that verifies the templates contain the new tokens and the XSL forms contain the corresponding inputs.

### Testing
- Built the project with a quick install to ensure local artifacts were available using the standard repo install step and then ran the focused Workbench test: `mvn -o -Dmaven.repo.local=.m2_repo -pl tools/workbench -Dtest=CreateServletTest verify` which passed (tests run: 6, failures: 0). 
- Evidence captured: initial failing run (pre-change) showed one failing assertion that the `memory-shacl.ttl` template did not contain the new token, and the post-change focused test run reported all tests green.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697bb17bbd50832e973386f67e0204be)