### PR TITLE
GH-0000 Restore secure JSON-LD default in Docker Tomcat image

### DIFF
--- a/docker/Dockerfile-tomcat
+++ b/docker/Dockerfile-tomcat
@@ -17,7 +17,7 @@ MAINTAINER Bart Hanssens (bart.hanssens@bosa.fgov.be)
 RUN apt-get clean && apt-get update && apt-get upgrade -y && apt-get clean
 
 ENV JAVA_OPTS="-Xmx2g"
-ENV CATALINA_OPTS="-Dorg.eclipse.rdf4j.appdata.basedir=/var/rdf4j -Dorg.eclipse.rdf4j.rio.jsonld_secure_mode=false"
+ENV CATALINA_OPTS="-Dorg.eclipse.rdf4j.appdata.basedir=/var/rdf4j"
 
 RUN adduser --system tomcat
 
@@ -35,4 +35,3 @@ USER tomcat
 WORKDIR /usr/local/tomcat/
 
 EXPOSE 8080
-


### PR DESCRIPTION
### Motivation
- Revert an insecure Docker default that forced `org.eclipse.rdf4j.rio.jsonld_secure_mode=false`, which disabled JSON-LD secure mode and allowed unrestricted remote context retrieval (SSRF/local resource access) during parsing.

### Description
- Remove the insecure JVM system property from the Tomcat Dockerfile by deleting `-Dorg.eclipse.rdf4j.rio.jsonld_secure_mode=false` from `ENV CATALINA_OPTS` in `docker/Dockerfile-tomcat`, leaving `-Dorg.eclipse.rdf4j.appdata.basedir=/var/rdf4j` intact.

### Testing
- Ran a repository quick install: `mvn -T 1C -o -Dmaven.repo.local=.m2_repo -Pquick clean install`, which completed successfully before and after the change (build succeeded).
- Verified the Dockerfile no longer contains the insecure property with `rg -n "jsonld_secure_mode|CATALINA_OPTS" docker/Dockerfile-tomcat` and inspected the file lines to confirm the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69b0d8fa3808832ea93c17fc6e9b8856)